### PR TITLE
Feature/step4 mcp http validation

### DIFF
--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -61,10 +61,24 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
 ## Product Notes
 
 - Boundary target setup has version-sensitive API behavior around auth methods, grant strings, target host-source actions, and brokered credential source attachment.
-- HAL MCP command namespace (`hal mcp`) is a stdio-first MVP for external tool integration.
-    - `hal mcp create|serve|status|delete` is the primary operator surface.
-    - Initial MCP tool surface is read-only and should leverage existing HAL command paths (`status`, `capacity`, `<product> status`) instead of reimplementing product logic.
+- HAL MCP command namespace (`hal mcp`) supports two transports:
+    - **stdio** (default, local/dev): `hal mcp serve` — spawned directly by HAL Plus; protocol `2024-11-05`.
+    - **streamable-HTTP** (container): `hal mcp serve --transport streamable-http --http-host 0.0.0.0 --http-port 8080 --http-path /mcp`; protocol `2025-03-26`.
+    - `hal mcp create --http` builds the MCP HTTP container image from source using a Linux multi-stage Docker build (`FROM golang:alpine` + `FROM alpine`). It does **not** copy the host binary — it compiles a fresh Linux binary inside the build stage.
+    - The built image tag is `hashimiche/hal-mcp:local`; it runs as a non-root user (`hal`, uid 10001).
+    - `hal mcp create|serve|status|delete` remains the primary operator surface.
+    - MCP tool surface is read-only and leverages existing HAL command paths (`status`, `capacity`, `<product> status`) instead of reimplementing product logic.
     - Product status tools (for example `get_tfe_status`) should keep product-specific `recommended_commands` first (`hal terraform status`) so AI clients can answer quick health prompts without falling back to generic checks like `hal capacity`.
