### PR TITLE
fix(skills): fix stale commands and add missing skill files for MCP

### DIFF
--- a/internal/skills/data/boundary/SKILL.md
+++ b/internal/skills/data/boundary/SKILL.md
@@ -9,10 +9,11 @@ Use this router when the user asks for Boundary workflows in hal but has not sel
 
 ## Routing Rules
 
-- Route deploy requests to the deploy skill.
-- Route teardown or cleanup requests to the destroy skill.
+- Route create/deploy requests to the create skill.
+- Route teardown or cleanup requests to the delete skill.
 - Route health checks to the status skill.
 - Route feature-specific requests to mariadb, ssh, or setup.
+- Route observability requests to the obs skill (`hal boundary obs create|update|delete|status`).
 
 ## Lab Assumptions
 

--- a/internal/skills/data/boundary/obs/EXAMPLES.md
+++ b/internal/skills/data/boundary/obs/EXAMPLES.md
@@ -1,0 +1,19 @@
+# Example Transcripts
+
+## Example 1: Wire Boundary Into Observability
+
+User: Add Boundary metrics to Grafana.
+
+A:
+
+    hal obs status
+    hal boundary obs create
+    hal boundary obs status
+
+## Example 2: Remove Boundary Monitoring
+
+User: Remove the Boundary dashboard from Grafana.
+
+A:
+
+    hal boundary obs delete

--- a/internal/skills/data/boundary/obs/SKILL.md
+++ b/internal/skills/data/boundary/obs/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: boundary-obs
+description: Manage Boundary observability artifacts in hal — Prometheus scrape targets and Grafana dashboards. Use when the user asks to wire Boundary metrics into the obs stack or manage Boundary monitoring artifacts.
+---
+
+# Boundary Observability Skill
+
+`hal boundary obs` manages Boundary-specific monitoring artifacts attached to the shared HAL obs stack.
+
+## Prerequisites
+
+```
+hal obs status
+hal obs create    # if not running
+```
+
+## Primary Commands
+
+```
+hal boundary obs create    # register Prometheus target + import Boundary Grafana dashboard
+hal boundary obs update    # re-register targets and re-import dashboard (idempotent)
+hal boundary obs delete    # remove Boundary Prometheus target and Grafana dashboard
+hal boundary obs status    # show obs artifact registration state for Boundary
+```
+
+## Key Behaviours
+
+- Boundary obs onboarding is explicit and opt-in — `hal boundary create` does not auto-register monitoring artifacts.
+- Official Boundary dashboard is auto-downloaded and imported into Grafana folder `HAL`.
+- `hal boundary obs create` fails with a clear message if the obs stack is not running.
+
+## Lab Assumptions
+
+- Grafana: `http://grafana.localhost:3000`
+- Prometheus: `http://prometheus.localhost:9090`
+- Boundary controller endpoint: `http://boundary.localhost:9200`

--- a/internal/skills/data/capacity/SKILL.md
+++ b/internal/skills/data/capacity/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: capacity
+description: Show local container engine capacity and HAL deployment estimates. Use when the user asks about available resources, whether there is headroom for a new stack, or what is currently deployed and how heavy it is.
+---
+
+# HAL Capacity Skill
+
+The `hal capacity` command surfaces live engine resource usage and per-stack footprint estimates so you can judge headroom before spinning up a new product stack.
+
+## Primary Commands
+
+```
+hal capacity                    # current engine view: CPU, RAM, running containers
+hal capacity --active           # active heavy deployment composition with per-stack footprint details
+hal capacity --pending          # pending heavy deployment impact estimates
+```
+
+## When To Use
+
+- Before `hal terraform create` or any other heavy create — to check if the engine has enough headroom.
+- After noticing sluggishness — to see which stacks are consuming the most resources.
+- To understand relative cost of stacks before deciding what to tear down.
+
+## Key Behaviours
+
+- Memory pressure calculations exclude cache/buffers (pressure memory, not free-cache-inflated baselines).
+- Interactive confirmation prompts on heavy creates only trigger when estimated post-create usage exceeds engine limits (CPU > 100% or RAM > machine RAM).
+- Podman on macOS exposes richer machine-runtime telemetry than Docker when available.
+- Capacity scenario labels are infra-centric (e.g. shared GitLab runner, KinD/VSO flows), not purely product-centric.
+
+## Lab Assumptions
+
+- `hal status` also surfaces a compact capacity summary alongside product state.
+- Use `hal capacity --active` to see exactly which running stacks own the current resource footprint before deciding what to scale down.

