### PR TITLE
feat(status): live status sidecar, RefreshHalStatus hooks, GHCR mcp i…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -34,3 +35,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # The Fine-Grained PAT you created to update the homebrew-tap repo
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+  publish-mcp-image:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Build linux/amd64 hal binary
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o hal-linux ./main.go
+
+      - name: Build and push hal-mcp image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.mcp
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/hashimiche/hal-mcp:latest
+            ghcr.io/hashimiche/hal-mcp:${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local build artifacts
 hal
+hal-linux
 bin/
 dist/
 

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,7 @@
+FROM alpine:3.20
+RUN apk add --no-cache docker-cli
+RUN adduser -D -u 10001 hal
+COPY hal-linux /usr/local/bin/hal
+USER hal
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/hal", "mcp", "serve", "--transport", "streamable-http", "--http-host", "0.0.0.0", "--http-port", "8080", "--http-path", "/mcp"]

--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -64,8 +64,9 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
 - HAL MCP command namespace (`hal mcp`) supports two transports:
     - **stdio** (default, local/dev): `hal mcp serve` — spawned directly by HAL Plus; protocol `2024-11-05`.
     - **streamable-HTTP** (container): `hal mcp serve --transport streamable-http --http-host 0.0.0.0 --http-port 8080 --http-path /mcp`; protocol `2025-03-26`.
-    - `hal mcp create --http` builds the MCP HTTP container image from source using a Linux multi-stage Docker build (`FROM golang:alpine` + `FROM alpine`). It does **not** copy the host binary — it compiles a fresh Linux binary inside the build stage.
-    - The built image tag is `hashimiche/hal-mcp:local`; it runs as a non-root user (`hal`, uid 10001).
+    - `hal mcp create --http` pulls `ghcr.io/hashimiche/hal-mcp:latest` from GHCR. No source tree or Go toolchain required on the user machine.
+    - The image is published automatically by the release workflow (`Dockerfile.mcp`) on every version tag as `ghcr.io/hashimiche/hal-mcp:latest` and `ghcr.io/hashimiche/hal-mcp:<version>`. It runs as a non-root user (`hal`, uid 10001).
+    - `--http-tag` flag overrides the pulled image tag (e.g. to pin a specific version).
     - `hal mcp create|serve|status|delete` remains the primary operator surface.
     - MCP tool surface is read-only and leverages existing HAL command paths (`status`, `capacity`, `<product> status`) instead of reimplementing product logic.
     - Product status tools (for example `get_tfe_status`) should keep product-specific `recommended_commands` first (`hal terraform status`) so AI clients can answer quick health prompts without falling back to generic checks like `hal capacity`.
@@ -88,6 +89,17 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
     - Task worker agent-run config must keep `/tmp/terraform` writable (not read-only) so remote plans can download Terraform binaries.
     - TFE API responses can emit archivist object links without `:8443`; proxy response rewriting keeps UI/raw plan/apply log links host-reachable.
     - `hal terraform vcs-workflow enable` should describe validation in terms of pushing a new commit to `main`; tag creation alone is not a reliable first-run trigger when the tagged SHA was already ingested from branch pushes.
+- `hal status` is a CRUD product that manages the `hal-status` sidecar container:
+    - `hal status create` / `hal status update` / `hal status delete` are the operator surface.
+    - `hal status update` is the manual escape hatch: refreshes the snapshot for the currently running ecosystem (e.g. after deploying a product extension outside the normal lifecycle).
+    - `hal status _serve` is a hidden internal command run inside the `hal-status` container — do not surface it to users.
+    - The `hal-status` container reuses `hashimiche/hal-mcp:latest` (same image as `hal-mcp`) with `--entrypoint /usr/local/bin/hal` and `status _serve` as args.
+    - It reads a frozen `HAL_STATUS_DATA` JSON env var at startup and serves it at `http://hal-status:9001/api/status` on `hal-net`.
+    - The snapshot is built on the **host** (which has engine socket access) by `global.RefreshHalStatus(engine)`, injected as an env var, then the container is recreated. The container itself never touches the engine.
+    - `global.RefreshHalStatus(engine)` is called after every product lifecycle event that changes ecosystem state: all product `create`/`delete` commands, and all vault/boundary extension enable/disable commands (`vault k8s`, `vault oidc`, `vault jwt`, `vault ldap`, `vault database`, `boundary mariadb`, `boundary ssh`).
+    - `RefreshHalStatus` is a no-op if `hal-net` does not exist or the `hashimiche/hal-mcp:latest` image is not present — safe to call unconditionally.
+    - HAL Plus fetches `http://hal-status:9001/api/status` as its primary product state source (via `fetchHalStatusProducts()` in `server/index.mjs`), with `fallbackProductsFromEndpoints()` as a fallback for local dev without containers.
+    - The snapshot shape: `{ timestamp, engine, products: [{ product, state, health, reason, endpoint, containers, features: [{ feature, state, health, reason }] }] }`.
 - Shared runtime helpers live under `internal/global`, especially engine detection and network management.
 - Engine resource advisory helpers live under `internal/global`; reuse them instead of open-coding engine-specific capacity checks in individual commands.
 - Vault k8s demo (`hal vault k8s`) now supports two explicit demo modes behind the same nginx endpoint (`http://web.localhost:8088`):

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Install the tooling required by the labs you want to run before installing HAL.
 | Docker **or** Podman | Almost every `hal` flow |
 | KinD + kubectl + helm | `hal vault k8s` |
 | Multipass | `hal nomad`, `hal boundary ssh` |
+| [Ollama](https://ollama.com) | `hal plus` — local AI model backend |
 
 > **Engine detection:** HAL probes `docker info` first, then `podman info`, and uses whichever responds. No alias is required — both engines work natively.
 
@@ -349,6 +350,9 @@ Notes:
 - For known presets, HAL creates a HAL-managed Ollama model with balanced defaults instead of requiring a manual `ollama pull` step.
 - `--model-config` lets you point HAL at a custom Ollama `Modelfile`; HAL will build a managed model on the host and then wire HAL Plus to use it.
 - `--keep-alive` controls how long Ollama keeps the model loaded after requests so idle memory can fall back down.
+- **Qwen3.5** (`--model qwen3.5`) is the recommended preset for HAL Plus — it has a 32k context window and produces concise, grounded answers. HAL Plus uses `think: false` for operational answers to keep latency low.
+- **Gemma4** (`--model gemma4`) is a lighter alternative with faster cold starts, suited for machines with less VRAM.
+- Ollama must be running on the host (`ollama serve`) before `hal plus create` is called. HAL Plus connects to it from inside the container via `host.containers.internal:11434`.
 
 ---
 

--- a/cmd/boundary/create.go
+++ b/cmd/boundary/create.go
@@ -106,6 +106,7 @@ var deployCmd = &cobra.Command{
 
 		fmt.Println()
 		fmt.Println("✅ Boundary Controller & Worker are up!")
+		global.RefreshHalStatus(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Println("   🔗 UI Address: http://boundary.localhost:9200")
 		fmt.Println("   👤 Login:      admin / password")

--- a/cmd/boundary/delete.go
+++ b/cmd/boundary/delete.go
@@ -52,6 +52,7 @@ var destroyCmd = &cobra.Command{
 			fmt.Printf("⚠️  Could not remove Boundary observability target file: %v\n", err)
 		}
 		fmt.Println("✅ Boundary environment destroyed successfully!")
+		global.RefreshHalStatus(engine)
 	},
 }
 

--- a/cmd/boundary/mariadb.go
+++ b/cmd/boundary/mariadb.go
@@ -212,6 +212,9 @@ func bootstrapBoundaryMariaDB(targetHost string) error {
 	}
 
 	fmt.Println("✅ Boundary Academy Lab Bootstrapped!")
+	if eng, err := global.DetectEngine(); err == nil {
+		global.RefreshHalStatus(eng)
+	}
 	return nil
 }
 

--- a/cmd/boundary/ssh.go
+++ b/cmd/boundary/ssh.go
@@ -374,6 +374,9 @@ func bootstrapBoundarySSH(targetIP string) error {
 	}
 
 	fmt.Println("✅ Boundary SSH target successfully bootstrapped!")
+	if eng, err := global.DetectEngine(); err == nil {
+		global.RefreshHalStatus(eng)
+	}
 	fmt.Println("\n💡 Test your access:")
 	fmt.Println("   1. Log in to UI (http://boundary.localhost:9200)")
 	fmt.Println("   2. Change Scope to 'hal-academy-ssh'")

--- a/cmd/consul/create.go
+++ b/cmd/consul/create.go
@@ -65,6 +65,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		fmt.Println("✅ Standalone Consul Server is up!")
+		global.RefreshHalStatus(engine)
 		fmt.Println("   🔗 UI Address: http://consul.localhost:8500")
 		fmt.Println("\n💡 Tip: Use this to test the KV store or learn the API.")
 		fmt.Println("   (For real workloads, use 'hal nomad create --with-consul' instead!)")

--- a/cmd/consul/delete.go
+++ b/cmd/consul/delete.go
@@ -37,6 +37,7 @@ var destroyCmd = &cobra.Command{
 			fmt.Printf("⚠️  Could not remove Consul observability target file: %v\n", err)
 		}
 		fmt.Println("✅ Consul environment destroyed successfully!")
+		global.RefreshHalStatus(engine)
 	},
 }
 

