### PR TITLE
feat(plus): improve ollama model ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,28 @@ hal mcp delete    # remove MCP config, managed binary, and stale PID state
 
 ---
 
+### HAL Plus (`hal plus`)
+
+HAL Plus runs the local web UI container, keeps HAL MCP on the same network, and now handles the common Ollama model UX on the host.
+
+```bash
+hal plus create                      # default preset: gemma4
+hal plus create --model qwen3.5     # build and use the qwen3.5 preset
+hal plus create --model gemma4 --keep-alive 5m
+hal plus create --model qwen3.5 --model-config ./Modelfile
+hal plus status
+hal plus delete
+```
+
+Notes:
+
+- `--model` accepts either a curated preset (`gemma4`, `qwen3.5`) or an existing host Ollama model name.
+- For known presets, HAL creates a HAL-managed Ollama model with balanced defaults instead of requiring a manual `ollama pull` step.
+- `--model-config` lets you point HAL at a custom Ollama `Modelfile`; HAL will build a managed model on the host and then wire HAL Plus to use it.
+- `--keep-alive` controls how long Ollama keeps the model loaded after requests so idle memory can fall back down.
+
+---
+
 ## Configuration
 
 HAL uses environment variables and Docker/Podman networking — there is no config file to edit under normal use.

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -20,30 +20,57 @@ var createCmd = &cobra.Command{
 			return
 		}
 
+		runtimeConfig, err := resolveOllamaRuntimeConfig(plusModel, plusModelConfig, ollamaKeepAlive)
+		if err != nil {
+			fmt.Printf("❌ Invalid Ollama model settings: %v\n", err)
+			return
+		}
+
 		containerOllamaURL := detectOllamaContainerURL(engine)
 
 		if global.DryRun {
 			fmt.Printf("[DRY RUN] Would verify Ollama host endpoint: %s\n", ollamaHostURL)
-			fmt.Printf("[DRY RUN] Would verify model availability: %s\n", plusModel)
+			if runtimeConfig.ManagedByHAL {
+				fmt.Printf("[DRY RUN] Would reconcile HAL-managed Ollama model: %s\n", runtimeConfig.RuntimeModel)
+				if runtimeConfig.BaseModel != "" {
+					fmt.Printf("[DRY RUN] Would build it from base model: %s\n", runtimeConfig.BaseModel)
+				}
+				if runtimeConfig.ModelfilePath != "" {
+					fmt.Printf("[DRY RUN] Would use model config: %s\n", runtimeConfig.ModelfilePath)
+				}
+			} else {
+				fmt.Printf("[DRY RUN] Would ensure Ollama model exists locally: %s\n", runtimeConfig.RuntimeModel)
+			}
 			fmt.Printf("[DRY RUN] Would verify local HAL MCP image exists: %s\n", mcpImage)
 			fmt.Println("[DRY RUN] Would ensure hal-net exists")
 			fmt.Printf("[DRY RUN] Would use local HAL Plus image if present, otherwise pull: %s\n", plusImage)
 			fmt.Println("[DRY RUN] Would start container hal-mcp on hal-net")
 			fmt.Println("[DRY RUN] Would start container hal-plus on hal-net")
 			fmt.Printf("[DRY RUN] Would set OLLAMA_BASE_URL=%s\n", containerOllamaURL)
+			fmt.Printf("[DRY RUN] Would set OLLAMA_MODEL=%s\n", runtimeConfig.RuntimeModel)
+			if runtimeConfig.ContextWindow > 0 {
+				fmt.Printf("[DRY RUN] Would set OLLAMA_CONTEXT_WINDOW=%d\n", runtimeConfig.ContextWindow)
+			}
+			fmt.Printf("[DRY RUN] Would set OLLAMA_KEEP_ALIVE=%s\n", runtimeConfig.KeepAlive)
 			fmt.Println("[DRY RUN] Would set HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp")
 			return
 		}
 
-		ok, err := ollamaModelAvailable(ollamaHostURL, plusModel)
+		if err := reconcileOllamaModel(runtimeConfig); err != nil {
+			fmt.Printf("❌ Failed to prepare Ollama model '%s': %v\n", runtimeConfig.RuntimeModel, err)
+			fmt.Printf("   💡 Ensure Ollama is installed, running, and reachable at %s.\n", ollamaHostURL)
+			return
+		}
+
+		ok, err := ollamaModelAvailable(ollamaHostURL, runtimeConfig.RuntimeModel)
 		if err != nil {
 			fmt.Printf("❌ Ollama preflight failed at %s: %v\n", ollamaHostURL, err)
 			fmt.Printf("   💡 Ensure Ollama is running on host and reachable before 'hal plus create'.\n")
 			return
 		}
 		if !ok {
-			fmt.Printf("❌ Ollama model '%s' was not found at %s\n", plusModel, ollamaHostURL)
-			fmt.Printf("   💡 Pull the model first (example): ollama pull %s\n", plusModel)
+			fmt.Printf("❌ Ollama model '%s' was not found at %s after reconciliation\n", runtimeConfig.RuntimeModel, ollamaHostURL)
+			fmt.Printf("   💡 Check the configured model source or Modelfile and retry 'hal plus create'.\n")
 			return
 		}
 