--- a/internal/skills/data/consul/SKILL.md
+++ b/internal/skills/data/consul/SKILL.md
@@ -9,9 +9,10 @@ Use this router when the user asks for Consul workflows in hal but has not selec
 
 ## Routing Rules
 
-- Route deploy requests to the deploy skill.
-- Route teardown requests to the destroy skill.
+- Route create/deploy requests to the create skill.
+- Route teardown requests to the delete skill.
 - Route health checks to the status skill.
+- Route observability requests to the obs skill (`hal consul obs create|update|delete|status`).
 
 ## Lab Assumptions
 

--- a/internal/skills/data/consul/obs/EXAMPLES.md
+++ b/internal/skills/data/consul/obs/EXAMPLES.md
@@ -1,0 +1,19 @@
+# Example Transcripts
+
+## Example 1: Wire Consul Into Observability
+
+User: I want to see Consul metrics in Grafana.
+
+A:
+
+    hal obs status
+    hal consul obs create
+    hal consul obs status
+
+## Example 2: Remove Consul Monitoring
+
+User: Remove the Consul dashboard from Grafana.
+
+A:
+
+    hal consul obs delete

--- a/internal/skills/data/consul/obs/SKILL.md
+++ b/internal/skills/data/consul/obs/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: consul-obs
+description: Manage Consul observability artifacts in hal — Prometheus scrape targets and Grafana dashboards. Use when the user asks to wire Consul metrics into the obs stack or manage Consul monitoring artifacts.
+---
+
+# Consul Observability Skill
+
+`hal consul obs` manages Consul-specific monitoring artifacts attached to the shared HAL obs stack.
+
+## Prerequisites
+
+```
+hal obs status
+hal obs create    # if not running
+```
+
+## Primary Commands
+
+```
+hal consul obs create    # register Prometheus target + import Consul Grafana dashboard
+hal consul obs update    # re-register targets and re-import dashboard (idempotent)
+hal consul obs delete    # remove Consul Prometheus target and Grafana dashboard
+hal consul obs status    # show obs artifact registration state for Consul
+```
+
+## Key Behaviours
+
+- Consul obs onboarding is explicit and opt-in — `hal consul create` does not auto-register monitoring artifacts.
+- Official Consul dashboard is auto-downloaded and imported into Grafana folder `HAL`.
+- `hal consul obs create` fails with a clear message if the obs stack is not running.
+
+## Lab Assumptions
+
+- Grafana: `http://grafana.localhost:3000`
+- Prometheus: `http://prometheus.localhost:9090`
+- Consul UI: `http://consul.localhost:8500`

--- a/internal/skills/data/health/SKILL.md
+++ b/internal/skills/data/health/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: health
+description: Manage the hal-health sidecar container that serves live ecosystem state snapshots to HAL Plus and other consumers. Use when the user asks to refresh the status snapshot, recreate the health container, or troubleshoot HAL Plus product state.
+---
+
+# HAL Health Skill
+
+The `hal health` namespace manages the `hal-health` sidecar container. It builds a frozen snapshot of the running HAL ecosystem and serves it at `http://hal-health:9001/api/status` on `hal-net` so HAL Plus and AI clients can query product state without touching the container engine directly.
+
+## Primary Commands
+
+```
+hal health create    # create (or recreate) the hal-health container with a fresh snapshot
+hal health update    # refresh the snapshot — use after ecosystem changes outside normal lifecycle
+hal health delete    # remove the hal-health container
+```
+
+## When To Use
+
+- **`hal health create`**: first-time setup or after `hal health delete`.
+- **`hal health update`**: manual escape hatch after a product was added/removed outside the normal `hal <product> create/delete` flow (e.g. manual container changes).
+- **`hal health delete`**: clean up the sidecar without affecting any product containers.
+
+## Architecture Notes
+
+- The `hal-health` container reuses `ghcr.io/hashimiche/hal-mcp:latest` with `--entrypoint /usr/local/bin/hal` and `health _serve` as args.
+- The snapshot shape: `{ timestamp, engine, products: [{ product, state, health, reason, endpoint, containers, features: [...] }] }`.
+- The container is a no-op host — it reads the `HAL_STATUS_DATA` env var injected at start time and never touches the container engine socket.
+- `global.RefreshHalStatus` is called automatically after all product `create`/`delete` commands — manual `hal health update` is only needed for out-of-band changes.
+- `hal health` is a no-op if `hal-net` does not exist or `ghcr.io/hashimiche/hal-mcp:latest` is not present locally.
+
+## Lab Assumptions
+
+- HAL Plus must be running on `hal-net` for `hal-health` to be reachable by HAL Plus.
+- HAL Plus falls back to direct product endpoint probing if `hal-health` is unavailable.

