### PR TITLE
add os secret engine

### DIFF
--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -43,11 +43,29 @@ var deployCmd = &cobra.Command{
 
 		// THE NEW LICENSE CHECK
 		if vaultEdition == "ent" || vaultEdition == "enterprise" {
-			if os.Getenv("VAULT_LICENSE") == "" {
-				fmt.Println("❌ Error: Vault Enterprise requested but VAULT_LICENSE environment variable is not set.")
-				fmt.Println("   💡 Please export your license key first: export VAULT_LICENSE='your_license_string'")
+			license := os.Getenv("VAULT_LICENSE")
+			licensePath := os.Getenv("VAULT_LICENSE_PATH")
+			
+			// If VAULT_LICENSE_PATH is set, read the license from file
+			if license == "" && licensePath != "" {
+				licenseBytes, err := os.ReadFile(licensePath)
+				if err != nil {
+					fmt.Printf("❌ Error: Failed to read license from VAULT_LICENSE_PATH: %v\n", err)
+					return
+				}
+				license = string(licenseBytes)
+			}
+			
+			if license == "" {
+				fmt.Println("❌ Error: Vault Enterprise requested but no license found.")
+				fmt.Println("   💡 Set one of:")
+				fmt.Println("      export VAULT_LICENSE='your_license_string'")
+				fmt.Println("      export VAULT_LICENSE_PATH='/path/to/vault.hclic'")
 				return
 			}
+			
+			// Store in environment for container injection
+			os.Setenv("VAULT_LICENSE", license)
 		}
 
 		if vaultUpdate {
@@ -55,7 +73,8 @@ var deployCmd = &cobra.Command{
 				fmt.Println("[DEBUG] --update detected. Reconciling Vault by replacing runtime artifacts...")
 			}
 			_ = exec.Command(engine, "rm", "-f", "hal-vault").Run()
-			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-logs").Run() // Purge des anciens logs
+			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-logs").Run()
+			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-plugins").Run()
 		}
 
 		// Determine the Image Repository and Version based on Edition
@@ -76,9 +95,10 @@ var deployCmd = &cobra.Command{
 		// 1. Ensure the global HAL network exists
 		global.EnsureNetwork(engine)
 
-		// NOUVEAU : Correction des permissions du volume d'audit pour l'utilisateur Vault (UID 100)
-		fmt.Println("⚙️  Preparing shared audit volume permissions...")
+		// Correction des permissions du volume d'audit pour l'utilisateur Vault (UID 100)
+		fmt.Println("⚙️  Preparing shared volume permissions...")
 		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-logs:/vault/logs", vaultHelperImage, "chown", "-R", "100:1000", "/vault/logs").Run()
+		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-plugins:/vault/plugins", vaultHelperImage, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
 
 		// 2. Build the Docker run arguments
 		vaultArgs := []string{
@@ -86,13 +106,19 @@ var deployCmd = &cobra.Command{
 			"--name", "hal-vault",
 			"--network", "hal-net",
 			"--cap-add", "IPC_LOCK",
-			"--cap-add", "SETFCAP",
 			"-p", "8200:8200",
 			"-v", "hal-vault-logs:/vault/logs",
+			"-v", "hal-vault-plugins:/vault/plugins",
 		}
 
-		// Vault 2.x images can require SETFCAP in some runtimes (notably rootless Podman)
-		// to initialize process capabilities cleanly for both CE and Enterprise.
+		// Vault 2.x tries to set SETFCAP capability which fails on Docker Desktop.
+		// Setting SKIP_SETCAP=true tells Vault to skip this step (safe for dev mode).
+		if strings.HasPrefix(actualVersion, "2.") {
+			vaultArgs = append(vaultArgs, "-e", "SKIP_SETCAP=true")
+		}
+		
+		// Set plugin directory for external plugins (like OS secret engine)
+		vaultArgs = append(vaultArgs, "-e", "VAULT_PLUGIN_DIR=/vault/plugins")
 
 		// Inject the Enterprise License (we already know it exists thanks to the pre-flight check)
 		if vaultEdition == "ent" || vaultEdition == "enterprise" {
@@ -109,7 +135,7 @@ var deployCmd = &cobra.Command{
 		// Append the image and the Vault Dev mode commands
 		vaultArgs = append(vaultArgs,
 			fmt.Sprintf("%s:%s", imageRepo, actualVersion),
-			"server", "-dev", "-dev-listen-address=0.0.0.0:8200", "-dev-root-token-id=root",
+			"server", "-dev", "-dev-listen-address=0.0.0.0:8200", "-dev-root-token-id=root", "-dev-plugin-dir=/vault/plugins",
 		)
 
 		if global.DryRun {

--- a/cmd/vault/delete.go
+++ b/cmd/vault/delete.go
@@ -22,7 +22,8 @@ var vaultEcosystem = []string{
 }
 
 var vaultVolumes = []string{
-	"hal-vault-logs", // Spun up by Audit/Loki
+	"hal-vault-logs",    // Spun up by Audit/Loki
+	"hal-vault-plugins", // Spun up for external plugins (OS secret engine)
 }
 
 var vaultDestroyCmd = &cobra.Command{

--- a/cmd/vault/os.go
+++ b/cmd/vault/os.go
@@ -1,0 +1,396 @@
+package vault
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"hal/internal/global"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/spf13/cobra"
+)
+
+var (
+	osEnable      bool
+	osDisable     bool
+	osUpdate      bool
+	osUbuntuImage string
+	osVMCPUs      string
+	osVMMem       string
+)
+
+var vaultOSCmd = &cobra.Command{
+	Use:   "os [status|enable|disable|update]",
+	Short: "Deploy Ubuntu VM and configure Vault OS secret engine for Linux user management",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := parseLifecycleAction(args, &osEnable, &osDisable, &osUpdate); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+
+		if err := exec.Command("multipass", "version").Run(); err != nil {
+			fmt.Println("❌ Error: Multipass is not installed or not running.")
+			fmt.Println("   💡 Install Multipass: https://multipass.run/install")
+			return
+		}
+
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			return
+		}
+
+		client, vaultErr := GetHealthyClient()
+
+		// ==========================================
+		// 1. SMART STATUS MODE (Default behavior)
+		// ==========================================
+		if !osEnable && !osDisable && !osUpdate {
+			fmt.Println("🔍 Checking Vault OS Secret Engine Status...")
+
+			vmExists := exec.Command("multipass", "info", "hal-vault-os").Run() == nil
+			vmIP := ""
+			if vmExists {
+				ipOut, _ := exec.Command("multipass", "info", "hal-vault-os", "--format", "csv").Output()
+				vmIP = extractMultipassIP(string(ipOut))
+			}
+
+			osMounted := false
+			if vaultErr == nil {
+				mounts, _ := client.Sys().ListMounts()
+				_, osMounted = mounts["os/"]
+			}
+
+			if vmExists {
+				fmt.Printf("  ✅ VM Instance   : Active (hal-vault-os, %s)\n", vmIP)
+			} else {
+				fmt.Printf("  ❌ VM Instance   : Not running\n")
+			}
+
+			if osMounted {
+				fmt.Printf("  ✅ Vault Secrets : Configured (os/)\n")
+			} else {
+				fmt.Printf("  ❌ Vault Secrets : Not configured\n")
+			}
+
+			fmt.Println("\n💡 Next Step:")
+			if !vmExists && !osMounted {
+				fmt.Println("   To deploy Ubuntu VM and wire up Vault OS secret engine, run:")
+				fmt.Println("   hal vault os enable")
+			} else if vmExists && osMounted {
+				fmt.Println("   Demo is ready! Rotate a password or read credentials:")
+				fmt.Println("   vault write -f os/hosts/demo-vm/accounts/demouser/rotate")
+				fmt.Println("   vault read os/hosts/demo-vm/accounts/demouser/creds")
+				fmt.Println("\n   To completely remove this demo environment, run:")
+				fmt.Println("   hal vault os disable")
+			} else {
+				fmt.Println("   Environment is partially degraded. To safely reset, run:")
+				fmt.Println("   hal vault os update")
+			}
+			return
+		}
+
+		// ==========================================
+		// 2. TEARDOWN / RESET PATH (--disable / --update)
+		// ==========================================
+		if osDisable || osUpdate {
+			if global.DryRun {
+				fmt.Println("[DRY RUN] Would execute: multipass delete hal-vault-os && multipass purge")
+				fmt.Println("[DRY RUN] Would call API to revoke leases and unmount 'os/'")
+			} else {
+				if osDisable {
+					fmt.Println("🛑 Tearing down OS secret engine environment...")
+				} else {
+					fmt.Println("♻️  Update requested. Destroying OS environment for reset...")
+				}
+
+				// Vault cleanup MUST happen before killing the VM
+				if vaultErr == nil && client != nil {
+					fmt.Println("⚙️  Cleaning up Vault resources...")
+					_ = client.Sys().RevokePrefix("os/")
+					_ = client.Sys().Unmount("os")
+				} else {
+					fmt.Println("⚠️  Vault is offline. Skipped Vault-internal cleanup.")
+				}
+
+				fmt.Println("⚙️  Removing Multipass VM...")
+				_ = exec.Command("multipass", "delete", "hal-vault-os").Run()
+				_ = exec.Command("multipass", "purge").Run()
+
+				if osDisable {
+					fmt.Println("✅ OS secret engine environment destroyed successfully!")
+					global.RefreshHalStatus(engine)
+				}
+			}
+
+			if osDisable && !global.DryRun {
+				return
+			}
+		}
+
+		// ==========================================
+		// 3. DEPLOY / ENABLE PATH (--enable / --update)
+		// ==========================================
+		if osEnable || osUpdate {
+			if vaultErr != nil {
+				fmt.Printf("❌ Cannot deploy: Vault must be running and healthy. %v\n", vaultErr)
+				return
+			}
+
+			health, err := client.Sys().Health()
+			if err == nil {
+				version := health.Version
+				if !strings.Contains(version, "ent") && !strings.Contains(version, "+") {
+					fmt.Println("❌ Error: The OS secret engine requires Vault Enterprise.")
+					fmt.Println("   💡 Your current Vault version is Community Edition.")
+					fmt.Println("\n   To deploy Vault Enterprise, run:")
+					fmt.Println("   hal vault delete")
+					fmt.Println("   export VAULT_LICENSE='your_license_string'")
+					fmt.Println("   # or: export VAULT_LICENSE_PATH='/path/to/vault.hclic'")
+					fmt.Println("   hal vault create --edition ent")
+					return
+				}
+			}
+
+			if global.DryRun {
+				fmt.Println("[DRY RUN] Would launch Multipass VM 'hal-vault-os'")
+				fmt.Println("[DRY RUN] Would create mgmt-user, demouser, appadmin on VM")
+				fmt.Println("[DRY RUN] Would configure Vault OS secrets engine with parent-managed rotation")
+				return
+			}
+
+			fmt.Println("🚀 Deploying Ubuntu VM for OS Secret Engine Demo...")
+
+			// 1. Launch the VM
+			fmt.Println("📦 Provisioning Ubuntu VM (this takes a moment)...")
+			launchArgs := []string{"launch", osUbuntuImage, "--name", "hal-vault-os", "--cpus", osVMCPUs, "--memory", osVMMem}
+			out, err := exec.Command("multipass", launchArgs...).CombinedOutput()
+			if err != nil {
+				if strings.Contains(string(out), "already exists") {
+					fmt.Println("⚠️  VM 'hal-vault-os' already exists. Use 'hal vault os update' to reconcile.")
+					return
+				}
+				fmt.Printf("❌ Failed to launch VM: %v\nOutput: %s\n", err, string(out))
+				return
+			}
+
+			// 2. Wait for VM IP
+			fmt.Println("⏳ Waiting for VM to get an IP address...")
+			var vmIP string
+			for i := 0; i < 30; i++ {
+				time.Sleep(2 * time.Second)
+				ipOut, err := exec.Command("multipass", "info", "hal-vault-os", "--format", "csv").Output()
+				if err != nil {
+					continue
+				}
+				vmIP = extractMultipassIP(string(ipOut))
+				if vmIP != "127.0.0.1" && vmIP != "" {
+					break
+				}
+			}
+			if vmIP == "127.0.0.1" || vmIP == "" {
+				fmt.Println("❌ Failed to get VM IP address")
+				return
+			}
+			fmt.Printf("✅ VM launched at %s\n", vmIP)
+
+			// 3. Configure VM: create users, set permissions, enable SSH password auth
+			//
+			// Uses parent-managed rotation: mgmt-user has sudo access to chpasswd only,
+			// and performs password rotations for demouser and appadmin on Vault's behalf.
+			fmt.Println("⚙️  Configuring VM users and SSH access...")
+			setupScript := `
+				# Create management account used by Vault to rotate other users
+				sudo useradd -m -s /bin/bash mgmt-user 2>/dev/null || true
+				echo 'mgmt-user:mgmt-password-789' | sudo chpasswd
+
+				# Create target accounts whose passwords Vault will manage
+				sudo useradd -m -s /bin/bash demouser 2>/dev/null || true
+				sudo useradd -m -s /bin/bash appadmin 2>/dev/null || true
+				echo 'demouser:initial-password-123' | sudo chpasswd
+				echo 'appadmin:admin-password-456' | sudo chpasswd
+
+				# Grant mgmt-user passwordless sudo for chpasswd only (required by Vault OS plugin)
+				echo 'mgmt-user ALL=NOPASSWD:/usr/sbin/chpasswd' | sudo tee /etc/sudoers.d/vault-mgmt > /dev/null
+				sudo chmod 0440 /etc/sudoers.d/vault-mgmt
+
+				# Enable SSH password authentication.
+				# Ubuntu cloud images ship 60-cloudimg-settings.conf with PasswordAuthentication no.
+				# OpenSSH uses first-match-wins across included files (alphabetical order), so we
+				# overwrite that file directly rather than trying to win with a higher-numbered file.
+				echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/60-cloudimg-settings.conf > /dev/null
+				sudo systemctl restart ssh
+			`
+			execArgs := []string{"exec", "hal-vault-os", "--", "bash", "-c", setupScript}
+			if out, err := exec.Command("multipass", execArgs...).CombinedOutput(); err != nil {
+				fmt.Printf("❌ Failed to configure VM: %v\nOutput: %s\n", err, string(out))
+				return
+			}
+			fmt.Println("   ✅ VM users and SSH configuration applied")
+
+			// 4. Verify the Vault container can reach the VM over SSH before proceeding
+			fmt.Printf("⚙️  Verifying network connectivity from Vault container to VM (%s:22)...\n", vmIP)
+			connCheck := exec.Command(engine, "exec", "hal-vault", "sh", "-c",
+				fmt.Sprintf("nc -z -w5 %s 22 && echo reachable || echo unreachable", vmIP))
+			connOut, _ := connCheck.CombinedOutput()
+			if strings.TrimSpace(string(connOut)) != "reachable" {
+				fmt.Printf("❌ The Vault container cannot reach %s:22\n", vmIP)
+				fmt.Println("   The OS plugin will be unable to connect to the VM.")
+				fmt.Println("   💡 This is usually a Docker-to-Multipass networking issue on macOS.")
+				fmt.Println("      Ensure Docker Desktop can route to the Multipass subnet (192.168.64.x).")
+				fmt.Println("      You can test manually: docker exec hal-vault nc -z " + vmIP + " 22")
+				return
+			}
+			fmt.Println("   ✅ Vault container can reach VM")
+
+			// 5. Register OS plugin
+			fmt.Println("⚙️  Registering OS secret engine plugin...")
+			osPluginVersion := "0.1.0+ent"
+			registerCmd := fmt.Sprintf(
+				"VAULT_ADDR='http://127.0.0.1:8200' VAULT_TOKEN='root' vault plugin register -download -version='%s' secret vault-plugin-secrets-os",
+				osPluginVersion,
+			)
+			if out, err := exec.Command(engine, "exec", "hal-vault", "sh", "-c", registerCmd).CombinedOutput(); err != nil {
+				fmt.Printf("❌ Failed to register OS plugin: %v\nOutput: %s\n", err, string(out))
+				fmt.Println("   💡 Check https://releases.hashicorp.com/vault-plugin-secrets-os for the latest version.")
+				return
+			}
+
+			// 6. Mount OS secrets engine
+			fmt.Println("⚙️  Enabling OS Secrets Engine...")
+			_ = client.Sys().Unmount("os")
+			if err = client.Sys().Mount("os", &vault.MountInput{
+				Type: "vault-plugin-secrets-os",
+			}); err != nil {
+				fmt.Printf("❌ Failed to enable OS secrets engine: %v\n", err)
+				return
+			}
+
+			// 7. Configure TOFU (trust-on-first-use for SSH host key verification)
+			fmt.Println("⚙️  Configuring OS secret engine (TOFU host key verification)...")
+			if _, err = client.Logical().Write("os/config", map[string]interface{}{
+				"ssh_host_key_trust_on_first_use": true,
+			}); err != nil {
+				fmt.Printf("❌ Failed to configure OS settings: %v\n", err)
+				return
+			}
+
+			// 8. Register the host
+			fmt.Println("⚙️  Registering host configuration...")
+			if _, err = client.Logical().Write("os/hosts/demo-vm", map[string]interface{}{
+				"address": vmIP,
+				"port":    22,
+			}); err != nil {
+				fmt.Printf("❌ Failed to create host: %v\n", err)
+				return
+			}
+			fmt.Println("   ✅ Host 'demo-vm' registered")
+
+			// 9. Register accounts
+			//
+			// mgmt-user: the privileged parent account. Vault SSHes in as this user and
+			// runs `sudo chpasswd` to rotate other accounts' passwords.
+			//
+			// demouser / appadmin: target accounts. Vault rotates their passwords via mgmt-user.
+			fmt.Println("⚙️  Registering accounts...")
+
+			if _, err = client.Logical().Write("os/hosts/demo-vm/accounts/mgmt-user", map[string]interface{}{
+				"username":          "mgmt-user",
+				"password":          "mgmt-password-789",
+				"verify_connection": false,
+			}); err != nil {
+				fmt.Printf("❌ Failed to register mgmt-user: %v\n", err)
+				return
+			}
+			fmt.Println("   ✅ mgmt-user registered (parent account)")
+
+			if _, err = client.Logical().Write("os/hosts/demo-vm/accounts/demouser", map[string]interface{}{
+				"username":           "demouser",
+				"password":           "initial-password-123",
+				"parent_account_ref": "mgmt-user",
+				"verify_connection":  false,
+			}); err != nil {
+				fmt.Printf("❌ Failed to register demouser: %v\n", err)
+				return
+			}
+			fmt.Println("   ✅ demouser registered")
+
+			if _, err = client.Logical().Write("os/hosts/demo-vm/accounts/appadmin", map[string]interface{}{
+				"username":           "appadmin",
+				"password":           "admin-password-456",
+				"parent_account_ref": "mgmt-user",
+				"verify_connection":  false,
+			}); err != nil {
+				fmt.Printf("❌ Failed to register appadmin: %v\n", err)
+				return
+			}
+			fmt.Println("   ✅ appadmin registered")
+
+			// 10. Rotate demouser password to verify end-to-end connectivity
+			fmt.Println("⚙️  Testing end-to-end password rotation for demouser...")
+			if _, err = client.Logical().Write("os/hosts/demo-vm/accounts/demouser/rotate", nil); err != nil {
+				fmt.Printf("❌ Rotation failed: %v\n", err)
+				fmt.Println("   💡 The plugin could not SSH into the VM. Check:")
+				fmt.Println("      1. VM is reachable: nc -z " + vmIP + " 22")
+				fmt.Println("      2. Password auth is enabled: multipass exec hal-vault-os -- sshd -T | grep passwordauth")
+				fmt.Println("      3. SSH service is running: multipass exec hal-vault-os -- systemctl status ssh")
+				return
+			}
+
+			secret, err := client.Logical().Read("os/hosts/demo-vm/accounts/demouser/creds")
+			if err != nil || secret == nil {
+				fmt.Printf("❌ Failed to read credentials after rotation: %v\n", err)
+				return
+			}
+			password := secret.Data["password"].(string)
+
+			fmt.Println("\n✅ Vault OS Secret Engine Integration Complete!")
+			global.RefreshHalStatus(engine)
+			fmt.Println("---------------------------------------------------------")
+			fmt.Printf("🔗 VM Address  : %s\n", vmIP)
+			fmt.Printf("👤 Users       : mgmt-user (parent), demouser, appadmin\n")
+			fmt.Printf("🔑 demouser pwd: %s (just rotated by Vault)\n", password)
+			fmt.Println("\n💡 HOW IT WORKS:")
+			fmt.Println("   Vault SSHes into the VM as 'mgmt-user' and runs:")
+			fmt.Println("   echo \"<user>:<newpass>\" | sudo /usr/sbin/chpasswd")
+			fmt.Println("   mgmt-user has passwordless sudo for chpasswd only.")
+			fmt.Println("\n📋 Try these commands:")
+			fmt.Println("   vault write -f os/hosts/demo-vm/accounts/demouser/rotate   # Rotate demouser password")
+			fmt.Println("   vault read os/hosts/demo-vm/accounts/demouser/creds        # Read current password")
+			fmt.Println("   vault read os/hosts/demo-vm/accounts/appadmin/creds        # Read appadmin password")
+			fmt.Printf("   multipass shell hal-vault-os                               # Shell into VM\n")
+			fmt.Println("---------------------------------------------------------")
+		}
+	},
+}
+
+func extractMultipassIP(csvData string) string {
+	lines := strings.Split(csvData, "\n")
+	if len(lines) > 1 {
+		cols := strings.Split(lines[1], ",")
+		if len(cols) > 2 {
+			return cols[2]
+		}
+	}
+	return "127.0.0.1"
+}
+
+func init() {
+	vaultOSCmd.Flags().BoolVarP(&osEnable, "enable", "e", false, "Deploy Ubuntu VM and configure Vault OS secret engine")
+	vaultOSCmd.Flags().BoolVarP(&osDisable, "disable", "d", false, "Remove VM and clean up Vault OS configuration")
+	vaultOSCmd.Flags().BoolVarP(&osUpdate, "update", "u", false, "Reconcile VM and Vault OS integration")
+	_ = vaultOSCmd.Flags().MarkHidden("enable")
+	_ = vaultOSCmd.Flags().MarkHidden("disable")
+	_ = vaultOSCmd.Flags().MarkHidden("update")
+
+	vaultOSCmd.Flags().StringVar(&osUbuntuImage, "ubuntu-image", "22.04", "Ubuntu image for Multipass VM")
+	vaultOSCmd.Flags().StringVar(&osVMCPUs, "vm-cpus", "1", "Number of CPUs for the VM")
+	vaultOSCmd.Flags().StringVar(&osVMMem, "vm-mem", "1G", "Amount of RAM for the VM")
+
+	Cmd.AddCommand(vaultOSCmd)
+}
+
+// Made with Bob

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -23,6 +23,7 @@ This index maps the HAL command tree to one spec file per command area.
 - [Vault k8s](vault-k8s.md)
 - [Vault ldap](vault-ldap.md)
 - [Vault database](vault-database.md)
+- [Vault os](vault-os.md)
 - [Boundary](boundary.md)
 - [Boundary deploy](boundary-deploy.md)
 - [Boundary status](boundary-status.md)

--- a/docs/commands/vault-os.md
+++ b/docs/commands/vault-os.md
@@ -1,0 +1,187 @@
+# HAL Vault OS Command Spec
+
+## Command
+- `hal vault os`
+
+## Purpose
+Deploy an Ubuntu VM via Multipass and configure Vault's OS secret engine to manage and rotate local Linux user passwords on the VM.
+
+## Related
+- Parent namespace: [vault.md](vault.md)
+
+## Prerequisites
+- HAL CLI is available in your local environment
+- Multipass is installed and running (https://multipass.run/install)
+- **Vault Enterprise 2.0+** must be running and healthy (OS secret engine is Enterprise-only)
+- Valid Vault Enterprise license (`VAULT_LICENSE` or `VAULT_LICENSE_PATH`)
+
+## Flags
+```text
+      --ubuntu-image string   Ubuntu image for Multipass VM (default "22.04")
+      --vm-cpus string        Number of CPUs for the VM (default "1")
+      --vm-mem string         Amount of RAM for the VM (default "1G")
+  -h, --help                  help for os
+```
+- Global flags: `--debug`, `--dry-run`
+
+## Side Effects
+- Creates a Multipass VM named `hal-vault-os`
+- Creates three local users on the VM: `mgmt-user`, `demouser`, `appadmin`
+- Mounts the OS secret engine plugin at `os/` in Vault
+- Registers a host (`demo-vm`) and three accounts in Vault
+
+## Lifecycle Actions
+
+### Status (Default)
+```bash
+hal vault os
+```
+Displays:
+- VM existence and IP address
+- Vault OS secret engine mount status
+- Suggested next steps
+
+### Enable
+```bash
+hal vault os enable
+```
+1. Launches Ubuntu 22.04 VM via Multipass
+2. Creates `mgmt-user` (privileged parent), `demouser`, and `appadmin` on the VM
+3. Grants `mgmt-user` passwordless sudo for `/usr/sbin/chpasswd` only
+4. Enables SSH password authentication on the VM
+5. Verifies network connectivity from the Vault container to the VM
+6. Registers and mounts the `vault-plugin-secrets-os` plugin
+7. Configures TOFU host key verification
+8. Registers the host and all three accounts in Vault
+9. Performs a test password rotation for `demouser` to verify end-to-end connectivity
+
+### Disable
+```bash
+hal vault os disable
+```
+1. Revokes all OS secret engine leases
+2. Unmounts the `os/` secrets engine
+3. Deletes the `hal-vault-os` Multipass VM and purges its cache
+
+### Update
+```bash
+hal vault os update
+```
+Runs disable followed by enable — full teardown and rebuild.
+
+## Example Workflows
+
+### Basic Setup
+```bash
+# Deploy Vault Enterprise first
+export VAULT_LICENSE_PATH=/path/to/vault.hclic
+hal vault create --edition ent
+
+# Deploy OS secret engine integration
+hal vault os enable
+
+# Check status
+hal vault os
+```
+
+### Password Rotation Demo
+```bash
+# Manually rotate demouser's password
+vault write -f os/hosts/demo-vm/accounts/demouser/rotate
+
+# Read the new password
+vault read os/hosts/demo-vm/accounts/demouser/creds
+
+# Read appadmin's current password
+vault read os/hosts/demo-vm/accounts/appadmin/creds
+
+# Shell into the VM to verify
+multipass shell hal-vault-os
+```
+
+### Cleanup
+```bash
+hal vault os disable
+```
+
+## How It Works
+
+The OS secret engine uses **parent-managed rotation**:
+
+1. Vault SSHes into the VM as `mgmt-user` using its stored password
+2. Vault runs `echo "<user>:<newpass>" | sudo /usr/sbin/chpasswd` on the VM
+3. `mgmt-user` has passwordless sudo scoped to only `/usr/sbin/chpasswd`
+4. The new password is versioned and stored in Vault
+
+This is more reliable than self-managed rotation (which uses a PTY + `passwd` expect workflow) and is the recommended approach for production-like demos.
+
+## Accounts
+
+| Account    | Role           | Purpose                                      |
+|------------|----------------|----------------------------------------------|
+| `mgmt-user`  | Parent account | SSHes in and rotates other users' passwords  |
+| `demouser`   | Target account | Managed by `mgmt-user`                       |
+| `appadmin`   | Target account | Managed by `mgmt-user`                       |
+
+## Technical Details
+
+### VM Configuration
+- **Name**: `hal-vault-os`
+- **OS**: Ubuntu 22.04 LTS (configurable via `--ubuntu-image`)
+- **Resources**: 1 CPU, 1GB RAM (configurable)
+- **Network**: Multipass default network
+
+### Vault Configuration
+- **Plugin**: `vault-plugin-secrets-os` v`0.1.0+ent`
+- **Mount Path**: `os/`
+- **Host Key Verification**: Trust-on-first-use (TOFU)
+- **Connection**: SSH with password authentication
+
+### sudoers
+```
+mgmt-user ALL=NOPASSWD:/usr/sbin/chpasswd
+```
+
+## Troubleshooting
+
+### Multipass Not Found
+```
+❌ Error: Multipass is not installed or not running.
+```
+Install from https://multipass.run/install
+
+### Vault Not Enterprise
+```
+❌ Error: The OS secret engine requires Vault Enterprise.
+```
+Deploy Enterprise: `hal vault delete && hal vault create --edition ent`
+
+### Vault Container Can't Reach VM
+```
+❌ The Vault container cannot reach <IP>:22
+```
+This is a Docker-to-Multipass networking issue on macOS. Verify Docker Desktop can route to the Multipass subnet:
+```bash
+docker exec hal-vault nc -z <VM_IP> 22
+```
+
+### Rotation Fails After Enable
+Check that SSH password auth is active on the VM:
+```bash
+multipass exec hal-vault-os -- sudo sshd -T | grep passwordauthentication
+# Should show: passwordauthentication yes
+```
+If it shows `no`, run `hal vault os update` to rebuild with the corrected config.
+
+### VM Already Exists
+```
+⚠️  VM 'hal-vault-os' already exists. Use 'hal vault os update' to reconcile.
+```
+Run `hal vault os update` to tear down and rebuild cleanly.
+
+## Related Commands
+- `hal vault create` — Deploy Vault instance
+- `hal vault database` — Database secrets engine integration
+- `hal vault ldap` — LDAP secrets engine integration
+- `hal nomad create` — Also uses Multipass for VM management
+- `hal boundary ssh` — Also uses Multipass for SSH target demo

--- a/docs/commands/vault.md
+++ b/docs/commands/vault.md
@@ -47,6 +47,10 @@
   - Configure dynamic DB credentials scenario (defaults to `mariadb`; `postgres` planned)
   - Spec: [vault-database.md](vault-database.md)
 
+- `hal vault os`
+  - Deploy Ubuntu VM and configure OS secret engine for Linux user password management
+  - Spec: [vault-os.md](vault-os.md)
+
 ## Local Lab Assumptions
 - Vault local endpoint defaults to `http://127.0.0.1:8200`
 - Typical local root token assumption: `root`


### PR DESCRIPTION
```shell
$ export VAULT_LICENSE_PATH=/path/to/license/vault.hclic
$ ./hal vault create --edition ent && ./hal vault os enable
🚀 Deploying Vault 2.0-ent (ENT) via docker...
⚙️  Preparing shared volume permissions...
   🔐 Injecting VAULT_LICENSE into container...
⏳ Waiting for Vault to initialize...
✅ Vault is up and running in Dev mode!
   🏗️  Edition: ENT
   🔗 UI Address: http://vault.localhost:8200
   🔑 Root Token: root

💡 Tip: Export your environment variables to use your local CLI:
   export VAULT_ADDR='http://vault.localhost:8200'
   export VAULT_TOKEN='root'
🚀 Deploying Ubuntu VM for OS Secret Engine Demo...
📦 Provisioning Ubuntu VM (this takes a moment)...
⏳ Waiting for VM to get an IP address...
✅ VM launched at 192.168.2.41
⚙️  Configuring VM users and SSH access...
   ✅ VM users and SSH configuration applied
⚙️  Verifying network connectivity from Vault container to VM (192.168.2.41:22)...
   ✅ Vault container can reach VM
⚙️  Registering OS secret engine plugin...
⚙️  Enabling OS Secrets Engine...
⚙️  Configuring OS secret engine (TOFU host key verification)...
⚙️  Registering host configuration...
   ✅ Host 'demo-vm' registered
⚙️  Registering accounts...
   ✅ mgmt-user registered (parent account)
   ✅ demouser registered
   ✅ appadmin registered
⚙️  Testing end-to-end password rotation for demouser...

✅ Vault OS Secret Engine Integration Complete!
---------------------------------------------------------
🔗 VM Address  : 192.168.2.41
👤 Users       : mgmt-user (parent), demouser, appadmin
🔑 demouser pwd: hDoyC8a7X06a4g02UxeIIe3UohEkUXE23SHuXugmvCOkDLaxoL1fYwVGu3He9F7W (just rotated by Vault)

💡 HOW IT WORKS:
   Vault SSHes into the VM as 'mgmt-user' and runs:
   echo "<user>:<newpass>" | sudo /usr/sbin/chpasswd
   mgmt-user has passwordless sudo for chpasswd only.

📋 Try these commands:
   vault write -f os/hosts/demo-vm/accounts/demouser/rotate   # Rotate demouser password
   vault read os/hosts/demo-vm/accounts/demouser/creds        # Read current password
   vault read os/hosts/demo-vm/accounts/appadmin/creds        # Read appadmin password
   multipass shell hal-vault-os                               # Shell into VM
---------------------------------------------------------
$ vault read -field=password os/hosts/demo-vm/accounts/demouser/creds
hDoyC8a7X06a4g02UxeIIe3UohEkUXE23SHuXugmvCOkDLaxoL1fYwVGu3He9F7W
```