@@ -73,10 +100,15 @@ var createCmd = &cobra.Command{
 			"-e", "API_HOST=0.0.0.0",
 			"-e", "API_PORT=9000",
 			"-e", fmt.Sprintf("OLLAMA_BASE_URL=%s", containerOllamaURL),
-			"-e", fmt.Sprintf("OLLAMA_MODEL=%s", plusModel),
+			"-e", fmt.Sprintf("OLLAMA_MODEL=%s", runtimeConfig.RuntimeModel),
+			"-e", fmt.Sprintf("OLLAMA_MODEL_LABEL=%s", runtimeConfig.RequestedModel),
+			"-e", fmt.Sprintf("OLLAMA_KEEP_ALIVE=%s", runtimeConfig.KeepAlive),
 			"-e", "HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp",
 			"-e", "HAL_PLUS_CONTAINER_MODE=true",
 			plusImage,
+		}
+		if runtimeConfig.ContextWindow > 0 {
+			plusArgs = append(plusArgs[:len(plusArgs)-1], append([]string{"-e", fmt.Sprintf("OLLAMA_CONTEXT_WINDOW=%d", runtimeConfig.ContextWindow)}, plusArgs[len(plusArgs)-1])...)
 		}
 		if err := ensureRunningContainer(engine, halPlusContainerName, plusArgs); err != nil {
 			fmt.Printf("❌ %v\n", err)
@@ -87,6 +119,10 @@ var createCmd = &cobra.Command{
 		fmt.Printf("🐳 Engine:       %s\n", engine)
 		fmt.Printf("🐳 HAL Plus:     %s\n", plusImage)
 		fmt.Printf("🐳 HAL MCP:      %s\n", mcpImage)
+		fmt.Printf("🧠 Ollama model: %s\n", runtimeConfig.RuntimeModel)
+		if runtimeConfig.RequestedModel != runtimeConfig.RuntimeModel {
+			fmt.Printf("🧩 Model preset: %s\n", runtimeConfig.RequestedModel)
+		}
 		fmt.Printf("🧠 Ollama host:  %s\n", ollamaHostURL)
 		fmt.Printf("🌐 UI URL:       http://hal.localhost:%d\n", plusPort)
 		fmt.Println("💡 Run 'hal plus status' to verify container and endpoint health.")

--- a/cmd/plus/ollama.go
+++ b/cmd/plus/ollama.go
@@ -1,0 +1,236 @@
+package plus
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const defaultOllamaKeepAlive = "5m"
+
+type ollamaModelPreset struct {
+	Key           string
+	BaseModel     string
+	ManagedModel  string
+	ContextWindow int
+	Temperature   float64
+	TopP          float64
+	TopK          int
+	MinP          float64
+	RepeatPenalty float64
+}
+
+type ollamaRuntimeConfig struct {
+	RequestedModel string
+	RuntimeModel   string
+	Managed        bool
+	ManagedByHAL   bool
+	ModelfilePath  string
+	ModelfileText  string
+	ContextWindow  int
+	KeepAlive      string
+	BaseModel      string
+}
+
+var ollamaModelPresets = map[string]ollamaModelPreset{
+	"gemma4": {
+		Key:           "gemma4",
+		BaseModel:     "gemma4:e4b",
+		ManagedModel:  "hal-plus-gemma4",
+		ContextWindow: 32768,
+		Temperature:   1.0,
+		TopP:          0.95,
+		TopK:          64,
+		MinP:          0.0,
+		RepeatPenalty: 1.0,
+	},
+	"qwen3.5": {
+		Key:           "qwen3.5",
+		BaseModel:     "qwen3.5:9b",
+		ManagedModel:  "hal-plus-qwen35",
+		ContextWindow: 32768,
+		Temperature:   0.6,
+		TopP:          0.95,
+		TopK:          20,
+		MinP:          0.0,
+		RepeatPenalty: 1.0,
+	},
+}
+
+func normalizeOllamaModelSelection(selection string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(selection))
+	switch trimmed {
+	case "gemma", "gemma4":
+		return "gemma4"
+	case "qwen", "qwen35", "qwen-3.5", "qwen3.5":
+		return "qwen3.5"
+	default:
+		return trimmed
+	}
+}
+
+func resolveOllamaPreset(selection string) (ollamaModelPreset, bool) {
+	preset, ok := ollamaModelPresets[normalizeOllamaModelSelection(selection)]
+	return preset, ok
+}
+
+func supportedOllamaModelsHelp() string {
+	return "Ollama model preset or existing host model name (presets: gemma4, qwen3.5)"
+}
+
+func resolveOllamaRuntimeConfig(requestedModel, modelConfigPath, keepAlive string) (ollamaRuntimeConfig, error) {
+	selection := strings.TrimSpace(requestedModel)
+	if selection == "" {
+		return ollamaRuntimeConfig{}, fmt.Errorf("model cannot be empty")
+	}
+
+	runtimeConfig := ollamaRuntimeConfig{
+		RequestedModel: selection,
+		RuntimeModel:   selection,
+		KeepAlive:      strings.TrimSpace(keepAlive),
+	}
+	if runtimeConfig.KeepAlive == "" {
+		runtimeConfig.KeepAlive = defaultOllamaKeepAlive
+	}
+
+	if preset, ok := resolveOllamaPreset(selection); ok {
+		runtimeConfig.RuntimeModel = preset.ManagedModel
+		runtimeConfig.Managed = true
+		runtimeConfig.ManagedByHAL = true
+		runtimeConfig.BaseModel = preset.BaseModel
+		runtimeConfig.ContextWindow = preset.ContextWindow
+		runtimeConfig.ModelfileText = buildPresetModelfile(preset)
+	}
+
+	if strings.TrimSpace(modelConfigPath) == "" {
+		return runtimeConfig, nil
+	}
+
+	absPath, err := filepath.Abs(modelConfigPath)
+	if err != nil {
+		return ollamaRuntimeConfig{}, fmt.Errorf("resolve model config path: %w", err)
+	}
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return ollamaRuntimeConfig{}, fmt.Errorf("read model config: %w", err)
+	}
+
+	runtimeConfig.Managed = true
+	runtimeConfig.ManagedByHAL = true
+	runtimeConfig.ModelfilePath = absPath
+	runtimeConfig.ModelfileText = string(content)
+	runtimeConfig.ContextWindow = parseModelfileContextWindow(runtimeConfig.ModelfileText, runtimeConfig.ContextWindow)
+	if !strings.Contains(runtimeConfig.RuntimeModel, "hal-plus-") {
+		runtimeConfig.RuntimeModel = managedModelAlias(selection)
+	}
+
+	return runtimeConfig, nil
+}
+
+func buildPresetModelfile(preset ollamaModelPreset) string {
+	return strings.TrimSpace(fmt.Sprintf(`FROM %s
+PARAMETER num_ctx %d
+PARAMETER temperature %.2f
+PARAMETER top_p %.2f
+PARAMETER top_k %d
+PARAMETER min_p %.2f
+PARAMETER repeat_penalty %.2f
+`,
+		preset.BaseModel,
+		preset.ContextWindow,
+		preset.Temperature,
+		preset.TopP,
+		preset.TopK,
+		preset.MinP,
+		preset.RepeatPenalty,
+	)) + "\n"
+}
+
+func parseModelfileContextWindow(content string, fallback int) int {
+	contextWindow := fallback
+	for _, rawLine := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "parameter") || !strings.EqualFold(fields[1], "num_ctx") {
+			continue
+		}
+		var parsed int
+		if _, err := fmt.Sscanf(fields[2], "%d", &parsed); err == nil && parsed > 0 {
+			contextWindow = parsed
+		}
+	}
+	return contextWindow
+}
+
+func managedModelAlias(selection string) string {
+	var builder strings.Builder
+	for _, char := range strings.ToLower(selection) {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') {
+			builder.WriteRune(char)
+			continue
+		}
+		if builder.Len() > 0 && builder.String()[builder.Len()-1] != '-' {
+			builder.WriteRune('-')
+		}
+	}
+	alias := strings.Trim(builder.String(), "-")
+	if alias == "" {
+		alias = "custom"
+	}
+	return "hal-plus-" + alias
+}
+
+func reconcileOllamaModel(config ollamaRuntimeConfig) error {
+	if config.Managed {
+		modelfilePath := config.ModelfilePath
+		cleanupPath := ""
+		if strings.TrimSpace(modelfilePath) == "" {
+			tempFile, err := os.CreateTemp("", "hal-plus-*.Modelfile")
+			if err != nil {
+				return fmt.Errorf("create temp Modelfile: %w", err)
+			}
+			if _, err := tempFile.WriteString(config.ModelfileText); err != nil {
+				_ = tempFile.Close()
+				_ = os.Remove(tempFile.Name())
+				return fmt.Errorf("write temp Modelfile: %w", err)
+			}
+			if err := tempFile.Close(); err != nil {
+				_ = os.Remove(tempFile.Name())
+				return fmt.Errorf("close temp Modelfile: %w", err)
+			}
+			modelfilePath = tempFile.Name()
+			cleanupPath = tempFile.Name()
+		}
+		if cleanupPath != "" {
+			defer os.Remove(cleanupPath)
+		}
+
+		out, err := exec.Command("ollama", "create", config.RuntimeModel, "-f", modelfilePath).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("ollama create %s failed: %v (%s)", config.RuntimeModel, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+
+	if _, err := exec.LookPath("ollama"); err != nil {
+		return fmt.Errorf("ollama CLI not found in PATH")
+	}
+
+	if ok, err := ollamaModelAvailable(ollamaHostURL, config.RuntimeModel); err == nil && ok {
+		return nil
+	}
+
+	out, err := exec.Command("ollama", "pull", config.RuntimeModel).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ollama pull %s failed: %v (%s)", config.RuntimeModel, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/cmd/plus/plus.go
+++ b/cmd/plus/plus.go
@@ -22,8 +22,10 @@ var (
 	mcpImage           string
 	plusPort           int
 	plusModel          string
+	plusModelConfig    string
 	ollamaHostURL      string
 	ollamaContainerURL string
+	ollamaKeepAlive    string
 )
 
 // Cmd manages HAL Plus container lifecycle.
@@ -140,16 +142,20 @@ func init() {
 	plusImage = "ghcr.io/hashimiche/hal-plus:latest"
 	mcpImage = "hashimiche/hal-mcp:local"
 	plusPort = 9000
-	plusModel = "gemma4"
+	plusModel = "qwen3.5"
+	plusModelConfig = ""
 	ollamaHostURL = "http://127.0.0.1:11434"
 	ollamaContainerURL = ""
+	ollamaKeepAlive = defaultOllamaKeepAlive
 
 	createCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image to run")
 	createCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected to exist locally")
 	createCmd.Flags().IntVar(&plusPort, "port", plusPort, "Host port for HAL Plus UI")
-	createCmd.Flags().StringVar(&plusModel, "model", plusModel, "Ollama model name expected on host")
+	createCmd.Flags().StringVar(&plusModel, "model", plusModel, supportedOllamaModelsHelp())
+	createCmd.Flags().StringVar(&plusModelConfig, "model-config", plusModelConfig, "Optional Modelfile path used to build a HAL-managed Ollama model on the host")
 	createCmd.Flags().StringVar(&ollamaHostURL, "ollama-host-url", ollamaHostURL, "Host-side Ollama URL used for preflight checks")
 	createCmd.Flags().StringVar(&ollamaContainerURL, "ollama-base-url", ollamaContainerURL, "Container-side OLLAMA_BASE_URL override (defaults by engine)")
+	createCmd.Flags().StringVar(&ollamaKeepAlive, "keep-alive", ollamaKeepAlive, "Ollama model keep-alive duration for HAL Plus chat requests (for example 10m or 0)")
 
 	statusCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image expected")
 	statusCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected")


### PR DESCRIPTION
## Summary

Improve the `hal plus` Ollama UX so the CLI can prepare and manage the host-side model setup instead of assuming the model already exists.

## What Changed

- Added curated Ollama presets for:
  - `qwen3.5`
  - `gemma4`
- Switched the default `hal plus` model preset to `qwen3.5`
- Added support for `--model-config` so `hal plus create` can build a HAL-managed Ollama model from a custom Modelfile
- Added support for `--keep-alive` so users can control Ollama idle memory behavior
- Added host-side model reconciliation during `hal plus create`:
  - build HAL-managed models for known presets / Modelfiles
  - pull existing named models if they are missing
- Passed the selected runtime model, friendly label, context window, and keep-alive settings into the `hal-plus` container
- Updated README docs for the new `hal plus` model workflow

## UX Outcome

Users no longer need to manually prepare the common Ollama path before starting HAL Plus.

Examples:

- `hal plus create`
- `hal plus create --model gemma4`
- `hal plus create --model qwen3.5 --model-config /path/to/Modelfile`
- `hal plus create --keep-alive 0`

## Why

The previous flow assumed the requested Ollama model already existed on the host and failed otherwise. That created avoidable friction for the main local UX.

This change makes `hal plus` responsible for the common setup path and gives users a clearer model-selection story without pushing them into manual Ollama commands.