--- a/internal/skills/data/mcp/SKILL.md
+++ b/internal/skills/data/mcp/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mcp
+description: Manage the HAL MCP server lifecycle and AI client configuration. Use when the user asks to start MCP, configure an AI client (Copilot, Claude), check MCP health, or understand the MCP transport options.
+---
+
+# HAL MCP Skill
+
+The `hal mcp` namespace manages the HAL MCP server — the runtime bridge between AI clients and the live HAL lab environment.
+
+## Transport Modes
+
+| Mode | Command | Protocol |
+|---|---|---|
+| stdio (local/dev) | `hal mcp serve` | 2024-11-05 |
+| streamable-HTTP (container) | `hal mcp serve --transport streamable-http --http-host 0.0.0.0 --http-port 8080 --http-path /mcp` | 2025-03-26 |
+
+## Primary Commands
+
+```
+hal mcp create          # scaffold AI client config (stdio, local dev)
+hal mcp create --http   # pull ghcr.io/hashimiche/hal-mcp:latest and run container
+hal mcp serve           # start MCP server in stdio mode (used by HAL Plus)
+hal mcp status          # check MCP readiness
+hal mcp delete          # remove MCP managed artifacts
+hal mcp policy          # print runtime answer/tool policy (read-only)
+```
+
+## Key Flags
+
+- `--http` — run the MCP server as a streamable-HTTP container instead of stdio
+- `--http-tag <tag>` — override the pulled image tag (default `latest`)
+
+## Architecture Notes
+
+- The `hal-mcp` container does **not** mount the host container engine socket and does not run as root.
+- Tool calls requiring engine access (`hal_status_baseline`) return engine-unavailable in rootless Podman — this is expected.
+- AI clients must treat engine-unavailable as `runtime unknown`, not product down.
+- There is no SSH-based MCP transport. Do not suggest SSH tunnelling for MCP.
+- `hal mcp create` configures the AI client config scaffold; it does not start a persistent server process unless `--http` is used.
+
+## Lab Assumptions
+
+- MCP runs on `hal-net` alongside HAL Plus.
+- HAL Plus spawns `hal mcp serve` (stdio) internally — no manual `hal mcp serve` needed when using HAL Plus.
+- For standalone AI client use (Copilot, Claude Desktop), run `hal mcp create` to generate the client config.

--- a/internal/skills/data/nomad/SKILL.md
+++ b/internal/skills/data/nomad/SKILL.md
@@ -9,10 +9,11 @@ Use this router when the user asks for Nomad workflows in hal but has not select
 
 ## Routing Rules
 
-- Route deploy requests to the deploy skill.
+- Route create/deploy requests to the create skill.
 - Route workload requests to the job skill.
 - Route health checks to the status skill.
-- Route teardown requests to the destroy skill.
+- Route teardown requests to the delete skill.
+- Route observability requests to the obs skill (`hal nomad obs create|update|delete|status`).
 
 ## Lab Assumptions
 

