### PR TITLE
Feature/custom prom targets

### DIFF
--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -14,12 +14,16 @@ import (
 )
 
 var (
-	obsUpdate      bool
-	lokiVer        string
-	grafanaVer     string
-	promVer        string
-	promtailVer    string
-	promConfigPath string
+	obsUpdate       bool
+	lokiVer         string
+	grafanaVer      string
+	promVer         string
+	promtailVer     string
+	promConfigPath  string
+	obsJobName      string
+	obsMetricsPath  string
+	obsMetricsToken string
+	obsScrapeConfig string
 )
 
 var deployCmd = &cobra.Command{
@@ -238,6 +242,36 @@ providers:
 		fmt.Println("🔗 Prometheus: http://prometheus.localhost:9090")
 		fmt.Println("🔗 Loki API:   http://loki.localhost:3100/ready")
 		fmt.Println("---------------------------------------------------------")
+
+		if obsJobName != "" {
+			configPath := filepath.Join(filepath.Join(homeDir, ".hal", "obs"), "prometheus.yml")
+			targetFile := obsJobName + ".json"
+			if err := global.UpsertObsPromJob(configPath, obsJobName, obsMetricsPath, obsMetricsToken, targetFile); err != nil {
+				fmt.Printf("⚠️  Custom job registration failed: %v\n", err)
+			} else if err := global.ReloadPrometheus(engine); err != nil {
+				fmt.Printf("⚠️  Prometheus reload failed: %v\n", err)
+			} else {
+				targetPath := filepath.Join(targetsDir, targetFile)
+				placeholder := fmt.Sprintf(`[{"targets":["host:port"],"labels":{"job":%q}}]\n`, obsJobName)
+				if _, statErr := os.Stat(targetPath); os.IsNotExist(statErr) {
+					_ = os.WriteFile(targetPath, []byte(placeholder), 0o644)
+				}
+				fmt.Printf("✅ Custom Prometheus job '%s' registered (path: %s).\n", obsJobName, obsMetricsPath)
+				fmt.Printf("   📄 Edit target file: %s\n", targetPath)
+				fmt.Println("   Replace \"host:port\" with your real endpoint.")
+			}
+		}
+
+		if obsJobName == "" && obsScrapeConfig != "" {
+			configPath := filepath.Join(filepath.Join(homeDir, ".hal", "obs"), "prometheus.yml")
+			if err := global.UpsertObsPromJobFromFile(configPath, obsScrapeConfig); err != nil {
+				fmt.Printf("⚠️  Scrape config merge failed: %v\n", err)
+			} else if err := global.ReloadPrometheus(engine); err != nil {
+				fmt.Printf("⚠️  Prometheus reload failed: %v\n", err)
+			} else {
+				fmt.Printf("✅ Scrape config from %s merged into prometheus.yml.\n", obsScrapeConfig)
+			}
+		}
 	},
 }
 
@@ -309,6 +343,48 @@ var updateCmd = &cobra.Command{
 	Short: "Reconcile the PLG observability stack",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		// If only a custom job flag is passed, just edit prometheus.yml and
+		// reload — do NOT tear down or recreate the stack.
+		if obsJobName != "" || obsScrapeConfig != "" {
+			engine, err := global.DetectEngine()
+			if err != nil {
+				fmt.Printf("❌ Error: %v\n", err)
+				return
+			}
+			homeDir, _ := os.UserHomeDir()
+			configPath := filepath.Join(homeDir, ".hal", "obs", "prometheus.yml")
+			targetsDir := filepath.Join(homeDir, ".hal", "obs", "targets")
+
+			if obsJobName != "" {
+				targetFile := obsJobName + ".json"
+				if err := global.UpsertObsPromJob(configPath, obsJobName, obsMetricsPath, obsMetricsToken, targetFile); err != nil {
+					fmt.Printf("⚠️  Custom job registration failed: %v\n", err)
+					return
+				}
+				targetPath := filepath.Join(targetsDir, targetFile)
+				placeholder := fmt.Sprintf("[{\"targets\":[\"host:port\"],\"labels\":{\"job\":%q}}]\n", obsJobName)
+				if _, statErr := os.Stat(targetPath); os.IsNotExist(statErr) {
+					_ = os.WriteFile(targetPath, []byte(placeholder), 0o644)
+				}
+				fmt.Printf("✅ Custom Prometheus job '%s' registered (path: %s).\n", obsJobName, obsMetricsPath)
+				fmt.Printf("   📄 Edit target file: %s\n", targetPath)
+				fmt.Println("   Replace \"host:port\" with your real endpoint.")
+			}
+
+			if obsScrapeConfig != "" {
+				if err := global.UpsertObsPromJobFromFile(configPath, obsScrapeConfig); err != nil {
+					fmt.Printf("⚠️  Scrape config merge failed: %v\n", err)
+					return
+				}
+				fmt.Printf("✅ Scrape config from %s merged into prometheus.yml.\n", obsScrapeConfig)
+			}
+
+			if err := global.ReloadPrometheus(engine); err != nil {
+				fmt.Printf("⚠️  Prometheus reload failed: %v\n", err)
+			}
+			return
+		}
+
 		obsUpdate = true
 		deployCmd.Run(cmd, args)
 	},