+    - The `hal-mcp` container does **not** mount the host container engine socket and does not run as root. Tool calls that require engine access (for example `hal_status_baseline`) will return an engine-unavailable error in rootless podman deployments — this is expected; HAL Plus handles it gracefully.
+    - AI clients must treat this engine-unavailable baseline as **runtime unknown**, not as product up/down evidence. For quick status prompts, respond with `Unknown` and recommend the product-specific status command (for example `hal vault status`).
+    - There is no SSH-based MCP transport pattern. Do not introduce or suggest SSH tunnelling for MCP.
+- HAL Plus stack lifecycle is managed via `hal plus create|status|delete`:
+    - `hal plus create` runs preflight checks (Ollama reachability, model availability, local MCP image presence), ensures `hal-net` exists, then starts `hal-mcp` and `hal-plus` containers on `hal-net`.
+    - `hal plus create --image <tag>` uses a local image directly if it exists (no forced pull); pulls from registry only when image is absent.
+    - `hal plus delete` tears down both containers.
+    - `hal plus status` reports image presence, container state, and endpoint health.
+    - Ollama must run on the **host**. HAL Plus contacts it from inside the container via `host.containers.internal:11434` (podman) or `host.docker.internal:11434` (docker). `OLLAMA_BASE_URL` env var overrides the resolved URL.
+    - No socket mounts, no `--user` overrides, no `DOCKER_HOST` injection into `hal-mcp`. Podman stays rootless.
 - Terraform Enterprise local deployment depends on a mocked PostgreSQL, Redis, and MinIO stack and uses local TLS material under `~/.hal/tfe-certs`.
     - Rootless Podman path uses `https://tfe.localhost:8443` through `hal-tfe-proxy`.
     - Twin TFE lifecycle is target-based on product CRUD commands (for example `hal terraform create --target twin`) instead of a dedicated `hal terraform twin` subcommand.

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -403,9 +403,9 @@ func provisionManagedMCPBinary(targetPath string) (string, error) {
 }
 
 func buildManagedMCPHTTPImage(engine, imageTag string) error {
-	exePath, err := os.Executable()
+	sourceRoot, err := resolveHalSourceRoot()
 	if err != nil {
-		return fmt.Errorf("resolve hal executable: %w", err)
+		return err
 	}
 
 	tmpDir, err := os.MkdirTemp("", "hal-mcp-image-")
@@ -414,31 +414,17 @@ func buildManagedMCPHTTPImage(engine, imageTag string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	binaryPath := filepath.Join(tmpDir, "hal")
-	src, err := os.Open(exePath)
-	if err != nil {
-		return fmt.Errorf("open executable for image build: %w", err)
-	}
-	defer src.Close()
+	dockerfile := `FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/hal ./main.go
 
-	dst, err := os.Create(binaryPath)
-	if err != nil {
-		return fmt.Errorf("create temp executable: %w", err)
-	}
-	if _, err := io.Copy(dst, src); err != nil {
-		dst.Close()
-		return fmt.Errorf("copy executable into build context: %w", err)
-	}
-	if err := dst.Close(); err != nil {
-		return fmt.Errorf("close temp executable: %w", err)
-	}
-	if err := os.Chmod(binaryPath, 0o755); err != nil {
-		return fmt.Errorf("chmod temp executable: %w", err)
-	}
-
-	dockerfile := `FROM alpine:3.20
+FROM alpine:3.20
+RUN apk add --no-cache docker-cli
 RUN adduser -D -u 10001 hal
-COPY hal /usr/local/bin/hal
+COPY --from=build /out/hal /usr/local/bin/hal
 USER hal
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/hal", "mcp", "serve", "--transport", "streamable-http", "--http-host", "0.0.0.0", "--http-port", "8080", "--http-path", "/mcp"]
@@ -447,13 +433,39 @@ ENTRYPOINT ["/usr/local/bin/hal", "mcp", "serve", "--transport", "streamable-htt
 		return fmt.Errorf("write temporary Dockerfile: %w", err)
 	}
 
-	buildCmd := exec.Command(engine, "build", "-t", imageTag, tmpDir)
+	buildCmd := exec.Command(engine, "build", "-t", imageTag, "-f", filepath.Join(tmpDir, "Dockerfile"), sourceRoot)
 	buildOutput, err := buildCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s build failed: %w\n%s", engine, err, strings.TrimSpace(string(buildOutput)))
 	}
 
 	return nil
+}
+
+func resolveHalSourceRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	dir := wd
+	for {
+		modPath := filepath.Join(dir, "go.mod")
+		payload, readErr := os.ReadFile(modPath)
+		if readErr == nil {
+			if strings.Contains(string(payload), "module hal") {
+				return dir, nil
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("cannot locate HAL source root with go.mod (run from hal repo tree)")
 }
 
 func serveStdioMCP(stdin io.Reader, stdout io.Writer) error {

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -1,0 +1,92 @@
+package plus
+
+import (
+	"fmt"
+	"os/exec"
+
+	"hal/internal/global"
+
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create HAL Plus container runtime",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+
+		containerOllamaURL := detectOllamaContainerURL(engine)
+
+		if global.DryRun {
+			fmt.Printf("[DRY RUN] Would verify Ollama host endpoint: %s\n", ollamaHostURL)
+			fmt.Printf("[DRY RUN] Would verify model availability: %s\n", plusModel)
+			fmt.Printf("[DRY RUN] Would verify local HAL MCP image exists: %s\n", mcpImage)
+			fmt.Println("[DRY RUN] Would ensure hal-net exists")
+			fmt.Printf("[DRY RUN] Would pull HAL Plus image: %s\n", plusImage)
+			fmt.Println("[DRY RUN] Would start container hal-mcp on hal-net")
+			fmt.Println("[DRY RUN] Would start container hal-plus on hal-net")
+			fmt.Printf("[DRY RUN] Would set OLLAMA_BASE_URL=%s\n", containerOllamaURL)
+			fmt.Println("[DRY RUN] Would set HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp")
+			return
+		}
+
+		ok, err := ollamaModelAvailable(ollamaHostURL, plusModel)
+		if err != nil {
+			fmt.Printf("❌ Ollama preflight failed at %s: %v\n", ollamaHostURL, err)
+			fmt.Printf("   💡 Ensure Ollama is running on host and reachable before 'hal plus create'.\n")
+			return
+		}
+		if !ok {
+			fmt.Printf("❌ Ollama model '%s' was not found at %s\n", plusModel, ollamaHostURL)
+			fmt.Printf("   💡 Pull the model first (example): ollama pull %s\n", plusModel)
+			return
+		}
+
+		if !imageExists(engine, mcpImage) {
+			fmt.Printf("❌ Required HAL MCP image not found locally: %s\n", mcpImage)
+			fmt.Println("   💡 Run 'hal mcp create --http' first, then retry 'hal plus create'.")
+			return
+		}
+
+		global.EnsureNetwork(engine)
+
+		if out, err := exec.Command(engine, "pull", plusImage).CombinedOutput(); err != nil {
+			fmt.Printf("❌ Failed to pull HAL Plus image %s: %v\n%s\n", plusImage, err, string(out))
+			return
+		}
+
+		if err := ensureRunningContainer(engine, halMCPContainerName, []string{"--network", "hal-net", mcpImage}); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+
+		plusArgs := []string{
+			"--network", "hal-net",
+			"-p", fmt.Sprintf("%d:9000", plusPort),
+			"-e", "API_HOST=0.0.0.0",
+			"-e", "API_PORT=9000",
+			"-e", fmt.Sprintf("OLLAMA_BASE_URL=%s", containerOllamaURL),
+			"-e", fmt.Sprintf("OLLAMA_MODEL=%s", plusModel),
+			"-e", "HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp",
+			"-e", "HAL_PLUS_CONTAINER_MODE=true",
+			plusImage,
+		}
+		if err := ensureRunningContainer(engine, halPlusContainerName, plusArgs); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+
+		fmt.Println("✅ HAL Plus runtime created successfully.")
+		fmt.Printf("🐳 Engine:       %s\n", engine)
+		fmt.Printf("🐳 HAL Plus:     %s\n", plusImage)
+		fmt.Printf("🐳 HAL MCP:      %s\n", mcpImage)
+		fmt.Printf("🧠 Ollama host:  %s\n", ollamaHostURL)
+		fmt.Printf("🌐 UI URL:       http://hal.localhost:%d\n", plusPort)
+		fmt.Println("💡 Run 'hal plus status' to verify container and endpoint health.")
+	},
+}

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -27,7 +27,7 @@ var createCmd = &cobra.Command{
 			fmt.Printf("[DRY RUN] Would verify model availability: %s\n", plusModel)
 			fmt.Printf("[DRY RUN] Would verify local HAL MCP image exists: %s\n", mcpImage)
 			fmt.Println("[DRY RUN] Would ensure hal-net exists")
-			fmt.Printf("[DRY RUN] Would pull HAL Plus image: %s\n", plusImage)
+			fmt.Printf("[DRY RUN] Would use local HAL Plus image if present, otherwise pull: %s\n", plusImage)
 			fmt.Println("[DRY RUN] Would start container hal-mcp on hal-net")
 			fmt.Println("[DRY RUN] Would start container hal-plus on hal-net")
 			fmt.Printf("[DRY RUN] Would set OLLAMA_BASE_URL=%s\n", containerOllamaURL)
@@ -55,9 +55,11 @@ var createCmd = &cobra.Command{
 
 		global.EnsureNetwork(engine)
 
-		if out, err := exec.Command(engine, "pull", plusImage).CombinedOutput(); err != nil {
-			fmt.Printf("❌ Failed to pull HAL Plus image %s: %v\n%s\n", plusImage, err, string(out))
-			return
+		if !imageExists(engine, plusImage) {
+			if out, err := exec.Command(engine, "pull", plusImage).CombinedOutput(); err != nil {
+				fmt.Printf("❌ Failed to pull HAL Plus image %s: %v\n%s\n", plusImage, err, string(out))
+				return
+			}
 		}
 
 		if err := ensureRunningContainer(engine, halMCPContainerName, []string{"--network", "hal-net", mcpImage}); err != nil {

--- a/cmd/plus/delete.go
+++ b/cmd/plus/delete.go
@@ -1,0 +1,36 @@
+package plus
+
+import (
+	"fmt"
+	"os/exec"
+
+	"hal/internal/global"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete HAL Plus runtime containers",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+
+		if global.DryRun {
+			fmt.Printf("[DRY RUN] Would remove containers: %s, %s\n", halPlusContainerName, halMCPContainerName)
+			fmt.Println("[DRY RUN] Would clean hal-net if unused")
+			return
+		}
+
+		for _, c := range []string{halPlusContainerName, halMCPContainerName} {
+			_ = exec.Command(engine, "rm", "-f", c).Run()
+		}
+
+		global.CleanNetworkIfEmpty(engine)
+		fmt.Println("✅ HAL Plus runtime deleted.")
+	},
+}

--- a/cmd/plus/plus.go
+++ b/cmd/plus/plus.go
@@ -1,0 +1,163 @@
+package plus
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	halPlusContainerName = "hal-plus"
+	halMCPContainerName  = "hal-mcp"
+)
+
+var (
+	plusImage          string
+	mcpImage           string
+	plusPort           int
+	plusModel          string
+	ollamaHostURL      string
+	ollamaContainerURL string
+)
+
+// Cmd manages HAL Plus container lifecycle.
+var Cmd = &cobra.Command{
+	Use:   "plus",
+	Short: "Manage HAL Plus web UI runtime",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		statusCmd.Run(cmd, args)
+	},
+}
+
+func detectOllamaContainerURL(engine string) string {
+	if strings.TrimSpace(ollamaContainerURL) != "" {
+		return strings.TrimSpace(ollamaContainerURL)
+	}
+	if engine == "podman" {
+		return "http://host.containers.internal:11434"
+	}
+	return "http://host.docker.internal:11434"
+}
+
+func imageExists(engine, image string) bool {
+	err := exec.Command(engine, "image", "inspect", image).Run()
+	return err == nil
+}
+
+func containerState(engine, name string) string {
+	out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", name).Output()
+	if err != nil {
+		return "missing"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func ensureRunningContainer(engine string, name string, args []string) error {
+	state := containerState(engine, name)
+	if state == "running" {
+		return nil
+	}
+	if state != "missing" {
+		_ = exec.Command(engine, "rm", "-f", name).Run()
+	}
+	cmdArgs := append([]string{"run", "-d", "--name", name}, args...)
+	out, err := exec.Command(engine, cmdArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run %s: %v (%s)", name, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
+func ollamaModelAvailable(baseURL, model string) (bool, error) {
+	url := strings.TrimRight(baseURL, "/") + "/api/tags"
+	client := http.Client{Timeout: 8 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return false, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	var tags ollamaTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return false, err
+	}
+
+	needle := strings.TrimSpace(model)
+	for _, m := range tags.Models {
+		name := strings.TrimSpace(m.Name)
+		if name == needle || strings.HasPrefix(name, needle+":") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func endpointReady(url string) bool {
+	client := http.Client{Timeout: 4 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func runOutput(engine string, args ...string) string {
+	out, err := exec.Command(engine, args...).CombinedOutput()
+	if err != nil {
+		return strings.TrimSpace(string(out))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func prettyJSON(v interface{}) string {
+	buf := bytes.Buffer{}
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return "{}"
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func init() {
+	plusImage = "ghcr.io/hashimiche/hal-plus:latest"
+	mcpImage = "hashimiche/hal-mcp:local"
+	plusPort = 9000
+	plusModel = "gemma4"
+	ollamaHostURL = "http://127.0.0.1:11434"
+	ollamaContainerURL = ""
+
+	createCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image to run")
+	createCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected to exist locally")
+	createCmd.Flags().IntVar(&plusPort, "port", plusPort, "Host port for HAL Plus UI")
+	createCmd.Flags().StringVar(&plusModel, "model", plusModel, "Ollama model name expected on host")
+	createCmd.Flags().StringVar(&ollamaHostURL, "ollama-host-url", ollamaHostURL, "Host-side Ollama URL used for preflight checks")
+	createCmd.Flags().StringVar(&ollamaContainerURL, "ollama-base-url", ollamaContainerURL, "Container-side OLLAMA_BASE_URL override (defaults by engine)")
+
+	statusCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image expected")
+	statusCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected")
+
+	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(statusCmd)
+	Cmd.AddCommand(deleteCmd)
+
+	deleteCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image expected")
+	deleteCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected")
+}

--- a/cmd/plus/status.go
+++ b/cmd/plus/status.go
@@ -1,0 +1,52 @@
+package plus
+
+import (
+	"fmt"
+
+	"hal/internal/global"
+
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show HAL Plus runtime status",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+
+		plusState := containerState(engine, halPlusContainerName)
+		mcpState := containerState(engine, halMCPContainerName)
+		plusImagePresent := imageExists(engine, plusImage)
+		mcpImagePresent := imageExists(engine, mcpImage)
+
+		uiReady := plusState == "running" && endpointReady(fmt.Sprintf("http://127.0.0.1:%d/api/health", plusPort))
+		mcpReady := mcpState == "running"
+
+		fmt.Println("HAL Plus Status")
+		fmt.Println("================")
+		fmt.Printf("Engine:              %s\n", engine)
+		fmt.Printf("HAL Plus image:      %s (%s)\n", plusImage, boolLabel(plusImagePresent))
+		fmt.Printf("HAL MCP image:       %s (%s)\n", mcpImage, boolLabel(mcpImagePresent))
+		fmt.Printf("HAL Plus container:  %s (%s)\n", halPlusContainerName, plusState)
+		fmt.Printf("HAL MCP container:   %s (%s)\n", halMCPContainerName, mcpState)
+		fmt.Printf("HAL Plus health:     %s\n", boolLabel(uiReady))
+		fmt.Printf("HAL MCP health:      %s\n", boolLabel(mcpReady))
+		fmt.Printf("UI endpoint:         http://hal.localhost:%d\n", plusPort)
+
+		if plusState != "running" || mcpState != "running" {
+			fmt.Println("💡 Tip: Run 'hal plus create' to start or reconcile HAL Plus and HAL MCP containers.")
+		}
+	},
+}
+
+func boolLabel(ok bool) string {
+	if ok {
+		return "ready"
+	}
+	return "missing"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"hal/cmd/mcp"
 	"hal/cmd/nomad"
 	"hal/cmd/observability"
+	"hal/cmd/plus"
 	"hal/cmd/terraform"
 	"hal/cmd/vault"
 
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(boundary.Cmd)
 	rootCmd.AddCommand(consul.Cmd)
 	rootCmd.AddCommand(mcp.Cmd)
+	rootCmd.AddCommand(plus.Cmd)
 	rootCmd.AddCommand(terraform.Cmd)
 	rootCmd.AddCommand(observability.Cmd)
 }


### PR DESCRIPTION
## Title
Rootless MCP HTTP lifecycle and local image handling for hal plus

## Summary
Improves the hal plus container lifecycle for rootless environments and streamable-HTTP MCP usage.

## What changed
- Removed socket and root-user dependency from hal plus runtime flow to keep Podman rootless.
- Improved `hal mcp create --http` managed image build flow.
- Added local-image-first behavior for `hal plus create --image` so local tags are used without forced registry pull.

## Why
- Avoid fragile engine-socket behavior in rootless mode.
- Make local localhost image tags reliable.
- Keep MCP transport health independent from host engine access.

## Validation
- Built MCP and plus images and recreated the stack with `plus delete/create`.
- Verified hal-plus reaches MCP over HTTP and lifecycle commands succeed.