--- a/internal/skills/data/nomad/obs/EXAMPLES.md
+++ b/internal/skills/data/nomad/obs/EXAMPLES.md
@@ -1,0 +1,19 @@
+# Example Transcripts
+
+## Example 1: Wire Nomad Into Observability
+
+User: Add Nomad metrics to the Grafana dashboard.
+
+A:
+
+    hal obs status
+    hal nomad obs create
+    hal nomad obs status
+
+## Example 2: Remove Nomad Monitoring
+
+User: Remove the Nomad dashboard from Grafana.
+
+A:
+
+    hal nomad obs delete

--- a/internal/skills/data/nomad/obs/SKILL.md
+++ b/internal/skills/data/nomad/obs/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: nomad-obs
+description: Manage Nomad observability artifacts in hal — Prometheus scrape targets and Grafana dashboards. Use when the user asks to wire Nomad metrics into the obs stack or manage Nomad monitoring artifacts.
+---
+
+# Nomad Observability Skill
+
+`hal nomad obs` manages Nomad-specific monitoring artifacts attached to the shared HAL obs stack.
+
+## Prerequisites
+
+```
+hal obs status
+hal obs create    # if not running
+```
+
+## Primary Commands
+
+```
+hal nomad obs create    # register Prometheus target + import Nomad Grafana dashboard
+hal nomad obs update    # re-register targets and re-import dashboard (idempotent)
+hal nomad obs delete    # remove Nomad Prometheus target and Grafana dashboard
+hal nomad obs status    # show obs artifact registration state for Nomad
+```
+
+## Key Behaviours
+
+- Nomad obs onboarding is explicit and opt-in — `hal nomad create` does not auto-register monitoring artifacts.
+- Official Nomad dashboard is auto-downloaded and imported into Grafana folder `HAL`.
+- `hal nomad obs create` fails with a clear message if the obs stack is not running.
+
+## Lab Assumptions
+
+- Grafana: `http://grafana.localhost:3000`
+- Prometheus: `http://prometheus.localhost:9090`
+- Nomad cluster runs via Multipass VM (`hal-nomad`)

--- a/internal/skills/data/terraform/SKILL.md
+++ b/internal/skills/data/terraform/SKILL.md
@@ -9,13 +9,14 @@ Use this router when the user asks for Terraform workflows in hal but has not se
 
 ## Routing Rules
 
-- Route deploy requests to the deploy skill.
+- Route create/deploy requests to the create skill.
 - Route status checks to the status skill.
-- Route teardown requests to the destroy skill.
+- Route teardown requests to the delete skill.
 - Route twin-instance requests to target-based product lifecycle commands (`hal terraform create|update|status|delete --target twin`).
 - Route workspace wiring requests to `hal terraform vcs-workflow enable`.
 - Route helper-shell, TFX, self-signed cert, or `hal tf api-workflow` requests to the cli skill.
 - Route custom agent pool requests to `hal terraform agent enable` and the agent skill.
+- Route observability requests to the obs skill (`hal terraform obs create|update|delete|status`).
 
 ## Lab Assumptions
 

--- a/internal/skills/data/terraform/obs/EXAMPLES.md
+++ b/internal/skills/data/terraform/obs/EXAMPLES.md
@@ -1,0 +1,37 @@
+# Example Transcripts
+
+## Example 1: Wire TFE Into Observability
+
+User: I want to see Terraform Enterprise metrics in Grafana.
+
+A:
+
+    hal obs status
+    hal terraform obs create
+    hal terraform obs status
+
+## Example 2: Wire Both Primary And Twin Into Obs
+
+User: I have the twin running too. Wire both into Grafana.
+
+A:
+
+    hal terraform obs create --target both
+    hal terraform obs status
+
+## Example 3: Refresh After TFE Update
+
+User: I recreated TFE. Do I need to redo the obs wiring?
+
+A:
+
+    hal terraform obs update
+
+## Example 4: Remove TFE Monitoring Artifacts
+
+User: Remove Terraform from Grafana but keep the obs stack running.
+
+A:
+
+    hal terraform obs delete
+    hal terraform obs status