@@ -323,6 +399,10 @@ func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
 	cmd.Flags().StringVar(&promVer, "prom-version", "main", "Tag for the prom/prometheus image")
 	cmd.Flags().StringVar(&promtailVer, "promtail-version", "3.6", "Tag for the grafana/promtail image")
 	cmd.Flags().StringVar(&promConfigPath, "prom-config-path", "", "Path to a custom prometheus.yml; skips the generated config when set")
+	cmd.Flags().StringVar(&obsJobName, "job-name", "", "Register a custom Prometheus scrape job with this name (no local TFE required)")
+	cmd.Flags().StringVar(&obsMetricsPath, "metrics-path", "/metrics", "Metrics path for the custom job (only used when --job-name is set)")
+	cmd.Flags().StringVar(&obsMetricsToken, "metrics-token", "", "Bearer token for authenticated metrics endpoints (only used when --job-name is set)")
+	cmd.Flags().StringVar(&obsScrapeConfig, "scrape-config-path", "", "Path to a JSON/YAML file with a single scrape job config to merge into prometheus.yml")
 }
 
 func init() {

--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	obsUpdate   bool
-	lokiVer     string
-	grafanaVer  string
-	promVer     string
-	promtailVer string
+	obsUpdate      bool
+	lokiVer        string
+	grafanaVer     string
+	promVer        string
+	promtailVer    string
+	promConfigPath string
 )
 
 var deployCmd = &cobra.Command{
@@ -82,40 +83,55 @@ var deployCmd = &cobra.Command{
 		_ = os.MkdirAll(targetsDir, 0755)
 		_ = os.MkdirAll(dashboardsDir, 0755)
 
-		promConfig := strings.Join([]string{
-			"global:",
-			"  scrape_interval: 15s",
-			"scrape_configs:",
-			"  - job_name: 'vault'",
-			"    metrics_path: '/v1/sys/metrics'",
-			"    params:",
-			"      format: ['prometheus']",
-			"    file_sd_configs:",
-			"      - files: ['/etc/prometheus/targets/vault.json']",
-			"  - job_name: 'consul'",
-			"    metrics_path: '/v1/agent/metrics'",
-			"    params:",
-			"      format: ['prometheus']",
-			"    file_sd_configs:",
-			"      - files: ['/etc/prometheus/targets/consul.json']",
-			"  - job_name: 'nomad'",
-			"    metrics_path: '/v1/metrics'",
-			"    params:",
-			"      format: ['prometheus']",
-			"    file_sd_configs:",
-			"      - files: ['/etc/prometheus/targets/nomad.json']",
-			"  - job_name: 'boundary'",
-			"    metrics_path: '/v1/metrics'",
-			"    file_sd_configs:",
-			"      - files: ['/etc/prometheus/targets/boundary.json']",
-			"  - job_name: 'terraform-enterprise'",
-			"    metrics_path: '/metrics'",
-			"    params:",
-			"      format: ['prometheus']",
-			"    file_sd_configs:",
-			"      - files: ['/etc/prometheus/targets/terraform.json']",
-		}, "\n") + "\n"
-		_ = os.WriteFile(filepath.Join(configDir, "prometheus.yml"), []byte(promConfig), 0644)
+		if promConfigPath != "" {
+			src, err := os.ReadFile(promConfigPath)
+			if err != nil {
+				fmt.Printf("❌ Cannot read --prom-config-path %q: %v\n", promConfigPath, err)
+				return
+			}
+			if err := os.WriteFile(filepath.Join(configDir, "prometheus.yml"), src, 0644); err != nil {
+				fmt.Printf("❌ Failed to write prometheus.yml: %v\n", err)
+				return
+			}
+			fmt.Printf("📄 Using custom Prometheus config: %s\n", promConfigPath)
+		} else {
+
+			promConfig := strings.Join([]string{
+				"global:",
+				"  scrape_interval: 15s",
+				"scrape_configs:",
+				"  - job_name: 'vault'",
+				"    metrics_path: '/v1/sys/metrics'",
+				"    params:",
+				"      format: ['prometheus']",
+				"    file_sd_configs:",
+				"      - files: ['/etc/prometheus/targets/vault.json']",
+				"  - job_name: 'consul'",
+				"    metrics_path: '/v1/agent/metrics'",
+				"    params:",
+				"      format: ['prometheus']",
+				"    file_sd_configs:",
+				"      - files: ['/etc/prometheus/targets/consul.json']",
+				"  - job_name: 'nomad'",
+				"    metrics_path: '/v1/metrics'",
+				"    params:",
+				"      format: ['prometheus']",
+				"    file_sd_configs:",
+				"      - files: ['/etc/prometheus/targets/nomad.json']",
+				"  - job_name: 'boundary'",
+				"    metrics_path: '/v1/metrics'",
+				"    file_sd_configs:",
+				"      - files: ['/etc/prometheus/targets/boundary.json']",
+				"  - job_name: 'terraform-enterprise'",
+				"    metrics_path: '/metrics'",
+				"    params:",
+				"      format: ['prometheus']",
+				"    file_sd_configs:",
+				"      - files: ['/etc/prometheus/targets/terraform.json']",
+			}, "\n") + "\n"
+			_ = os.WriteFile(filepath.Join(configDir, "prometheus.yml"), []byte(promConfig), 0644)
+
+		} // end promConfigPath else
 
 		lokiConfig := `auth_enabled: false
 server:
@@ -306,6 +322,7 @@ func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
 	cmd.Flags().StringVar(&grafanaVer, "grafana-version", "main", "Tag for the grafana/grafana image")
 	cmd.Flags().StringVar(&promVer, "prom-version", "main", "Tag for the prom/prometheus image")
 	cmd.Flags().StringVar(&promtailVer, "promtail-version", "3.6", "Tag for the grafana/promtail image")
+	cmd.Flags().StringVar(&promConfigPath, "prom-config-path", "", "Path to a custom prometheus.yml; skips the generated config when set")
 }
 
 func init() {

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -221,7 +221,7 @@ var deployCmd = &cobra.Command{
 			"hal-tfe",
 			"sh",
 			"-lc",
-			"cp /etc/ssl/tfe/cert.pem /usr/local/share/ca-certificates/tfe-localhost.crt && update-ca-certificates >/dev/null 2>&1 && supervisorctl restart tfe:archivist >/dev/null 2>&1",
+			"cp /etc/ssl/tfe/cert.pem /usr/local/share/ca-certificates/tfe-localhost.crt && update-ca-certificates 2>&1",
 		).CombinedOutput(); trustErr != nil {
 			fmt.Printf("⚠️  Could not refresh TFE trust store automatically: %s\n", strings.TrimSpace(string(trustOut)))
 		}
@@ -237,7 +237,7 @@ var deployCmd = &cobra.Command{
 			"hal-tfe",
 			"sh",
 			"-lc",
-			"sed -i 's/readonly = \"true\"/readonly = \"false\"/' /run/terraform-enterprise/task-worker/config.hcl && supervisorctl restart tfe:task-worker >/dev/null 2>&1",
+			"sed -i 's/readonly = \"true\"/readonly = \"false\"/' /run/terraform-enterprise/task-worker/config.hcl 2>&1",
 		).CombinedOutput(); taskWorkerErr != nil {
 			fmt.Printf("⚠️  Could not patch TFE task-worker cache mount automatically: %s\n", strings.TrimSpace(string(taskWorkerOut)))
 		}

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -237,7 +237,7 @@ var deployCmd = &cobra.Command{
 			"hal-tfe",
 			"sh",
 			"-lc",
-			"sed -i 's/readonly = \"true\"/readonly = \"false\"/' /run/terraform-enterprise/task-worker/config.hcl 2>&1",
+			"test -f /run/terraform-enterprise/task-worker/config.hcl && sed -i 's/readonly = \"true\"/readonly = \"false\"/' /run/terraform-enterprise/task-worker/config.hcl 2>&1 || true",
 		).CombinedOutput(); taskWorkerErr != nil {
 			fmt.Printf("⚠️  Could not patch TFE task-worker cache mount automatically: %s\n", strings.TrimSpace(string(taskWorkerOut)))
 		}
@@ -300,7 +300,7 @@ http {
 			return
 		}
 
-		fmt.Println("\n✅ Terraform Enterprise 1.x is UP!")
+		fmt.Printf("\n✅ Terraform Enterprise %s is UP!\n", tfeVersion)
 		global.RefreshHalStatus(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Printf("🔗 UI Address:   %s\n", uiURL)

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -88,7 +88,7 @@ var deployCmd = &cobra.Command{
 
 		// Keep an unprivileged HTTPS listener for rootless Podman.
 		tfeHostname := "tfe.localhost"
-		healthURL := "https://tfe.localhost:8443/_health_check"
+		healthURL := "https://tfe.localhost:8443/api/v1/health/readiness"
 		uiURL := "https://tfe.localhost:8443"
 		// Stable internal proxy IP on hal-net used to route in-cluster tfe.localhost:443 traffic.
 		proxyInternalIP := "10.89.3.54"

--- a/cmd/terraform/obs.go
+++ b/cmd/terraform/obs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -13,6 +14,11 @@ import (
 )
 
 const terraformObsProduct = "terraform"
+
+var (
+	obsCustomJobName     string
+	obsCustomMetricsPath string
+)
 
 // syncTerraformObsTargets keeps the canonical Terraform Prometheus target file in sync
 // with whichever TFE instances are currently running.
@@ -256,6 +262,17 @@ var terraformObsCreateCmd = &cobra.Command{
 		}
 		_ = global.RemoveObsPromTargetFile("terraform-bis")
 		fmt.Println("✅ Terraform observability artifacts configured.")
+
+		if obsCustomJobName != "" {
+			targetsDir := global.ObsTargetsDir()
+			if err := registerCustomTFEJob(engine, obsCustomJobName, obsCustomMetricsPath); err != nil {
+				fmt.Printf("⚠️  Custom Prometheus job registration failed: %v\n", err)
+			} else {
+				fmt.Printf("✅ Custom Prometheus job '%s' registered (metrics path: %s).\n", obsCustomJobName, obsCustomMetricsPath)
+				fmt.Printf("   📄 Drop your target file at: %s\n", filepath.Join(targetsDir, obsCustomJobName+".json"))
+				fmt.Println("   Format: [{\"targets\":[\"host:port\"],\"labels\":{\"job\":\"" + obsCustomJobName + "\"}}]")
+			}
+		}
 	},
 }
 
@@ -372,10 +389,69 @@ func init() {
 	bindTFETargetFlag(terraformObsDeleteCmd)
 	bindTFETargetFlag(terraformObsStatusCmd)
 
+	for _, cmd := range []*cobra.Command{terraformObsCreateCmd, terraformObsUpdateCmd} {
+		cmd.Flags().StringVar(&obsCustomJobName, "job-name", "", "Custom Prometheus job name for a non-standard TFE metrics endpoint")
+		cmd.Flags().StringVar(&obsCustomMetricsPath, "metrics-path", "/metrics", "Metrics path for the custom Prometheus job (only used when --job-name is set)")
+	}
+
 	terraformObsCmd.AddCommand(terraformObsCreateCmd)
 	terraformObsCmd.AddCommand(terraformObsUpdateCmd)
 	terraformObsCmd.AddCommand(terraformObsDeleteCmd)
 	terraformObsCmd.AddCommand(terraformObsStatusCmd)
 
 	Cmd.AddCommand(terraformObsCmd)
+}
+
+func registerCustomTFEJob(engine, jobName, metricsPath string) error {
+	targetsDir := global.ObsTargetsDir()
+	if targetsDir == "" {
+		return fmt.Errorf("could not resolve obs targets directory")
+	}
+
+	targetFile := jobName + ".json"
+	configPath := filepath.Join(filepath.Dir(targetsDir), "prometheus.yml")
+	if err := upsertPromJob(configPath, jobName, metricsPath, targetFile); err != nil {
+		return fmt.Errorf("prometheus config update failed: %w", err)
+	}
+
+	return reloadPrometheus(engine)
+}
+
+func upsertPromJob(configPath, jobName, metricsPath, targetFile string) error {
+	existing, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	jobBlock := strings.Join([]string{
+		fmt.Sprintf("  - job_name: '%s'", jobName),
+		fmt.Sprintf("    metrics_path: '%s'", metricsPath),
+		"    file_sd_configs:",
+		fmt.Sprintf("      - files: ['/etc/prometheus/targets/%s']", targetFile),
+		"        refresh_interval: 15s",
+	}, "\n")
+
+	content := string(existing)
+	jobHeader := fmt.Sprintf("  - job_name: '%s'", jobName)
+	if idx := strings.Index(content, jobHeader); idx != -1 {
+		// Replace existing job block: find start, find where next job begins or EOF
+		rest := content[idx+len(jobHeader):]
+		if nextIdx := strings.Index(rest, "\n  - job_name:"); nextIdx != -1 {
+			content = content[:idx] + rest[nextIdx+1:]
+		} else {
+			content = content[:idx]
+		}
+		content = strings.TrimRight(content, "\n") + "\n"
+	}
+
+	content = strings.TrimRight(content, "\n") + "\n" + jobBlock + "\n"
+	return os.WriteFile(configPath, []byte(content), 0o644)
+}
+
+func reloadPrometheus(engine string) error {
+	out, err := exec.Command(engine, "exec", "hal-prometheus", "kill", "-HUP", "1").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("prometheus reload failed: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
 }

--- a/cmd/terraform/obs.go
+++ b/cmd/terraform/obs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -14,11 +13,6 @@ import (
 )
 
 const terraformObsProduct = "terraform"
-
-var (
-	obsCustomJobName     string
-	obsCustomMetricsPath string
-)
 
 // syncTerraformObsTargets keeps the canonical Terraform Prometheus target file in sync
 // with whichever TFE instances are currently running.
@@ -262,17 +256,6 @@ var terraformObsCreateCmd = &cobra.Command{
 		}
 		_ = global.RemoveObsPromTargetFile("terraform-bis")
 		fmt.Println("✅ Terraform observability artifacts configured.")
-
-		if obsCustomJobName != "" {
-			targetsDir := global.ObsTargetsDir()
-			if err := registerCustomTFEJob(engine, obsCustomJobName, obsCustomMetricsPath); err != nil {
-				fmt.Printf("⚠️  Custom Prometheus job registration failed: %v\n", err)
-			} else {
-				fmt.Printf("✅ Custom Prometheus job '%s' registered (metrics path: %s).\n", obsCustomJobName, obsCustomMetricsPath)
-				fmt.Printf("   📄 Drop your target file at: %s\n", filepath.Join(targetsDir, obsCustomJobName+".json"))
-				fmt.Println("   Format: [{\"targets\":[\"host:port\"],\"labels\":{\"job\":\"" + obsCustomJobName + "\"}}]")
-			}
-		}
 	},
 }
 
@@ -389,69 +372,10 @@ func init() {
 	bindTFETargetFlag(terraformObsDeleteCmd)
 	bindTFETargetFlag(terraformObsStatusCmd)
 
-	for _, cmd := range []*cobra.Command{terraformObsCreateCmd, terraformObsUpdateCmd} {
-		cmd.Flags().StringVar(&obsCustomJobName, "job-name", "", "Custom Prometheus job name for a non-standard TFE metrics endpoint")
-		cmd.Flags().StringVar(&obsCustomMetricsPath, "metrics-path", "/metrics", "Metrics path for the custom Prometheus job (only used when --job-name is set)")
-	}
-
 	terraformObsCmd.AddCommand(terraformObsCreateCmd)
 	terraformObsCmd.AddCommand(terraformObsUpdateCmd)
 	terraformObsCmd.AddCommand(terraformObsDeleteCmd)
 	terraformObsCmd.AddCommand(terraformObsStatusCmd)
 
 	Cmd.AddCommand(terraformObsCmd)
-}
-
-func registerCustomTFEJob(engine, jobName, metricsPath string) error {
-	targetsDir := global.ObsTargetsDir()
-	if targetsDir == "" {
-		return fmt.Errorf("could not resolve obs targets directory")
-	}
-
-	targetFile := jobName + ".json"
-	configPath := filepath.Join(filepath.Dir(targetsDir), "prometheus.yml")
-	if err := upsertPromJob(configPath, jobName, metricsPath, targetFile); err != nil {
-		return fmt.Errorf("prometheus config update failed: %w", err)
-	}
-
-	return reloadPrometheus(engine)
-}
-
-func upsertPromJob(configPath, jobName, metricsPath, targetFile string) error {
-	existing, err := os.ReadFile(configPath)
-	if err != nil {
-		return err
-	}
-
-	jobBlock := strings.Join([]string{
-		fmt.Sprintf("  - job_name: '%s'", jobName),
-		fmt.Sprintf("    metrics_path: '%s'", metricsPath),
-		"    file_sd_configs:",
-		fmt.Sprintf("      - files: ['/etc/prometheus/targets/%s']", targetFile),
-		"        refresh_interval: 15s",
-	}, "\n")
-
-	content := string(existing)
-	jobHeader := fmt.Sprintf("  - job_name: '%s'", jobName)
-	if idx := strings.Index(content, jobHeader); idx != -1 {
-		// Replace existing job block: find start, find where next job begins or EOF
-		rest := content[idx+len(jobHeader):]
-		if nextIdx := strings.Index(rest, "\n  - job_name:"); nextIdx != -1 {
-			content = content[:idx] + rest[nextIdx+1:]
-		} else {
-			content = content[:idx]
-		}
-		content = strings.TrimRight(content, "\n") + "\n"
-	}
-
-	content = strings.TrimRight(content, "\n") + "\n" + jobBlock + "\n"
-	return os.WriteFile(configPath, []byte(content), 0o644)
-}
-
-func reloadPrometheus(engine string) error {
-	out, err := exec.Command(engine, "exec", "hal-prometheus", "kill", "-HUP", "1").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("prometheus reload failed: %s", strings.TrimSpace(string(out)))
-	}
-	return nil
 }

--- a/cmd/terraform/twin.go
+++ b/cmd/terraform/twin.go
@@ -391,7 +391,7 @@ func buildTFETwinLayout() (tfeTwinLayout, error) {
 		CertDir:        filepath.Join(homeDir, ".hal", trimmedCore+"-certs"),
 		ProxyConfPath:  filepath.Join(homeDir, ".hal", trimmedCore+"-proxy.conf"),
 		UIURL:          fmt.Sprintf("https://%s:%d", hostname, tfeTwinHTTPSPort),
-		HealthURL:      fmt.Sprintf("https://%s:%d/_health_check", hostname, tfeTwinHTTPSPort),
+		HealthURL:      fmt.Sprintf("https://%s:%d/api/v1/health/readiness", hostname, tfeTwinHTTPSPort),
 	}, nil
 }
 

--- a/examples/tfe-cli-scenario/bootstrap.sh
+++ b/examples/tfe-cli-scenario/bootstrap.sh
@@ -23,7 +23,7 @@ curl_api() {
 
 # If the default hostname from .tfx.hcl is not reachable from inside the helper
 # network, fall back to the internal TFE service endpoint and recompute resolve args.
-if ! curl_api -o /dev/null "https://${HOST}/_health_check"; then
+if ! curl_api -o /dev/null "https://${HOST}/api/v1/health/readiness"; then
   HOST="hal-tfe:8443"
   API="https://${HOST}/api/v2"
   HOST_NAME="${HOST%%:*}"

--- a/internal/global/obs.go
+++ b/internal/global/obs.go
@@ -159,6 +159,181 @@ func RemoveObsPromTargetFile(product string) error {
 	return nil
 }
 
+// UpsertObsPromJob adds or replaces a named scrape job in prometheus.yml.
+// targetFile is the bare filename (e.g. "hcpt.json") that will be resolved
+// inside the container's /etc/prometheus/targets/ directory.
+// bearerToken is optional; when non-empty a bearer_token line is added to the job.
+func UpsertObsPromJob(configPath, jobName, metricsPath, bearerToken, targetFile string) error {
+	existing, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	lines := []string{
+		fmt.Sprintf("  - job_name: '%s'", jobName),
+		fmt.Sprintf("    metrics_path: '%s'", metricsPath),
+	}
+	if strings.TrimSpace(bearerToken) != "" {
+		lines = append(lines, fmt.Sprintf("    bearer_token: '%s'", strings.TrimSpace(bearerToken)))
+	}
+	lines = append(lines,
+		"    file_sd_configs:",
+		fmt.Sprintf("      - files: ['/etc/prometheus/targets/%s']", targetFile),
+		"        refresh_interval: 15s",
+	)
+	jobBlock := strings.Join(lines, "\n")
+
+	content := string(existing)
+	jobHeader := fmt.Sprintf("  - job_name: '%s'", jobName)
+	if idx := strings.Index(content, jobHeader); idx != -1 {
+		rest := content[idx+len(jobHeader):]
+		if nextIdx := strings.Index(rest, "\n  - job_name:"); nextIdx != -1 {
+			content = content[:idx] + rest[nextIdx+1:]
+		} else {
+			content = content[:idx]
+		}
+		content = strings.TrimRight(content, "\n") + "\n"
+	}
+
+	content = strings.TrimRight(content, "\n") + "\n" + jobBlock + "\n"
+	return os.WriteFile(configPath, []byte(content), 0o644)
+}
+
+// ReloadPrometheus sends SIGHUP to the hal-prometheus container to apply
+// config changes without restarting the container.
+func ReloadPrometheus(engine string) error {
+	out, err := exec.Command(engine, "exec", "hal-prometheus", "kill", "-HUP", "1").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("prometheus reload failed: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// UpsertObsPromJobFromFile reads a JSON file containing either a single scrape
+// job object or a {"scrape_configs":[...]} wrapper and upserts the first job
+// entry into the HAL prometheus.yml.  This handles arbitrary fields (scheme,
+// http_headers, static_configs, etc.) without HAL needing to know about each
+// one — the raw job block is injected verbatim.
+func UpsertObsPromJobFromFile(configPath, jobFilePath string) error {
+	raw, err := os.ReadFile(jobFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot read scrape config file: %w", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return fmt.Errorf("invalid scrape config file (expected JSON): %w", err)
+	}
+
+	// Support both bare job object and {"scrape_configs":[...]} wrapper.
+	jobMap := parsed
+	if sc, ok := parsed["scrape_configs"]; ok {
+		list, ok := sc.([]interface{})
+		if !ok || len(list) == 0 {
+			return fmt.Errorf("scrape_configs must be a non-empty array")
+		}
+		jobMap, ok = list[0].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("first entry in scrape_configs is not a valid job object")
+		}
+	}
+
+	jobName, _ := jobMap["job_name"].(string)
+	if strings.TrimSpace(jobName) == "" {
+		return fmt.Errorf("scrape config must contain a non-empty job_name")
+	}
+
+	// Render the job map as indented YAML lines (no external dependency).
+	jobLines := mapToYAMLLines(jobMap, 4)
+	// First line gets the list marker; it's already indented at 4 spaces from mapToYAMLLines.
+	// Convert to a properly indented list item under scrape_configs (2-space + "- ").
+	var sb strings.Builder
+	for i, line := range jobLines {
+		stripped := strings.TrimLeft(line, " ")
+		depth := len(line) - len(stripped)
+		if i == 0 {
+			sb.WriteString("  - " + stripped + "\n")
+		} else {
+			sb.WriteString(strings.Repeat(" ", depth) + stripped + "\n")
+		}
+	}
+	jobBlock := strings.TrimRight(sb.String(), "\n")
+
+	existing, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	content := string(existing)
+
+	// Remove existing block for this job name (all quoting variants).
+	for _, variant := range []string{
+		fmt.Sprintf("  - job_name: %s", jobName),
+		fmt.Sprintf("  - job_name: '%s'", jobName),
+		fmt.Sprintf(`  - job_name: "%s"`, jobName),
+	} {
+		if idx := strings.Index(content, variant); idx != -1 {
+			rest := content[idx+len(variant):]
+			if nextIdx := strings.Index(rest, "\n  - job_name:"); nextIdx != -1 {
+				content = content[:idx] + rest[nextIdx+1:]
+			} else {
+				content = content[:idx]
+			}
+			content = strings.TrimRight(content, "\n") + "\n"
+			break
+		}
+	}
+
+	content = strings.TrimRight(content, "\n") + "\n" + jobBlock + "\n"
+	return os.WriteFile(configPath, []byte(content), 0o644)
+}
+
+// mapToYAMLLines renders a map[string]interface{} as YAML lines with the given
+// base indentation.  Handles strings, numbers, bools, slices, and nested maps.
+func mapToYAMLLines(m map[string]interface{}, indent int) []string {
+	pad := strings.Repeat(" ", indent)
+	var lines []string
+	for k, v := range m {
+		lines = append(lines, mapValueToYAMLLines(k, v, pad, indent)...)
+	}
+	return lines
+}
+
+func mapValueToYAMLLines(key string, v interface{}, pad string, indent int) []string {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		lines := []string{pad + key + ":"}
+		for k2, v2 := range val {
+			lines = append(lines, mapValueToYAMLLines(k2, v2, pad+"  ", indent+2)...)
+		}
+		return lines
+	case []interface{}:
+		lines := []string{pad + key + ":"}
+		for _, item := range val {
+			switch iv := item.(type) {
+			case map[string]interface{}:
+				first := true
+				for k2, v2 := range iv {
+					if first {
+						sub := mapValueToYAMLLines(k2, v2, pad+"  ", indent+2)
+						sub[0] = pad + "- " + strings.TrimLeft(sub[0], " ")
+						lines = append(lines, sub...)
+						first = false
+					} else {
+						lines = append(lines, mapValueToYAMLLines(k2, v2, pad+"  ", indent+2)...)
+					}
+				}
+			default:
+				lines = append(lines, fmt.Sprintf("%s- %v", pad, iv))
+			}
+		}
+		return lines
+	case string:
+		return []string{fmt.Sprintf("%s%s: %q", pad, key, val)}
+	default:
+		return []string{fmt.Sprintf("%s%s: %v", pad, key, val)}
+	}
+}
+
 func EnsureGrafanaDashboardIfKnown(product string) error {
 	dashboardIDByProduct := map[string]int{
 		"terraform": 15630,

--- a/internal/integrations/tfe.go
+++ b/internal/integrations/tfe.go
@@ -72,17 +72,38 @@ func TFECreateInitialAdmin(baseURL, iactToken, username, email, password string)
 		return "", nil, 0, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(buf))
+	// TFE 2.x returns a 301 on the IACT endpoint.  Go's http.Client silently downgrades
+	// POST→GET on 301/302, losing the request body.  The hal-tfe-proxy (nginx) already
+	// rewrites the Location port back to :8443 via proxy_redirect, so we only need to
+	// stop Go from auto-following and re-POST to whatever Location the proxy hands back.
+	client := tfeHTTPClient()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	doPost := func(target string) (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(buf))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		return client.Do(req)
+	}
+
+	resp, err := doPost(endpoint)
 	if err != nil {
 		return "", nil, 0, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
 
-	client := tfeHTTPClient()
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", nil, 0, err
+	if resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 307 || resp.StatusCode == 308 {
+		resp.Body.Close()
+		if loc := resp.Header.Get("Location"); loc != "" {
+			resp, err = doPost(loc)
+			if err != nil {
+				return "", nil, 0, err
+			}
+		}
 	}
 	defer resp.Body.Close()
 

--- a/internal/skills/data/terraform/deploy/EXAMPLES.md
+++ b/internal/skills/data/terraform/deploy/EXAMPLES.md
@@ -44,7 +44,7 @@ User: I use Podman rootless and TFE health works but /app keeps looping.
 Assistant:
 
     hal terraform create
-    curl -k -I https://tfe.localhost:8443/_health_check
+    curl -k -I https://tfe.localhost:8443/api/v1/health/readiness
     curl -k -I https://tfe.localhost:8443/app
 
 Assistant: HAL deploy includes a local proxy layer that rewrites TFE canonical redirects for `:8443`, so `/app` should stop self-looping without changing host sysctl settings.


### PR DESCRIPTION
obs: add --scrape-config-path and safe hal obs update short-circuit

--scrape-config-path <file> added to hal obs create/update — reads a JSON file (bare scrape job object or {"scrape_configs":[...]} wrapper), merges the job verbatim into prometheus.yml, and SIGHUPs Prometheus. Handles arbitrary Prometheus job fields (scheme, http_headers, static_configs, etc.) without HAL needing to know about each one.

hal obs update no longer destroys the stack when only --scrape-config-path or [--job-name](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is passed. The command short-circuits to a prometheus.yml-only edit + reload, leaving all containers and config untouched. The full stack rebuild only triggers when neither job flag is set (original behavior).

No new module dependencies — uses encoding/json + stdlib only.

Close #34
Close #32 