--- a/cmd/halstatus/halstatus.go
+++ b/cmd/halstatus/halstatus.go
@@ -1,0 +1,227 @@
+package halstatus
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"hal/internal/global"
+
+	"github.com/spf13/cobra"
+)
+
+// Cmd is the root cobra command for `hal status`.
+var Cmd = &cobra.Command{
+	Use:   "status",
+	Short: "Manage the hal-status runtime container",
+	Long:  `Create, update, or delete the hal-status container that serves live ecosystem state to hal-plus and other consumers.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create (or recreate) the hal-status container",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+		if global.DryRun {
+			fmt.Printf("[DRY RUN] Would create %s container on hal-net (port %d)\n",
+				global.HalStatusContainerName, global.HalStatusPort)
+			return
+		}
+		global.EnsureNetwork(engine)
+		global.RefreshHalStatus(engine)
+		fmt.Println("✅ hal-status container created.")
+		fmt.Printf("   API: http://hal-status:%d/api/status (from hal-net)\n", global.HalStatusPort)
+	},
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Refresh the hal-status snapshot (re-inspect the ecosystem and replace the container)",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+		if global.DryRun {
+			fmt.Printf("[DRY RUN] Would refresh %s snapshot\n", global.HalStatusContainerName)
+			return
+		}
+		global.RefreshHalStatus(engine)
+		fmt.Println("✅ hal-status snapshot refreshed.")
+	},
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Remove the hal-status container",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+		if global.DryRun {
+			fmt.Printf("[DRY RUN] Would remove container %s\n", global.HalStatusContainerName)
+			return
+		}
+		global.RemoveHalStatus(engine)
+		fmt.Printf("✅ %s removed.\n", global.HalStatusContainerName)
+	},
+}
+
+// serveCmd is hidden — called by the container entrypoint, not the user.
+// It reads HAL_STATUS_DATA and serves a minimal JSON + HTML status API.
+var serveCmd = &cobra.Command{
+	Use:    "_serve",
+	Short:  "Internal: serve HAL_STATUS_DATA over HTTP (used by the hal-status container)",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		raw := os.Getenv("HAL_STATUS_DATA")
+		if raw == "" {
+			fmt.Fprintln(os.Stderr, "HAL_STATUS_DATA not set")
+			os.Exit(1)
+		}
+
+		var snap global.StatusSnapshot
+		if err := json.Unmarshal([]byte(raw), &snap); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to parse HAL_STATUS_DATA: %v\n", err)
+			os.Exit(1)
+		}
+
+		port := global.HalStatusPort
+		if v := os.Getenv("HAL_STATUS_PORT"); v != "" {
+			if p, err := strconv.Atoi(v); err == nil {
+				port = p
+			}
+		}
+
+		mux := http.NewServeMux()
+
+		// GET /api/status — full snapshot
+		mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(snap)
+		})
+
+		// GET /api/products — products array
+		mux.HandleFunc("/api/products", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(snap.Products)
+		})
+
+		// GET /api/products/{name} — single product
+		mux.HandleFunc("/api/products/", func(w http.ResponseWriter, r *http.Request) {
+			name := strings.TrimPrefix(r.URL.Path, "/api/products/")
+			name = strings.TrimSuffix(name, "/")
+			if name == "" {
+				http.Redirect(w, r, "/api/products", http.StatusMovedPermanently)
+				return
+			}
+			for _, p := range snap.Products {
+				if strings.EqualFold(p.Product, name) {
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+					enc := json.NewEncoder(w)
+					enc.SetIndent("", "  ")
+					_ = enc.Encode(p)
+					return
+				}
+			}
+			http.Error(w, `{"error":"product not found"}`, http.StatusNotFound)
+		})
+
+		// GET / — simple HTML status page
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprintf(w, htmlStatusPage(snap))
+		})
+
+		addr := fmt.Sprintf(":%d", port)
+		fmt.Printf("hal-status serving on %s (snapshot: %s)\n", addr, snap.Timestamp)
+		srv := &http.Server{
+			Addr:         addr,
+			Handler:      mux,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		if err := srv.ListenAndServe(); err != nil {
+			fmt.Fprintf(os.Stderr, "server error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func htmlStatusPage(snap global.StatusSnapshot) string {
+	var rows strings.Builder
+	for _, p := range snap.Products {
+		stateColor := "#e74c3c"
+		if p.State == "running" {
+			stateColor = "#27ae60"
+		} else if p.State == "partial" {
+			stateColor = "#f39c12"
+		}
+		var featureCells strings.Builder
+		for _, f := range p.Features {
+			fc := "#aaa"
+			if f.State == "enabled" {
+				fc = "#27ae60"
+			}
+			featureCells.WriteString(fmt.Sprintf(
+				`<span style="margin-right:8px;color:%s">&#9679; %s</span>`, fc, f.Feature))
+		}
+		rows.WriteString(fmt.Sprintf(`
+<tr>
+  <td style="padding:8px 12px;font-weight:600">%s</td>
+  <td style="padding:8px 12px;color:%s">%s</td>
+  <td style="padding:8px 12px"><a href="%s" target="_blank">%s</a></td>
+  <td style="padding:8px 12px;font-size:0.85em">%s</td>
+</tr>`, p.Product, stateColor, p.State, p.Endpoint, p.Endpoint, featureCells.String()))
+	}
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>HAL Status</title>
+<style>body{font-family:monospace;background:#111;color:#eee;padding:24px}
+table{border-collapse:collapse;width:100%%}
+th{text-align:left;padding:8px 12px;border-bottom:1px solid #333;color:#aaa;font-size:0.8em;text-transform:uppercase}
+tr:hover{background:#1a1a1a}a{color:#7c3aed}</style>
+</head>
+<body>
+<h2 style="color:#7c3aed">HAL Ecosystem Status</h2>
+<p style="color:#aaa;font-size:0.85em">Snapshot: %s &nbsp;·&nbsp; Engine: %s</p>
+<table>
+<thead><tr><th>Product</th><th>State</th><th>Endpoint</th><th>Features</th></tr></thead>
+<tbody>%s</tbody>
+</table>
+<p style="color:#555;font-size:0.75em;margin-top:24px">API: <a href="/api/status">/api/status</a> &nbsp;·&nbsp; <a href="/api/products">/api/products</a></p>
+</body></html>`, snap.Timestamp, snap.Engine, rows.String())
+}
+
+func init() {
+	Cmd.AddCommand(createCmd, updateCmd, deleteCmd, serveCmd)
+}

--- a/cmd/mcp/advanced.go
+++ b/cmd/mcp/advanced.go
@@ -781,133 +781,16 @@ func buildStructuredStatus() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339)
-	products := []map[string]interface{}{
-		buildProductState(engine, "consul", []string{"hal-consul"}, map[string]string{"core": boolState(checkContainer(engine, "hal-consul"))}, "http://consul.localhost:8500"),
-		buildProductState(engine, "vault", []string{"hal-vault"}, map[string]string{"audit": resolveVaultAuditFeature(engine), "k8s": boolState(checkContainer(engine, "kind-control-plane")), "jwt": boolState(checkContainer(engine, "hal-gitlab")), "ldap": boolState(checkContainer(engine, "hal-openldap")), "database": boolState(checkContainer(engine, "hal-vault-mariadb")), "oidc": boolState(checkContainer(engine, "hal-keycloak"))}, "http://vault.localhost:8200"),
-		buildProductState(engine, "nomad", []string{"hal-nomad"}, map[string]string{"job": boolState(checkMultipass("hal-nomad"))}, "multipass://hal-nomad"),
-		buildProductState(engine, "boundary", []string{"hal-boundary"}, map[string]string{"mariadb": boolState(checkContainer(engine, "hal-boundary-target-mariadb")), "ssh": boolState(checkMultipass("hal-boundary-ssh"))}, "http://boundary.localhost:9200"),
-		buildProductState(engine, "terraform", []string{"hal-tfe", "hal-tfe-db", "hal-tfe-redis", "hal-tfe-minio", "hal-tfe-proxy"}, map[string]string{"workspace": boolState(checkContainer(engine, "hal-tfe") && checkContainer(engine, "hal-gitlab"))}, "https://tfe.localhost:8443"),
-		buildProductState(engine, "obs", []string{"hal-grafana", "hal-prometheus", "hal-loki"}, map[string]string{"grafana": boolState(checkContainer(engine, "hal-grafana")), "prometheus": boolState(checkContainer(engine, "hal-prometheus")), "loki": boolState(checkContainer(engine, "hal-loki"))}, "http://grafana.localhost:3000"),
-	}
-
-	return map[string]interface{}{
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
-		"engine":    engine,
-		"products":  products,
-		"generated": now,
-	}, nil
-}
-
-func buildProductState(engine, product string, containers []string, features map[string]string, endpoint string) map[string]interface{} {
-	runningCount := 0
-	for _, c := range containers {
-		if c == "hal-nomad" {
-			if checkMultipass("hal-nomad") {
-				runningCount++
-			}
-			continue
-		}
-		if checkContainer(engine, c) {
-			runningCount++
-		}
-	}
-
-	state := "not_deployed"
-	health := "down"
-	reason := "required resources are not running"
-	if runningCount > 0 && runningCount < len(containers) {
-		state = "partial"
-		health = "degraded"
-		reason = "some resources are running"
-	}
-	if runningCount == len(containers) {
-		state = "running"
-		health = "healthy"
-		reason = "all required resources are running"
-	}
-	if len(containers) == 1 && runningCount == 1 {
-		state = "running"
-		health = "healthy"
-		reason = "primary resource is running"
-	}
-
-	featureRows := make([]map[string]string, 0, len(features))
-	for k, v := range features {
-		healthState := "down"
-		reasonState := "feature is disabled"
-		if v == "enabled" {
-			healthState = "healthy"
-			reasonState = "feature is enabled"
-		}
-		featureRows = append(featureRows, map[string]string{
-			"feature": k,
-			"state":   v,
-			"health":  healthState,
-			"reason":  reasonState,
-		})
-	}
-	sort.Slice(featureRows, func(i, j int) bool { return featureRows[i]["feature"] < featureRows[j]["feature"] })
-
-	return map[string]interface{}{
-		"product":    product,
-		"state":      state,
-		"health":     health,
-		"reason":     reason,
-		"endpoint":   endpoint,
-		"containers": containers,
-		"features":   featureRows,
-	}
-}
-
-func resolveVaultAuditFeature(engine string) string {
-	if !checkContainer(engine, "hal-vault") {
-		return "disabled"
-	}
-	out, err := exec.Command(
-		engine,
-		"exec",
-		"-e",
-		"VAULT_ADDR=http://127.0.0.1:8200",
-		"-e",
-		"VAULT_TOKEN=root",
-		"hal-vault",
-		"vault",
-		"audit",
-		"list",
-		"-format=json",
-	).Output()
+	snap, err := global.BuildStatusSnapshot(engine)
 	if err != nil {
-		return "unknown"
+		return nil, err
 	}
-	trimmed := strings.TrimSpace(string(out))
-	if trimmed == "{}" || trimmed == "" {
-		return "disabled"
-	}
-	return "enabled"
-}
 
-func checkContainer(engine, name string) bool {
-	out, err := exec.Command(engine, "ps", "-q", "-f", fmt.Sprintf("name=^%s$", name)).Output()
-	if err != nil {
-		return false
+	var result map[string]interface{}
+	if err := json.Unmarshal(snap, &result); err != nil {
+		return nil, err
 	}
-	return strings.TrimSpace(string(out)) != ""
-}
-
-func checkMultipass(name string) bool {
-	out, err := exec.Command("multipass", "info", name, "--format", "csv").Output()
-	if err != nil {
-		return false
-	}
-	return strings.Contains(string(out), "Running")
-}
-
-func boolState(enabled bool) string {
-	if enabled {
-		return "enabled"
-	}
-	return "disabled"
+	return result, nil
 }
 
 func buildDiagnostics(product string, tailLines int) (map[string]interface{}, error) {
@@ -934,7 +817,7 @@ func buildDiagnostics(product string, tailLines int) (map[string]interface{}, er
 	reFailure := regexp.MustCompile(`(?i)(error|failed|panic|denied|refused|timeout)`) // safe heuristic
 
 	for _, c := range containers {
-		if !checkContainer(engine, c) {
+		if !global.CheckContainer(engine, c) {
 			logs[c] = "container not running"
 			failureHints[c] = "container not running"
 			continue

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -403,69 +403,13 @@ func provisionManagedMCPBinary(targetPath string) (string, error) {
 }
 
 func buildManagedMCPHTTPImage(engine, imageTag string) error {
-	sourceRoot, err := resolveHalSourceRoot()
-	if err != nil {
-		return err
+	pullCmd := exec.Command(engine, "pull", imageTag)
+	pullCmd.Stdout = os.Stdout
+	pullCmd.Stderr = os.Stderr
+	if err := pullCmd.Run(); err != nil {
+		return fmt.Errorf("pull %s: %w", imageTag, err)
 	}
-
-	tmpDir, err := os.MkdirTemp("", "hal-mcp-image-")
-	if err != nil {
-		return fmt.Errorf("create temp build directory: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	dockerfile := `FROM golang:1.26-alpine AS build
-WORKDIR /src
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /out/hal ./main.go
-
-FROM alpine:3.20
-RUN apk add --no-cache docker-cli
-RUN adduser -D -u 10001 hal
-COPY --from=build /out/hal /usr/local/bin/hal
-USER hal
-EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/hal", "mcp", "serve", "--transport", "streamable-http", "--http-host", "0.0.0.0", "--http-port", "8080", "--http-path", "/mcp"]
-`
-	if err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
-		return fmt.Errorf("write temporary Dockerfile: %w", err)
-	}
-
-	buildCmd := exec.Command(engine, "build", "-t", imageTag, "-f", filepath.Join(tmpDir, "Dockerfile"), sourceRoot)
-	buildOutput, err := buildCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s build failed: %w\n%s", engine, err, strings.TrimSpace(string(buildOutput)))
-	}
-
 	return nil
-}
-
-func resolveHalSourceRoot() (string, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("resolve working directory: %w", err)
-	}
-
-	dir := wd
-	for {
-		modPath := filepath.Join(dir, "go.mod")
-		payload, readErr := os.ReadFile(modPath)
-		if readErr == nil {
-			if strings.Contains(string(payload), "module hal") {
-				return dir, nil
-			}
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-
-	return "", fmt.Errorf("cannot locate HAL source root with go.mod (run from hal repo tree)")
 }
 
 func serveStdioMCP(stdin io.Reader, stdout io.Writer) error {
@@ -1065,7 +1009,7 @@ func init() {
 	createCmd.Flags().StringVar(&createBinaryPath, "binary-path", "", "Path to write the managed HAL binary used by MCP clients (default ~/.hal/bin/hal-mcp)")
 	createCmd.Flags().BoolVar(&createJSONOnly, "json", false, "Only generate/replace MCP config JSON (skip managed binary provisioning)")
 	createCmd.Flags().BoolVar(&createHTTPImage, "http", false, "Build a local HAL MCP container image for streamable-http transport")
-	createCmd.Flags().StringVar(&createHTTPTag, "http-tag", "hashimiche/hal-mcp:local", "Image tag used when --http is set")
+	createCmd.Flags().StringVar(&createHTTPTag, "http-tag", "hashimiche/hal-mcp:latest", "Image tag used when --http is set")
 	upCmd.Flags().StringVar(&upTransport, "transport", transportStdio, "MCP transport to use: stdio or streamable-http")
 	upCmd.Flags().StringVar(&upHTTPHost, "http-host", "0.0.0.0", "Host/interface to bind when --transport=streamable-http")
 	upCmd.Flags().IntVar(&upHTTPPort, "http-port", 8080, "TCP port to listen on when --transport=streamable-http")

--- a/cmd/mcp/ops_api.go
+++ b/cmd/mcp/ops_api.go
@@ -1323,7 +1323,7 @@ func componentContext(component string) (map[string]interface{}, []string, error
 				"sensitive":       true,
 			},
 			"state": map[string]interface{}{
-				"vault_container_running": checkContainer("podman", "hal-vault") || checkContainer("docker", "hal-vault"),
+				"vault_container_running": global.CheckContainer("podman", "hal-vault") || global.CheckContainer("docker", "hal-vault"),
 			},
 		}, []string{"hal vault status", "hal vault create", "hal vault audit"}, nil
 	case "oidc", "vault_oidc":
@@ -1582,7 +1582,7 @@ func buildOIDCOrJWTStatus(mode string) (map[string]interface{}, []string, error)
 	if err != nil {
 		return nil, []string{"hal status"}, err
 	}
-	if !checkContainer(engine, "hal-vault") {
+	if !global.CheckContainer(engine, "hal-vault") {
 		return map[string]interface{}{"enabled": false, "mount_path": mode + "/", "config_complete": false, "missing_fields": []string{"vault_not_running"}}, []string{"hal vault create", "hal vault status"}, fmt.Errorf("vault is not deployed")
 	}
 
@@ -1596,10 +1596,10 @@ func buildOIDCOrJWTStatus(mode string) (map[string]interface{}, []string, error)
 	if !enabled {
 		missing = append(missing, "auth_mount")
 	}
-	if mode == "oidc" && !checkContainer(engine, "hal-keycloak") {
+	if mode == "oidc" && !global.CheckContainer(engine, "hal-keycloak") {
 		missing = append(missing, "keycloak_provider")
 	}
-	if mode == "jwt" && !checkContainer(engine, "hal-gitlab") {
+	if mode == "jwt" && !global.CheckContainer(engine, "hal-gitlab") {
 		missing = append(missing, "gitlab_provider")
 	}
 	status := map[string]interface{}{
@@ -1875,8 +1875,8 @@ func handleTFECLIStatus() mcpToolCallResult {
 	}
 	state, _ := product["state"].(string)
 	reason, _ := product["reason"].(string)
-	newHelperReady := checkContainer(engine, "hal-tfe-api")
-	legacyHelperReady := checkContainer(engine, "hal-tfe-cli")
+	newHelperReady := global.CheckContainer(engine, "hal-tfe-api")
+	legacyHelperReady := global.CheckContainer(engine, "hal-tfe-cli")
 	cliHelperReady := newHelperReady || legacyHelperReady
 	helperContainerName := "hal-tfe-api"
 	if !newHelperReady && legacyHelperReady {
@@ -1888,14 +1888,14 @@ func handleTFECLIStatus() mcpToolCallResult {
 	tokenReady := tokenErr == nil
 	checks := []opCheck{
 		{Name: "terraform_runtime", Status: checkStatusFromState(state), Details: reason},
-		{Name: "terraform_cli_helper", Status: checkStatusFromState(boolState(cliHelperReady)), Details: helperContainerName + " helper availability"},
-		{Name: "terraform_cli_token_cache", Status: checkStatusFromState(boolState(tokenReady)), Details: tokenPath},
+		{Name: "terraform_cli_helper", Status: checkStatusFromState(global.BoolState(cliHelperReady)), Details: helperContainerName + " helper availability"},
+		{Name: "terraform_cli_token_cache", Status: checkStatusFromState(global.BoolState(tokenReady)), Details: tokenPath},
 	}
 	data := map[string]interface{}{
 		"runtime": product,
 		"cli_helper": map[string]interface{}{
 			"container": helperContainerName,
-			"state":     boolState(cliHelperReady),
+			"state":     global.BoolState(cliHelperReady),
 		},
 		"token_cache": map[string]interface{}{
 			"path":    tokenPath,

--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -216,6 +216,7 @@ providers:
 
 		fmt.Println()
 		fmt.Println("✅ Observability Stack Deployed Successfully!")
+		global.RefreshHalStatus(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Println("🔗 Grafana:    http://grafana.localhost:3000 (Auto-logged in as Admin)")
 		fmt.Println("🔗 Prometheus: http://prometheus.localhost:9090")

--- a/cmd/observability/delete.go
+++ b/cmd/observability/delete.go
@@ -49,6 +49,7 @@ var destroyCmd = &cobra.Command{
 
 		global.CleanNetworkIfEmpty(engine)
 		fmt.Println("✅ Observability environment destroyed successfully!")
+		global.RefreshHalStatus(engine)
 	},
 }
 

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -116,6 +116,7 @@ var createCmd = &cobra.Command{
 		}
 
 		fmt.Println("✅ HAL Plus runtime created successfully.")
+		global.RefreshHalStatus(engine)
 		fmt.Printf("🐳 Engine:       %s\n", engine)
 		fmt.Printf("🐳 HAL Plus:     %s\n", plusImage)
 		fmt.Printf("🐳 HAL MCP:      %s\n", mcpImage)

--- a/cmd/plus/delete.go
+++ b/cmd/plus/delete.go
@@ -29,6 +29,7 @@ var deleteCmd = &cobra.Command{
 		for _, c := range []string{halPlusContainerName, halMCPContainerName} {
 			_ = exec.Command(engine, "rm", "-f", c).Run()
 		}
+		global.RemoveHalStatus(engine)
 
 		global.CleanNetworkIfEmpty(engine)
 		fmt.Println("✅ HAL Plus runtime deleted.")

--- a/cmd/plus/plus.go
+++ b/cmd/plus/plus.go
@@ -140,7 +140,7 @@ func prettyJSON(v interface{}) string {
 
 func init() {
 	plusImage = "ghcr.io/hashimiche/hal-plus:latest"
-	mcpImage = "hashimiche/hal-mcp:local"
+	mcpImage = "hashimiche/hal-mcp:latest"
 	plusPort = 9000
 	plusModel = "qwen3.5"
 	plusModelConfig = ""

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"hal/cmd/boundary"
 	"hal/cmd/consul"
+	"hal/cmd/halstatus"
 	"hal/cmd/mcp"
 	"hal/cmd/nomad"
 	"hal/cmd/observability"
@@ -52,4 +53,5 @@ func init() {
 	rootCmd.AddCommand(plus.Cmd)
 	rootCmd.AddCommand(terraform.Cmd)
 	rootCmd.AddCommand(observability.Cmd)
+	rootCmd.AddCommand(halstatus.Cmd)
 }

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -301,6 +301,7 @@ http {
 		}
 
 		fmt.Println("\n✅ Terraform Enterprise 1.x is UP!")
+		global.RefreshHalStatus(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Printf("🔗 UI Address:   %s\n", uiURL)
 		fmt.Printf("🗂️  MinIO API:    http://127.0.0.1:%d\n", minioAPIPort)

--- a/cmd/terraform/delete.go
+++ b/cmd/terraform/delete.go
@@ -173,6 +173,7 @@ var destroyCmd = &cobra.Command{
 
 		if !global.DryRun {
 			fmt.Println("\n✅ TFE environment wiped. You are ready for a clean 'hal terraform create'.")
+			global.RefreshHalStatus(engine)
 		}
 	},
 }

--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -136,6 +136,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		fmt.Println("✅ Vault is up and running in Dev mode!")
+		global.RefreshHalStatus(engine)
 		fmt.Printf("   🏗️  Edition: %s\n", strings.ToUpper(vaultEdition))
 		fmt.Println("   🔗 UI Address: http://vault.localhost:8200")
 		fmt.Println("   🔑 Root Token: root")

--- a/cmd/vault/database.go
+++ b/cmd/vault/database.go
@@ -253,6 +253,7 @@ var vaultDatabaseCmd = &cobra.Command{
 			password := secret.Data["password"].(string)
 
 			fmt.Println("\n✅ Enterprise Dynamic Database Credentials Generated!")
+			global.RefreshHalStatus(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Printf("🔗 Database Host: %s:%s\n", hostAlias, containerPort)
 			fmt.Println("👤 JIT Username:  " + username)

--- a/cmd/vault/delete.go
+++ b/cmd/vault/delete.go
@@ -83,6 +83,7 @@ var vaultDestroyCmd = &cobra.Command{
 
 		if !global.DryRun {
 			fmt.Println("\n✅ Vault instance and all extensions destroyed successfully!")
+			global.RefreshHalStatus(engine)
 		}
 	},
 }

--- a/cmd/vault/jwt.go
+++ b/cmd/vault/jwt.go
@@ -133,6 +133,7 @@ var vaultJwtCmd = &cobra.Command{
 				_ = exec.Command(engine, "rm", "-f", "hal-gitlab", "hal-gitlab-runner").Run()
 				_ = global.ClearSharedService("gitlab")
 				fmt.Println("✅ GitLab containers removed and Vault API cleaned up.")
+				global.RefreshHalStatus(engine)
 			}
 
 			if jwtDisable && !global.DryRun {
@@ -187,7 +188,7 @@ var vaultJwtCmd = &cobra.Command{
 				return
 			}
 			fmt.Println("\n✅ GitLab API is online!")
-
+			global.RefreshHalStatus(engine)
 			// 1. Authenticate via OAuth
 			fmt.Println("⚙️  Authenticating root account via API...")
 			apiToken := getGitLabToken("http://127.0.0.1:8080/oauth/token")

--- a/cmd/vault/k8s.go
+++ b/cmd/vault/k8s.go
@@ -227,6 +227,7 @@ var vaultK8sCmd = &cobra.Command{
 				_ = exec.Command("kind", "delete", "cluster").Run()
 
 				fmt.Println("✅ Kubernetes environment destroyed successfully!")
+				global.RefreshHalStatus(engine)
 			}
 
 			if k8sDisable && !global.DryRun {
@@ -768,6 +769,7 @@ spec:
 			_ = exec.Command("kubectl", "rollout", "status", "deployment/hal-web-proxy", "-n", "app1", "--timeout=180s").Run()
 
 			fmt.Println("\n✅ Kubernetes Secret Zero Environment Ready!")
+			global.RefreshHalStatus(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Printf("🌐 [%s]\n", modeTitle)
 			fmt.Println("   Endpoint: http://web.localhost:8088")

--- a/cmd/vault/ldap.go
+++ b/cmd/vault/ldap.go
@@ -138,6 +138,7 @@ var vaultLdapCmd = &cobra.Command{
 
 				if ldapDisable {
 					fmt.Println("✅ LDAP environment destroyed successfully!")
+					global.RefreshHalStatus(engine)
 				}
 			}
 
@@ -282,6 +283,7 @@ userPassword: {{.Password}}`,
 			_, _ = client.Logical().Write("ldap/rotate-root", map[string]interface{}{})
 
 			fmt.Println("\n✅ LDAP Infrastructure & Vault Integration Complete!")
+			global.RefreshHalStatus(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Println("🔗 phpLDAPadmin UI: https://phpldapadmin.localhost:8082")
 			fmt.Println("   Login DN: cn=admin,dc=hal,dc=local")

--- a/cmd/vault/oidc.go
+++ b/cmd/vault/oidc.go
@@ -134,6 +134,7 @@ var vaultOidcCmd = &cobra.Command{
 
 				if oidcDisable {
 					fmt.Println("✅ OIDC integration, KV engine, and identity data successfully removed!")
+					global.RefreshHalStatus(engine)
 				}
 			}
 
@@ -319,6 +320,7 @@ path "kv-oidc/metadata/team1" { capabilities = ["read", "list"] }
 			setupExternalGroup(client, "user-ro", oidcAccessor, []string{"user-ro"})
 
 			fmt.Println("\n✅ Vault OIDC & KV Integration Complete!")
+			global.RefreshHalStatus(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Println("🔗 UI Login:    http://vault.localhost:8200")
 			fmt.Println("                (Select 'OIDC' and leave the role blank)")

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -13,6 +13,11 @@ var (
 	DryRun bool
 )
 
+const (
+	HalStatusContainerName = "hal-status"
+	HalStatusPort          = 9001
+)
+
 func DetectEngine() (string, error) {
 	if err := exec.Command("docker", "info").Run(); err == nil {
 		return "docker", nil
@@ -21,6 +26,32 @@ func DetectEngine() (string, error) {
 		return "podman", nil
 	}
 	return "", fmt.Errorf("no container engine found (make sure Docker or Podman is running)")
+}
+
+// CheckContainer reports whether a container is currently running.
+func CheckContainer(engine, name string) bool {
+	out, err := exec.Command(engine, "ps", "-q", "-f", fmt.Sprintf("name=^%s$", name)).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// CheckMultipass reports whether a Multipass VM is running.
+func CheckMultipass(name string) bool {
+	out, err := exec.Command("multipass", "info", name, "--format", "csv").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "Running")
+}
+
+// BoolState converts a boolean to the "enabled"/"disabled" string used in status snapshots.
+func BoolState(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
 }
 
 // EnsureNetwork creates the global grid if it doesn't exist.

--- a/internal/global/status_snapshot.go
+++ b/internal/global/status_snapshot.go
@@ -1,0 +1,220 @@
+package global
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HalStatusImage is the container image used for hal-status.
+// Reuses the hal-mcp image since it already embeds the hal binary.
+const HalStatusImage = "hashimiche/hal-mcp:latest"
+
+// ProductFeature represents a single feature of a product.
+type ProductFeature struct {
+	Feature string `json:"feature"`
+	State   string `json:"state"`
+	Health  string `json:"health"`
+	Reason  string `json:"reason"`
+}
+
+// ProductStatus is the status of a single product in the HAL ecosystem.
+type ProductStatus struct {
+	Product    string           `json:"product"`
+	State      string           `json:"state"`
+	Health     string           `json:"health"`
+	Reason     string           `json:"reason"`
+	Endpoint   string           `json:"endpoint"`
+	Containers []string         `json:"containers"`
+	Features   []ProductFeature `json:"features"`
+}
+
+// StatusSnapshot is the full runtime snapshot written into hal-status.
+type StatusSnapshot struct {
+	Timestamp string          `json:"timestamp"`
+	Engine    string          `json:"engine"`
+	Products  []ProductStatus `json:"products"`
+}
+
+// BuildStatusSnapshot inspects the live container engine and returns a JSON-encoded snapshot.
+// Must be called on the host (has engine socket access).
+func BuildStatusSnapshot(engine string) ([]byte, error) {
+	products := []ProductStatus{
+		buildProductStatus(engine, "consul",
+			[]string{"hal-consul"},
+			map[string]string{"core": BoolState(CheckContainer(engine, "hal-consul"))},
+			"http://consul.localhost:8500"),
+
+		buildProductStatus(engine, "vault",
+			[]string{"hal-vault"},
+			map[string]string{
+				"audit":    resolveVaultAudit(engine),
+				"k8s":      BoolState(CheckContainer(engine, "kind-control-plane")),
+				"jwt":      BoolState(CheckContainer(engine, "hal-gitlab")),
+				"ldap":     BoolState(CheckContainer(engine, "hal-openldap")),
+				"database": BoolState(CheckContainer(engine, "hal-vault-mariadb")),
+				"oidc":     BoolState(CheckContainer(engine, "hal-keycloak")),
+			},
+			"http://vault.localhost:8200"),
+
+		buildProductStatus(engine, "nomad",
+			[]string{"hal-nomad"},
+			map[string]string{"job": BoolState(CheckMultipass("hal-nomad"))},
+			"multipass://hal-nomad"),
+
+		buildProductStatus(engine, "boundary",
+			[]string{"hal-boundary"},
+			map[string]string{
+				"mariadb": BoolState(CheckContainer(engine, "hal-boundary-target-mariadb")),
+				"ssh":     BoolState(CheckMultipass("hal-boundary-ssh")),
+			},
+			"http://boundary.localhost:9200"),
+
+		buildProductStatus(engine, "terraform",
+			[]string{"hal-tfe", "hal-tfe-db", "hal-tfe-redis", "hal-tfe-minio", "hal-tfe-proxy"},
+			map[string]string{"workspace": BoolState(CheckContainer(engine, "hal-tfe") && CheckContainer(engine, "hal-gitlab"))},
+			"https://tfe.localhost:8443"),
+
+		buildProductStatus(engine, "obs",
+			[]string{"hal-grafana", "hal-prometheus", "hal-loki"},
+			map[string]string{
+				"grafana":    BoolState(CheckContainer(engine, "hal-grafana")),
+				"prometheus": BoolState(CheckContainer(engine, "hal-prometheus")),
+				"loki":       BoolState(CheckContainer(engine, "hal-loki")),
+			},
+			"http://grafana.localhost:3000"),
+	}
+
+	snap := StatusSnapshot{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Engine:    engine,
+		Products:  products,
+	}
+	return json.Marshal(snap)
+}
+
+// RefreshHalStatus (re)creates the hal-status container with a fresh snapshot.
+// It is safe to call from any product create/update/delete — it is a no-op when
+// hal-net does not exist yet (hal-plus has not been deployed) and silently skips
+// when the hal-mcp image is not present locally.
+func RefreshHalStatus(engine string) {
+	// Only run when hal-net exists — avoids creating it just for the status container.
+	netOut, _ := exec.Command(engine, "network", "ls", "--format", "{{.Name}}").Output()
+	if !strings.Contains(string(netOut), "hal-net") {
+		return
+	}
+
+	// Only run when the image is available — hal-status is optional.
+	imgOut, _ := exec.Command(engine, "images", "-q", HalStatusImage).Output()
+	if strings.TrimSpace(string(imgOut)) == "" {
+		return
+	}
+
+	data, err := BuildStatusSnapshot(engine)
+	if err != nil {
+		if Debug {
+			fmt.Printf("[DEBUG] hal-status: snapshot build failed: %v\n", err)
+		}
+		return
+	}
+
+	// Remove old container (ignore errors) and start fresh with the new snapshot.
+	_ = exec.Command(engine, "rm", "-f", HalStatusContainerName).Run()
+
+	args := []string{
+		"run", "-d",
+		"--name", HalStatusContainerName,
+		"--network", "hal-net",
+		"--entrypoint", "/usr/local/bin/hal",
+		"-e", fmt.Sprintf("HAL_STATUS_DATA=%s", string(data)),
+		"-e", fmt.Sprintf("HAL_STATUS_PORT=%d", HalStatusPort),
+		HalStatusImage,
+		"status", "_serve",
+	}
+	if out, err := exec.Command(engine, args...).CombinedOutput(); err != nil {
+		if Debug {
+			fmt.Printf("[DEBUG] hal-status: container start failed: %v\n%s\n", err, string(out))
+		}
+	} else if Debug {
+		fmt.Printf("[DEBUG] hal-status: container refreshed (snapshot ts=%s)\n",
+			time.Now().UTC().Format(time.RFC3339))
+	}
+}
+
+// RemoveHalStatus stops and removes the hal-status container.
+func RemoveHalStatus(engine string) {
+	_ = exec.Command(engine, "rm", "-f", HalStatusContainerName).Run()
+}
+
+func buildProductStatus(engine, product string, containers []string, features map[string]string, endpoint string) ProductStatus {
+	runningCount := 0
+	for _, c := range containers {
+		if c == "hal-nomad" {
+			if CheckMultipass("hal-nomad") {
+				runningCount++
+			}
+			continue
+		}
+		if CheckContainer(engine, c) {
+			runningCount++
+		}
+	}
+
+	state := "not_deployed"
+	health := "down"
+	reason := "required resources are not running"
+	switch {
+	case runningCount == len(containers):
+		state, health, reason = "running", "healthy", "all required resources are running"
+	case runningCount > 0:
+		state, health, reason = "partial", "degraded", "some resources are running"
+	}
+	// single-container products: running when that one container is up
+	if len(containers) == 1 && runningCount == 1 {
+		state, health, reason = "running", "healthy", "primary resource is running"
+	}
+
+	featureRows := make([]ProductFeature, 0, len(features))
+	for k, v := range features {
+		fh, fr := "down", "feature is disabled"
+		if v == "enabled" {
+			fh, fr = "healthy", "feature is enabled"
+		}
+		featureRows = append(featureRows, ProductFeature{Feature: k, State: v, Health: fh, Reason: fr})
+	}
+	sort.Slice(featureRows, func(i, j int) bool { return featureRows[i].Feature < featureRows[j].Feature })
+
+	return ProductStatus{
+		Product:    product,
+		State:      state,
+		Health:     health,
+		Reason:     reason,
+		Endpoint:   endpoint,
+		Containers: containers,
+		Features:   featureRows,
+	}
+}
+
+func resolveVaultAudit(engine string) string {
+	if !CheckContainer(engine, "hal-vault") {
+		return "disabled"
+	}
+	out, err := exec.Command(
+		engine, "exec",
+		"-e", "VAULT_ADDR=http://127.0.0.1:8200",
+		"-e", "VAULT_TOKEN=root",
+		"hal-vault",
+		"vault", "audit", "list", "-format=json",
+	).Output()
+	if err != nil {
+		return "unknown"
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "{}" || trimmed == "" {
+		return "disabled"
+	}
+	return "enabled"
+}

--- a/internal/skills/data/obs/SKILL.md
+++ b/internal/skills/data/obs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: obs
+description: Deploy, verify, update, and destroy the standalone HAL observability stack (Grafana, Prometheus, Loki, Promtail). Use when the user asks to set up monitoring, wire dashboards, or check the health of the observability stack.
+---
+
+# HAL Observability Stack
+
+The `hal obs` subcommand manages a standalone Grafana + Prometheus + Loki + Promtail stack that product-specific observability wiring (`hal vault obs`, `hal terraform obs`, etc.) can attach to.
+
+## Lab Assumptions
+
+- The obs stack is a shared dependency. Deploy it before using `hal vault obs`, `hal terraform obs`, or any product-specific `obs create` command.
+- All dashboards are pre-provisioned; no manual import is required.
+- Grafana default credentials: `admin` / `admin`.
+
+## Primary Commands
+
+```
+hal obs create
+hal obs status
+hal obs update
+hal obs delete
+```
+
+## Version Pinning (Optional)
+
+```
+hal obs create \
+  --loki-version 3.7 \
+  --grafana-version main \
+  --prom-version main \
+  --promtail-version 3.6
+```
+
+## Workflow
+
+### Deploy
+
+```
+hal obs create
+```
+
+Verify it is healthy before wiring products into it:
+
+```
+hal obs status
+hal status
+```
+
+### Wire a product into obs
+
+After the stack is running, enable product-level observability. Examples:
+
+```
+hal vault obs create
+hal terraform obs create --target both
+hal consul obs create
+```
+
+### Update
+
+```
+hal obs update
+```
+
+Pull new image versions or re-apply configuration changes.
+
+### Teardown
+
+```
+hal obs delete
+```
+
+Tears down Grafana, Prometheus, Loki, and Promtail containers. Product `obs` artifacts are removed by their own lifecycle commands.
+
+## Lab Endpoints
+
+| Service | URL |
+|---|---|
+| Grafana | http://grafana.localhost:3000 |
+| Prometheus | http://prometheus.localhost:9090 |
+| Loki | http://loki.localhost:3100/ready |
+
+## Edge Cases
+
+- If a product `obs create` fails with a connection error, the obs stack is probably not running yet. Run `hal obs create` first.
+- If Grafana shows no data, confirm the relevant Promtail scrape config is active by checking `hal vault obs status` or the equivalent for the product.
+- `hal obs delete` does NOT remove product-specific dashboard artifacts — each product's `obs delete` must be run separately.

--- a/internal/skills/data/plus/SKILL.md
+++ b/internal/skills/data/plus/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: plus
+description: Deploy, configure, and operate HAL Plus — the local AI-powered web UI layer for HAL. Use when the user asks to start HAL Plus, switch models, check its health, or understand how it connects to Ollama and HAL MCP.
+---
+
+# HAL Plus
+
+HAL Plus is the local web UI for HAL. It runs as a container alongside HAL MCP and proxies queries to an Ollama model on the host. Answers are grounded through the HAL MCP runtime tools.
+
+## Lab Assumptions
+
+- Ollama must be running on the host (`ollama serve`) before `hal plus create`.
+- HAL Plus connects to Ollama via `host.containers.internal:11434` from inside the container.
+- HAL MCP (`hal mcp serve`) runs alongside HAL Plus on the same container network.
+- Default model preset: `qwen3.5` (32k context window).
+
+## Primary Commands
+
+```
+hal plus create
+hal plus status
+hal plus delete
+```
+
+## Model Presets
+
+```
+hal plus create --model qwen3.5      # default — balanced, 32k context
+hal plus create --model gemma4       # lighter, faster cold starts
+```
+
+Both presets are HAL-managed — no manual `ollama pull` needed.
+
+## Custom Model or Modelfile
+
+```
+hal plus create --model qwen3.5 --keep-alive 5m
+hal plus create --model qwen3.5 --model-config ./Modelfile
+```
+
+## Custom Image
+
+```
+hal plus create --image localhost/hal-plus:testmiche
+```
+
+Use a locally built image (e.g. during development or testing a branch).
+
+## Lab Endpoints
+
+| Service | URL |
+|---|---|
+| HAL Plus UI | http://hal.localhost:9000 |
+| HAL Plus UI (dark mode) | http://hal.localhost:9000/dark |
+| HAL Plus API | http://hal.localhost:9000/api |
+
+## Architecture Notes
+
+- HAL Plus API server runs on port 9001 internally; HAL forwards port 9000 → 9001.
+- HAL MCP is started as a sibling container and reached via HTTP at `http://127.0.0.1:18080/mcp` from inside HAL Plus.
+- Answers are classified by intent route:
+  - **Route A** (knowledge/factual): short prose + one command + one doc
+  - **Route B** (operational): Preflight → Run → Check → Verify → Docs — Qwen wraps the MCP-grounded block in humanized prose
+  - **Route C** (follow-up): prior matched behavior context injected as model grounding
+- Status/health checks bypass the Qwen wrapping step and stream the deterministic answer directly.
+
+## Edge Cases
+
+- If HAL Plus reports `LLM offline`, ensure Ollama is running (`ollama serve`) and the model is present (`ollama list`).
+- If MCP tools are missing, run `hal mcp status` to confirm the MCP server is reachable.
+- If `hal plus create` fails with an image pull error, either push the image to a registry or use `--image localhost/hal-plus:local` with a locally built image.
+- `hal plus delete` removes the container but does NOT unload the Ollama model from the host.


### PR DESCRIPTION
…mage pipeline

## hal status sidecar (new)

Introduce a frozen-snapshot architecture where a lightweight sidecar container (hal-status) serves a point-in-time snapshot of the lab state on port 9001.

- cmd/halstatus/: new cobra command group
  - hal status create / update / delete — explicit lifecycle management
  - hal status _serve — hidden internal HTTP server that reads HAL_STATUS_DATA env var and exposes /api/status; used as the container entrypoint
- internal/global/status_snapshot.go: BuildStatusSnapshot (podman/docker ps-based probe for all products + extensions), RefreshHalStatus (rm + re-create sidecar), RemoveHalStatus, HalStatusContainerName, HalStatusPort constants
- internal/global/global.go: BoolState helper, HalStatus* constants
- cmd/root.go: register halstatus.Cmd

## RefreshHalStatus hooks

Added global.RefreshHalStatus(engine) at the success point of every product and extension lifecycle command so the snapshot is always current after any operation:

Products: vault, consul, boundary, observability, plus, terraform (create + delete)
Vault extensions: k8s, oidc, jwt, ldap, database (enable + disable)
Boundary extensions: mariadb, ssh (inline DetectEngine — no engine in scope)
plus delete: calls RemoveHalStatus instead to tear down the sidecar alongside plus

## hal mcp create --http

Removed source-tree dependency entirely. The command now just pulls the image from GHCR (hashimiche/hal-mcp:latest) instead of compiling from source. Users no longer need the git repository cloned — any dev machine can run hal mcp create --http. Cleaned up resolveHalSourceRoot, the copy-binary path, and the local Dockerfile build logic from mcp.go and advanced.go.

## CI: publish-mcp-image job (.github/workflows/release.yml)

On every version tag push, after goreleaser:
- Cross-compile hal-linux (linux/amd64, CGO_ENABLED=0)
- Build Dockerfile.mcp → ghcr.io/hashimiche/hal-mcp:latest + :<tag>
- Dockerfile.mcp: minimal alpine:3.20 + docker-cli, hal binary as entrypoint

## Misc

- plus/plus.go, plus/create.go: :local → :latest image tag
- .gitignore: add hal-linux cross-compile artifact
- internal/skills/data/obs/, internal/skills/data/plus/: skill SKILL.md stubs
- LLM_CONTEXT.md, README.md: document hal-status architecture and mcp pull flow