--- a/internal/skills/data/terraform/obs/SKILL.md
+++ b/internal/skills/data/terraform/obs/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: terraform-obs
+description: Manage Terraform Enterprise observability artifacts in hal — Prometheus scrape targets and Grafana dashboards. Use when the user asks to wire TFE metrics into the obs stack or manage Terraform monitoring artifacts.
+---
+
+# Terraform Observability Skill
+
+`hal terraform obs` manages TFE-specific monitoring artifacts attached to the shared HAL obs stack.
+
+## Prerequisites
+
+The shared obs stack must already be running:
+
+```
+hal obs status
+hal obs create    # if not running
+```
+
+## Primary Commands
+
+```
+hal terraform obs create              # register Prometheus target + import TFE Grafana dashboard
+hal terraform obs create --target both  # register for both primary and twin TFE instances
+hal terraform obs update              # re-register targets and re-import dashboard (idempotent)
+hal terraform obs delete              # remove TFE Prometheus target and Grafana dashboard
+hal terraform obs status              # show obs artifact registration state for Terraform
+```
+
+## Key Behaviours
+
+- Terraform obs onboarding is explicit and opt-in — `hal terraform create` does not auto-register monitoring artifacts.
+- `hal terraform obs create` is a refresh/manage action — it requires the obs stack to already be running.
+- Official TFE dashboard is auto-downloaded and imported into Grafana folder `HAL`.
+- Dashboard JSON is normalized so panel datasources resolve to `hal-prometheus`.
+
+## Lab Assumptions
+
+- Grafana: `http://grafana.localhost:3000`
+- Prometheus: `http://prometheus.localhost:9090`
+- Primary TFE: `https://tfe.localhost:8443`
+- Twin TFE (if running): `https://tfe-bis.localhost:8444`

--- a/internal/skills/data/terraform/twin/EXAMPLES.md
+++ b/internal/skills/data/terraform/twin/EXAMPLES.md
@@ -7,8 +7,8 @@ User: Spin up a second TFE instance alongside the primary.
 A:
 
     hal terraform status
-    hal terraform twin enable
-    hal terraform twin
+    hal terraform create --target twin
+    hal terraform status --target twin
 
 ## Example 2: Check Twin Status
 
@@ -43,7 +43,7 @@ User: Remove the twin TFE but keep the primary running.
 
 A:
 
-    hal terraform twin disable --auto-approve
+    hal terraform delete --target twin --auto-approve
     hal terraform status
 
 ## Example 6: Recreate A Stale Twin
@@ -52,5 +52,5 @@ User: The twin feels stale. Recreate it cleanly.
 
 A:
 
-    hal terraform twin update
-    hal terraform twin
+    hal terraform update --target twin
+    hal terraform status --target twin

--- a/internal/skills/data/terraform/twin/SKILL.md
+++ b/internal/skills/data/terraform/twin/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: twin
-description: Manage a second local Terraform Enterprise instance (twin) alongside the primary in hal. Use for `hal terraform twin`, `hal tf twin`, `hal tf bis`, or `--target twin` flags.
+description: Manage a second local Terraform Enterprise instance (twin) alongside the primary in hal. Use for `--target twin` flags or `hal tf bis` aliases on terraform lifecycle commands.
 ---
 
 # Terraform Twin Skill
 
-This skill handles the lifecycle of a second local TFE instance — the "twin" — through `hal terraform twin` and `--target twin` flags on other terraform subcommands.
+This skill handles the lifecycle of a second local TFE instance — the "twin" — through `--target twin` on terraform core lifecycle commands.
 
 ## Intent
 
@@ -19,13 +19,12 @@ Use this skill when the user asks to:
 
 ## Core Commands
 
-- `hal terraform twin` — smart status view (default when no subcommand given)
-- `hal terraform twin enable` — provision the twin TFE instance
-- `hal terraform twin disable` — tear down the twin TFE instance only
-- `hal terraform twin update` — recreate the twin container in-place
-- `hal terraform create --target twin` — alternative deploy entry point
+- `hal terraform create --target twin` — provision the twin TFE instance
+- `hal terraform status --target twin` — smart status view of the twin
+- `hal terraform update --target twin` — recreate the twin container in-place
+- `hal terraform delete --target twin` — tear down the twin TFE instance only
 
-Short aliases: `hal tf twin enable`, `hal tf bis enable`, `hal tf dup enable`
+Short aliases: `hal tf create --target twin`, `hal tf create --target bis`
 
 ## Twin-Aware Sibling Commands
 
@@ -59,13 +58,13 @@ When the user scopes other workflows to the twin, use `--target twin`:
 
 ## Validation
 
-- Confirm primary TFE is running before enable.
-- Confirm twin container state with `hal terraform twin` or `hal terraform status --target twin`.
-- After enable, access twin UI at the configured twin endpoint.
+- Confirm primary TFE is running before create.
+- Confirm twin container state with `hal terraform status --target twin`.
+- After create, access twin UI at the configured twin endpoint.
 - If TLS errors occur, keep HAL-generated cert wiring; do not bypass TLS verification.
 
 ## Troubleshooting Notes
 
 - If twin fails to start, confirm there is no port conflict on the twin HTTPS port.
-- Use `hal terraform twin update` to recreate the container without tearing down the primary.
+- Use `hal terraform update --target twin` to recreate the container without tearing down the primary.
 - Use `hal terraform delete --target twin` to clean up twin resources only.

--- a/internal/skills/data/vault/SKILL.md
+++ b/internal/skills/data/vault/SKILL.md
@@ -9,7 +9,7 @@ Use this router when the user says Vault but does not clearly specify the exact 
 
 ## Product Baseline
 
-- Base deploy command: `hal vault create`
+- Base create command: `hal vault create`
 - Default startup mode: Vault dev mode with root token `root`
 - Enterprise path: `hal vault create --edition ent` with `VAULT_LICENSE` exported
 - Observability surfaces (when obs is deployed):
@@ -28,8 +28,9 @@ If obs comes after Vault, prefer `hal vault obs create` to backfill metrics/dash
 - Use k8s when the user asks about Kubernetes auth, KinD, VSO, secret refresh demos, or CSI projection.
 - Use mariadb when the user asks about database secrets, dynamic DB credentials, or root rotation.
 - Use ldap when the user asks about LDAP auth, LDAP secrets engine, dynamic users, static creds, or credential libraries.
-- Use deploy when the user asks for initial Vault bring-up, CE vs Enterprise selection, or obs backfill.
-- Use destroy when the user asks for full Vault ecosystem teardown.
+- Use create when the user asks for initial Vault bring-up, CE vs Enterprise selection, or obs backfill.
+- Use delete when the user asks for full Vault ecosystem teardown.
+- Use obs when the user asks to wire Vault metrics into Grafana or Prometheus, or manage Vault observability artifacts.
 - Use status when the user asks whether Vault and add-on scenarios are currently healthy.
 
 ## Shared Lab Assumptions

--- a/internal/skills/data/vault/audit/EXAMPLES.md
+++ b/internal/skills/data/vault/audit/EXAMPLES.md
@@ -22,9 +22,9 @@ Assistant: If obs is active, I include the log exploration surfaces:
 
 User: Vault requests started failing after audit updates.
 
-Assistant: I reset safely with a clean force cycle:
+Assistant: I reset safely with an update cycle:
 
-    hal vault audit --update --loki
+    hal vault audit update --loki
 
 ## Example 3: Disable Audit Device
 

--- a/internal/skills/data/vault/deploy/SKILL.md
+++ b/internal/skills/data/vault/deploy/SKILL.md
@@ -37,5 +37,5 @@ Handle hal vault create requests with a stable lifecycle pattern.
 ## Edge Cases
 
 - If ports are already in use, explain likely conflicts and next actions.
-- If an old broken deployment exists, suggest force or teardown path.
+- If an old broken deployment exists, suggest update (`hal vault update`) or delete (`hal vault delete`) path.
 - If Enterprise is requested without `VAULT_LICENSE`, explain the failure and provide the exact export + redeploy command.

--- a/internal/skills/data/vault/obs/EXAMPLES.md
+++ b/internal/skills/data/vault/obs/EXAMPLES.md
@@ -1,0 +1,39 @@
+# Example Transcripts
+
+## Example 1: Wire Vault Into Observability
+
+User: I want to see Vault metrics in Grafana.
+
+A:
+
+    hal obs status
+    hal vault obs create
+    hal vault obs status
+
+## Example 2: Vault Was Deployed Before Obs — Backfill
+
+User: I deployed Vault first, then obs. How do I backfill the dashboard?
+
+A:
+
+    hal obs status
+    hal vault obs create
+
+A: After this, the Vault dashboard appears in Grafana under the HAL folder.
+
+## Example 3: Refresh After Vault Config Change
+
+User: I updated Vault. Do I need to redo the obs wiring?
+
+A:
+
+    hal vault obs update
+
+## Example 4: Remove Vault Monitoring Artifacts
+
+User: I want to remove Vault from Grafana but keep the obs stack running.
+
+A:
+
+    hal vault obs delete
+    hal vault obs status

--- a/internal/skills/data/vault/obs/SKILL.md
+++ b/internal/skills/data/vault/obs/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: vault-obs
+description: Manage Vault observability artifacts in hal — Prometheus scrape targets and Grafana dashboards. Use when the user asks to wire Vault metrics into the obs stack, import the Vault dashboard, or remove Vault monitoring artifacts.
+---
+
+# Vault Observability Skill
+
+`hal vault obs` manages Vault-specific monitoring artifacts (Prometheus targets and Grafana dashboards) attached to the shared HAL obs stack.
+
+## Prerequisites
+
+The shared obs stack must be running before using these commands:
+
+```
+hal obs status
+hal obs create    # if not running
+```
+
+## Primary Commands
+
+```
+hal vault obs create    # register Prometheus target + import Vault Grafana dashboard
+hal vault obs update    # re-register targets and re-import dashboard (idempotent)
+hal vault obs delete    # remove Vault Prometheus target and Grafana dashboard
+hal vault obs status    # show obs artifact registration state for Vault
+```
+
+## Key Behaviours
+
+- Vault obs onboarding is explicit and opt-in — `hal vault create` no longer auto-registers monitoring artifacts.
+- Official Vault dashboard is auto-downloaded and imported into Grafana folder `HAL`.
+- Dashboard JSON is normalized so panel datasources resolve to `hal-prometheus`.
+- `hal vault obs create` will fail with a clear message if the obs stack is not running.
+
+## Lab Assumptions
+
+- Grafana: `http://grafana.localhost:3000` (default credentials: `admin` / `admin`)
+- Prometheus: `http://prometheus.localhost:9090`
+- Vault metrics endpoint: `http://vault.localhost:8200/v1/sys/metrics`


### PR DESCRIPTION
Stale content fixed:
- vault/SKILL.md: deploy→create, destroy→delete routing; add obs route
- vault/deploy/SKILL.md: remove --force suggestion, use update/delete
- vault/audit/EXAMPLES.md: remove --force cycle; use 'audit update'
- boundary/SKILL.md: deploy→create, destroy→delete; add obs route
- consul/SKILL.md: deploy→create, destroy→delete; add obs route
- nomad/SKILL.md: deploy→create, destroy→delete; add obs route
- terraform/SKILL.md: deploy→create, destroy→delete; add obs route
- terraform/twin/SKILL.md: replace standalone twin enable/disable/update commands with --target twin on core lifecycle commands
- terraform/twin/EXAMPLES.md: same as above

New skill files added:
- mcp/SKILL.md: hal mcp lifecycle, transports, architecture notes
- health/SKILL.md: hal health lifecycle, snapshot architecture
- capacity/SKILL.md: hal capacity flags and behaviors
- vault/obs/SKILL.md+EXAMPLES.md: vault observability artifacts
- boundary/obs/SKILL.md+EXAMPLES.md: boundary observability artifacts
- consul/obs/SKILL.md+EXAMPLES.md: consul observability artifacts
- nomad/obs/SKILL.md+EXAMPLES.md: nomad observability artifacts
- terraform/obs/SKILL.md+EXAMPLES.md: terraform observability artifacts

All files live under internal/skills/data/ (same inode as .github/copilot/skills/ via symlink) — MCP get_skill_context and embedded binary both pick them up automatically.

close #28 