### PR TITLE
Fix/health command

### DIFF
--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -89,16 +89,16 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
     - Task worker agent-run config must keep `/tmp/terraform` writable (not read-only) so remote plans can download Terraform binaries.
     - TFE API responses can emit archivist object links without `:8443`; proxy response rewriting keeps UI/raw plan/apply log links host-reachable.
     - `hal terraform vcs-workflow enable` should describe validation in terms of pushing a new commit to `main`; tag creation alone is not a reliable first-run trigger when the tagged SHA was already ingested from branch pushes.
-- `hal status` is a CRUD product that manages the `hal-status` sidecar container:
-    - `hal status create` / `hal status update` / `hal status delete` are the operator surface.
-    - `hal status update` is the manual escape hatch: refreshes the snapshot for the currently running ecosystem (e.g. after deploying a product extension outside the normal lifecycle).
-    - `hal status _serve` is a hidden internal command run inside the `hal-status` container — do not surface it to users.
-    - The `hal-status` container reuses `hashimiche/hal-mcp:latest` (same image as `hal-mcp`) with `--entrypoint /usr/local/bin/hal` and `status _serve` as args.
-    - It reads a frozen `HAL_STATUS_DATA` JSON env var at startup and serves it at `http://hal-status:9001/api/status` on `hal-net`.
-    - The snapshot is built on the **host** (which has engine socket access) by `global.RefreshHalStatus(engine)`, injected as an env var, then the container is recreated. The container itself never touches the engine.
-    - `global.RefreshHalStatus(engine)` is called after every product lifecycle event that changes ecosystem state: all product `create`/`delete` commands, and all vault/boundary extension enable/disable commands (`vault k8s`, `vault oidc`, `vault jwt`, `vault ldap`, `vault database`, `boundary mariadb`, `boundary ssh`).
-    - `RefreshHalStatus` is a no-op if `hal-net` does not exist or the `hashimiche/hal-mcp:latest` image is not present — safe to call unconditionally.
-    - HAL Plus fetches `http://hal-status:9001/api/status` as its primary product state source (via `fetchHalStatusProducts()` in `server/index.mjs`), with `fallbackProductsFromEndpoints()` as a fallback for local dev without containers.
+- `hal health` is a CRUD product that manages the `hal-health` sidecar container:
+    - `hal health create` / `hal health update` / `hal health delete` are the operator surface.
+    - `hal health update` is the manual escape hatch: refreshes the snapshot for the currently running ecosystem (e.g. after deploying a product extension outside the normal lifecycle).
+    - `hal health _serve` is a hidden internal command run inside the `hal-health` container — do not surface it to users.
+    - The `hal-health` container reuses `hashimiche/hal-mcp:latest` (same image as `hal-mcp`) with `--entrypoint /usr/local/bin/hal` and `health _serve` as args.
+    - It reads a frozen `HAL_HEALTH_DATA` JSON env var at startup and serves it at `http://hal-health:9001/api/status` on `hal-net`.
+    - The snapshot is built on the **host** (which has engine socket access) by `global.RefreshHalHealth(engine)`, injected as an env var, then the container is recreated. The container itself never touches the engine.
+    - `global.RefreshHalHealth(engine)` is called after every product lifecycle event that changes ecosystem state: all product `create`/`delete` commands, and all vault/boundary extension enable/disable commands (`vault k8s`, `vault oidc`, `vault jwt`, `vault ldap`, `vault database`, `boundary mariadb`, `boundary ssh`).
+    - `RefreshHalHealth` is a no-op if `hal-net` does not exist or the `hashimiche/hal-mcp:latest` image is not present — safe to call unconditionally.
+    - HAL Plus fetches `http://hal-health:9001/api/status` as its primary product state source (via `fetchHalStatusProducts()` in `server/index.mjs`), with `fallbackProductsFromEndpoints()` as a fallback for local dev without containers.
     - The snapshot shape: `{ timestamp, engine, products: [{ product, state, health, reason, endpoint, containers, features: [{ feature, state, health, reason }] }] }`.
 - Shared runtime helpers live under `internal/global`, especially engine detection and network management.
 - Engine resource advisory helpers live under `internal/global`; reuse them instead of open-coding engine-specific capacity checks in individual commands.

--- a/cmd/boundary/create.go
+++ b/cmd/boundary/create.go
@@ -106,7 +106,7 @@ var deployCmd = &cobra.Command{
 
 		fmt.Println()
 		fmt.Println("✅ Boundary Controller & Worker are up!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Println("   🔗 UI Address: http://boundary.localhost:9200")
 		fmt.Println("   👤 Login:      admin / password")

--- a/cmd/boundary/delete.go
+++ b/cmd/boundary/delete.go
@@ -52,7 +52,7 @@ var destroyCmd = &cobra.Command{
 			fmt.Printf("⚠️  Could not remove Boundary observability target file: %v\n", err)
 		}
 		fmt.Println("✅ Boundary environment destroyed successfully!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 	},
 }
 

--- a/cmd/boundary/mariadb.go
+++ b/cmd/boundary/mariadb.go
@@ -213,7 +213,7 @@ func bootstrapBoundaryMariaDB(targetHost string) error {
 
 	fmt.Println("✅ Boundary Academy Lab Bootstrapped!")
 	if eng, err := global.DetectEngine(); err == nil {
-		global.RefreshHalStatus(eng)
+		global.RefreshHalHealth(eng)
 	}
 	return nil
 }

--- a/cmd/boundary/ssh.go
+++ b/cmd/boundary/ssh.go
@@ -375,7 +375,7 @@ func bootstrapBoundarySSH(targetIP string) error {
 
 	fmt.Println("✅ Boundary SSH target successfully bootstrapped!")
 	if eng, err := global.DetectEngine(); err == nil {
-		global.RefreshHalStatus(eng)
+		global.RefreshHalHealth(eng)
 	}
 	fmt.Println("\n💡 Test your access:")
 	fmt.Println("   1. Log in to UI (http://boundary.localhost:9200)")

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -46,7 +46,7 @@ var catalogCmd = &cobra.Command{
 		fmt.Println("🔧 RUNTIME UTILITIES")
 		fmt.Println("   - capacity  Engine capacity view + per-stack footprint estimates")
 		fmt.Println("   - status    Global ecosystem status snapshot across all products")
-		fmt.Println("   - health    hal-status sidecar lifecycle (create / update / delete)")
+		fmt.Println("   - health    hal-health sidecar lifecycle (create / update / delete)")
 		fmt.Println("   - delete    Tear down all HAL infrastructure globally")
 
 		fmt.Println()

--- a/cmd/consul/create.go
+++ b/cmd/consul/create.go
@@ -65,7 +65,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		fmt.Println("✅ Standalone Consul Server is up!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 		fmt.Println("   🔗 UI Address: http://consul.localhost:8500")
 		fmt.Println("\n💡 Tip: Use this to test the KV store or learn the API.")
 		fmt.Println("   (For real workloads, use 'hal nomad create --with-consul' instead!)")

--- a/cmd/consul/delete.go
+++ b/cmd/consul/delete.go
@@ -37,7 +37,7 @@ var destroyCmd = &cobra.Command{
 			fmt.Printf("⚠️  Could not remove Consul observability target file: %v\n", err)
 		}
 		fmt.Println("✅ Consul environment destroyed successfully!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 	},
 }
 

--- a/cmd/halhealth/halhealth.go
+++ b/cmd/halhealth/halhealth.go
@@ -17,8 +17,8 @@ import (
 // Cmd is the root cobra command for `hal health`.
 var Cmd = &cobra.Command{
 	Use:   "health",
-	Short: "Manage the hal-status runtime container",
-	Long:  `Create, update, or delete the hal-status container that serves live ecosystem state to hal-plus and other consumers.`,
+	Short: "Manage the hal-health runtime container",
+	Long:  `Create, update, or delete the hal-health container that serves live ecosystem state to hal-plus and other consumers.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -26,7 +26,7 @@ var Cmd = &cobra.Command{
 
 var createCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create (or recreate) the hal-status container",
+	Short: "Create (or recreate) the hal-health container",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		engine, err := global.DetectEngine()
@@ -36,19 +36,19 @@ var createCmd = &cobra.Command{
 		}
 		if global.DryRun {
 			fmt.Printf("[DRY RUN] Would create %s container on hal-net (port %d)\n",
-				global.HalStatusContainerName, global.HalStatusPort)
+				global.HalHealthContainerName, global.HalHealthPort)
 			return
 		}
 		global.EnsureNetwork(engine)
-		global.RefreshHalStatus(engine)
-		fmt.Println("✅ hal-status container created.")
-		fmt.Printf("   API: http://hal-status:%d/api/status (from hal-net)\n", global.HalStatusPort)
+		global.RefreshHalHealth(engine)
+		fmt.Println("✅ hal-health container created.")
+		fmt.Printf("   API: http://hal-health:%d/api/status (from hal-net)\n", global.HalHealthPort)
 	},
 }
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Refresh the hal-status snapshot (re-inspect the ecosystem and replace the container)",
+	Short: "Refresh the hal-health snapshot (re-inspect the ecosystem and replace the container)",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		engine, err := global.DetectEngine()
@@ -57,17 +57,17 @@ var updateCmd = &cobra.Command{
 			return
 		}
 		if global.DryRun {
-			fmt.Printf("[DRY RUN] Would refresh %s snapshot\n", global.HalStatusContainerName)
+			fmt.Printf("[DRY RUN] Would refresh %s snapshot\n", global.HalHealthContainerName)
 			return
 		}
-		global.RefreshHalStatus(engine)
-		fmt.Println("✅ hal-status snapshot refreshed.")
+		global.RefreshHalHealth(engine)
+		fmt.Println("✅ hal-health snapshot refreshed.")
 	},
 }
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Remove the hal-status container",
+	Short: "Remove the hal-health container",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		engine, err := global.DetectEngine()
@@ -76,36 +76,36 @@ var deleteCmd = &cobra.Command{
 			return
 		}
 		if global.DryRun {
-			fmt.Printf("[DRY RUN] Would remove container %s\n", global.HalStatusContainerName)
+			fmt.Printf("[DRY RUN] Would remove container %s\n", global.HalHealthContainerName)
 			return
 		}
-		global.RemoveHalStatus(engine)
-		fmt.Printf("✅ %s removed.\n", global.HalStatusContainerName)
+		global.RemoveHalHealth(engine)
+		fmt.Printf("✅ %s removed.\n", global.HalHealthContainerName)
 	},
 }
 
 // serveCmd is hidden — called by the container entrypoint, not the user.
-// It reads HAL_STATUS_DATA and serves a minimal JSON + HTML status API.
+// It reads HAL_HEALTH_DATA and serves a minimal JSON + HTML health API.
 var serveCmd = &cobra.Command{
 	Use:    "_serve",
-	Short:  "Internal: serve HAL_STATUS_DATA over HTTP (used by the hal-status container)",
+	Short:  "Internal: serve HAL_HEALTH_DATA over HTTP (used by the hal-health container)",
 	Hidden: true,
 	Args:   cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		raw := os.Getenv("HAL_STATUS_DATA")
+		raw := os.Getenv("HAL_HEALTH_DATA")
 		if raw == "" {
-			fmt.Fprintln(os.Stderr, "HAL_STATUS_DATA not set")
+			fmt.Fprintln(os.Stderr, "HAL_HEALTH_DATA not set")
 			os.Exit(1)
 		}
 
 		var snap global.StatusSnapshot
 		if err := json.Unmarshal([]byte(raw), &snap); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to parse HAL_STATUS_DATA: %v\n", err)
+			fmt.Fprintf(os.Stderr, "failed to parse HAL_HEALTH_DATA: %v\n", err)
 			os.Exit(1)
 		}
 
-		port := global.HalStatusPort
-		if v := os.Getenv("HAL_STATUS_PORT"); v != "" {
+		port := global.HalHealthPort
+		if v := os.Getenv("HAL_HEALTH_PORT"); v != "" {
 			if p, err := strconv.Atoi(v); err == nil {
 				port = p
 			}
@@ -159,11 +159,11 @@ var serveCmd = &cobra.Command{
 				return
 			}
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			fmt.Fprintf(w, htmlStatusPage(snap))
+			fmt.Fprintf(w, htmlHealthPage(snap))
 		})
 
 		addr := fmt.Sprintf(":%d", port)
-		fmt.Printf("hal-status serving on %s (snapshot: %s)\n", addr, snap.Timestamp)
+		fmt.Printf("hal-health serving on %s (snapshot: %s)\n", addr, snap.Timestamp)
 		srv := &http.Server{
 			Addr:         addr,
 			Handler:      mux,
@@ -177,7 +177,7 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func htmlStatusPage(snap global.StatusSnapshot) string {
+func htmlHealthPage(snap global.StatusSnapshot) string {
 	var rows strings.Builder
 	for _, p := range snap.Products {
 		stateColor := "#e74c3c"
@@ -205,14 +205,14 @@ func htmlStatusPage(snap global.StatusSnapshot) string {
 	}
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>HAL Status</title>
+<head><meta charset="UTF-8"><title>HAL Health</title>
 <style>body{font-family:monospace;background:#111;color:#eee;padding:24px}
 table{border-collapse:collapse;width:100%%}
 th{text-align:left;padding:8px 12px;border-bottom:1px solid #333;color:#aaa;font-size:0.8em;text-transform:uppercase}
 tr:hover{background:#1a1a1a}a{color:#7c3aed}</style>
 </head>
 <body>
-<h2 style="color:#7c3aed">HAL Ecosystem Status</h2>
+<h2 style="color:#7c3aed">HAL Ecosystem Health</h2>
 <p style="color:#aaa;font-size:0.85em">Snapshot: %s &nbsp;·&nbsp; Engine: %s</p>
 <table>
 <thead><tr><th>Product</th><th>State</th><th>Endpoint</th><th>Features</th></tr></thead>

--- a/cmd/health/health.go
+++ b/cmd/health/health.go
@@ -159,7 +159,7 @@ var serveCmd = &cobra.Command{
 				return
 			}
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			fmt.Fprintf(w, htmlHealthPage(snap))
+			fmt.Fprint(w, htmlHealthPage(snap))
 		})
 
 		addr := fmt.Sprintf(":%d", port)

--- a/cmd/health/health.go
+++ b/cmd/health/health.go
@@ -1,4 +1,4 @@
-package halhealth
+package health
 
 import (
 	"encoding/json"

--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -236,7 +236,7 @@ providers:
 
 		fmt.Println()
 		fmt.Println("✅ Observability Stack Deployed Successfully!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Println("🔗 Grafana:    http://grafana.localhost:3000 (Auto-logged in as Admin)")
 		fmt.Println("🔗 Prometheus: http://prometheus.localhost:9090")

--- a/cmd/observability/delete.go
+++ b/cmd/observability/delete.go
@@ -49,7 +49,7 @@ var destroyCmd = &cobra.Command{
 
 		global.CleanNetworkIfEmpty(engine)
 		fmt.Println("✅ Observability environment destroyed successfully!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 	},
 }
 

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -125,7 +125,7 @@ var createCmd = &cobra.Command{
 		}
 
 		fmt.Println("✅ HAL Plus runtime created successfully.")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 		fmt.Printf("🐳 Engine:       %s\n", engine)
 		fmt.Printf("🐳 HAL Plus:     %s\n", plusImage)
 		fmt.Printf("🐳 HAL MCP:      %s\n", mcpImage)

--- a/cmd/plus/delete.go
+++ b/cmd/plus/delete.go
@@ -29,7 +29,7 @@ var deleteCmd = &cobra.Command{
 		for _, c := range []string{halPlusContainerName, halMCPContainerName} {
 			_ = exec.Command(engine, "rm", "-f", c).Run()
 		}
-		global.RemoveHalStatus(engine)
+		global.RemoveHalHealth(engine)
 
 		global.CleanNetworkIfEmpty(engine)
 		fmt.Println("✅ HAL Plus runtime deleted.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 
 	"hal/cmd/boundary"
 	"hal/cmd/consul"
-	"hal/cmd/halhealth"
+	"hal/cmd/health"
 	"hal/cmd/mcp"
 	"hal/cmd/nomad"
 	"hal/cmd/observability"
@@ -53,5 +53,5 @@ func init() {
 	rootCmd.AddCommand(plus.Cmd)
 	rootCmd.AddCommand(terraform.Cmd)
 	rootCmd.AddCommand(observability.Cmd)
-	rootCmd.AddCommand(halhealth.Cmd)
+	rootCmd.AddCommand(health.Cmd)
 }

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -301,7 +301,7 @@ http {
 		}
 
 		fmt.Printf("\n✅ Terraform Enterprise %s is UP!\n", tfeVersion)
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 		fmt.Println("---------------------------------------------------------")
 		fmt.Printf("🔗 UI Address:   %s\n", uiURL)
 		fmt.Printf("🗂️  MinIO API:    http://127.0.0.1:%d\n", minioAPIPort)

--- a/cmd/terraform/delete.go
+++ b/cmd/terraform/delete.go
@@ -173,7 +173,7 @@ var destroyCmd = &cobra.Command{
 
 		if !global.DryRun {
 			fmt.Println("\n✅ TFE environment wiped. You are ready for a clean 'hal terraform create'.")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 		}
 	},
 }

--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -162,7 +162,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		fmt.Println("✅ Vault is up and running in Dev mode!")
-		global.RefreshHalStatus(engine)
+		global.RefreshHalHealth(engine)
 		fmt.Printf("   🏗️  Edition: %s\n", strings.ToUpper(vaultEdition))
 		fmt.Println("   🔗 UI Address: http://vault.localhost:8200")
 		fmt.Println("   🔑 Root Token: root")

--- a/cmd/vault/database.go
+++ b/cmd/vault/database.go
@@ -253,7 +253,7 @@ var vaultDatabaseCmd = &cobra.Command{
 			password := secret.Data["password"].(string)
 
 			fmt.Println("\n✅ Enterprise Dynamic Database Credentials Generated!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Printf("🔗 Database Host: %s:%s\n", hostAlias, containerPort)
 			fmt.Println("👤 JIT Username:  " + username)

--- a/cmd/vault/delete.go
+++ b/cmd/vault/delete.go
@@ -84,7 +84,7 @@ var vaultDestroyCmd = &cobra.Command{
 
 		if !global.DryRun {
 			fmt.Println("\n✅ Vault instance and all extensions destroyed successfully!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 		}
 	},
 }

--- a/cmd/vault/jwt.go
+++ b/cmd/vault/jwt.go
@@ -133,7 +133,7 @@ var vaultJwtCmd = &cobra.Command{
 				_ = exec.Command(engine, "rm", "-f", "hal-gitlab", "hal-gitlab-runner").Run()
 				_ = global.ClearSharedService("gitlab")
 				fmt.Println("✅ GitLab containers removed and Vault API cleaned up.")
-				global.RefreshHalStatus(engine)
+				global.RefreshHalHealth(engine)
 			}
 
 			if jwtDisable && !global.DryRun {
@@ -188,7 +188,7 @@ var vaultJwtCmd = &cobra.Command{
 				return
 			}
 			fmt.Println("\n✅ GitLab API is online!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 			// 1. Authenticate via OAuth
 			fmt.Println("⚙️  Authenticating root account via API...")
 			apiToken := getGitLabToken("http://127.0.0.1:8080/oauth/token")

--- a/cmd/vault/k8s.go
+++ b/cmd/vault/k8s.go
@@ -227,7 +227,7 @@ var vaultK8sCmd = &cobra.Command{
 				_ = exec.Command("kind", "delete", "cluster").Run()
 
 				fmt.Println("✅ Kubernetes environment destroyed successfully!")
-				global.RefreshHalStatus(engine)
+				global.RefreshHalHealth(engine)
 			}
 
 			if k8sDisable && !global.DryRun {
@@ -769,7 +769,7 @@ spec:
 			_ = exec.Command("kubectl", "rollout", "status", "deployment/hal-web-proxy", "-n", "app1", "--timeout=180s").Run()
 
 			fmt.Println("\n✅ Kubernetes Secret Zero Environment Ready!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Printf("🌐 [%s]\n", modeTitle)
 			fmt.Println("   Endpoint: http://web.localhost:8088")

--- a/cmd/vault/ldap.go
+++ b/cmd/vault/ldap.go
@@ -138,7 +138,7 @@ var vaultLdapCmd = &cobra.Command{
 
 				if ldapDisable {
 					fmt.Println("✅ LDAP environment destroyed successfully!")
-					global.RefreshHalStatus(engine)
+					global.RefreshHalHealth(engine)
 				}
 			}
 
@@ -283,7 +283,7 @@ userPassword: {{.Password}}`,
 			_, _ = client.Logical().Write("ldap/rotate-root", map[string]interface{}{})
 
 			fmt.Println("\n✅ LDAP Infrastructure & Vault Integration Complete!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Println("🔗 phpLDAPadmin UI: https://phpldapadmin.localhost:8082")
 			fmt.Println("   Login DN: cn=admin,dc=hal,dc=local")

--- a/cmd/vault/oidc.go
+++ b/cmd/vault/oidc.go
@@ -134,7 +134,7 @@ var vaultOidcCmd = &cobra.Command{
 
 				if oidcDisable {
 					fmt.Println("✅ OIDC integration, KV engine, and identity data successfully removed!")
-					global.RefreshHalStatus(engine)
+					global.RefreshHalHealth(engine)
 				}
 			}
 
@@ -320,7 +320,7 @@ path "kv-oidc/metadata/team1" { capabilities = ["read", "list"] }
 			setupExternalGroup(client, "user-ro", oidcAccessor, []string{"user-ro"})
 
 			fmt.Println("\n✅ Vault OIDC & KV Integration Complete!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Println("🔗 UI Login:    http://vault.localhost:8200")
 			fmt.Println("                (Select 'OIDC' and leave the role blank)")

--- a/cmd/vault/os.go
+++ b/cmd/vault/os.go
@@ -122,7 +122,7 @@ var vaultOSCmd = &cobra.Command{
 
 				if osDisable {
 					fmt.Println("✅ OS secret engine environment destroyed successfully!")
-					global.RefreshHalStatus(engine)
+					global.RefreshHalHealth(engine)
 				}
 			}
 
@@ -348,7 +348,7 @@ var vaultOSCmd = &cobra.Command{
 			password := secret.Data["password"].(string)
 
 			fmt.Println("\n✅ Vault OS Secret Engine Integration Complete!")
-			global.RefreshHalStatus(engine)
+			global.RefreshHalHealth(engine)
 			fmt.Println("---------------------------------------------------------")
 			fmt.Printf("🔗 VM Address  : %s\n", vmIP)
 			fmt.Printf("👤 Users       : mgmt-user (parent), demouser, appadmin\n")

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -14,8 +14,8 @@ var (
 )
 
 const (
-	HalStatusContainerName = "hal-status"
-	HalStatusPort          = 9001
+	HalHealthContainerName = "hal-health"
+	HalHealthPort          = 9001
 )
 
 func DetectEngine() (string, error) {

--- a/internal/global/status_snapshot.go
+++ b/internal/global/status_snapshot.go
@@ -9,9 +9,9 @@ import (
 	"time"
 )
 
-// HalStatusImage is the container image used for hal-status.
+// HalHealthImage is the container image used for hal-health.
 // Reuses the hal-mcp image since it already embeds the hal binary.
-const HalStatusImage = "ghcr.io/hashimiche/hal-mcp:latest"
+const HalHealthImage = "ghcr.io/hashimiche/hal-mcp:latest"
 
 // ProductFeature represents a single feature of a product.
 type ProductFeature struct {
@@ -32,7 +32,7 @@ type ProductStatus struct {
 	Features   []ProductFeature `json:"features"`
 }
 
-// StatusSnapshot is the full runtime snapshot written into hal-status.
+// StatusSnapshot is the full runtime snapshot served by the hal-health container.
 type StatusSnapshot struct {
 	Timestamp string          `json:"timestamp"`
 	Engine    string          `json:"engine"`
@@ -101,19 +101,19 @@ func BuildStatusSnapshot(engine string) ([]byte, error) {
 	return json.Marshal(snap)
 }
 
-// RefreshHalStatus (re)creates the hal-status container with a fresh snapshot.
+// RefreshHalHealth (re)creates the hal-health container with a fresh snapshot.
 // It is safe to call from any product create/update/delete — it is a no-op when
 // hal-net does not exist yet (hal-plus has not been deployed) and silently skips
 // when the hal-mcp image is not present locally.
-func RefreshHalStatus(engine string) {
+func RefreshHalHealth(engine string) {
 	// Only run when hal-net exists — avoids creating it just for the status container.
 	netOut, _ := exec.Command(engine, "network", "ls", "--format", "{{.Name}}").Output()
 	if !strings.Contains(string(netOut), "hal-net") {
 		return
 	}
 
-	// Only run when the image is available — hal-status is optional.
-	imgOut, _ := exec.Command(engine, "images", "-q", HalStatusImage).Output()
+	// Only run when the image is available — hal-health is optional.
+	imgOut, _ := exec.Command(engine, "images", "-q", HalHealthImage).Output()
 	if strings.TrimSpace(string(imgOut)) == "" {
 		return
 	}
@@ -121,37 +121,37 @@ func RefreshHalStatus(engine string) {
 	data, err := BuildStatusSnapshot(engine)
 	if err != nil {
 		if Debug {
-			fmt.Printf("[DEBUG] hal-status: snapshot build failed: %v\n", err)
+			fmt.Printf("[DEBUG] hal-health: snapshot build failed: %v\n", err)
 		}
 		return
 	}
 
 	// Remove old container (ignore errors) and start fresh with the new snapshot.
-	_ = exec.Command(engine, "rm", "-f", HalStatusContainerName).Run()
+	_ = exec.Command(engine, "rm", "-f", HalHealthContainerName).Run()
 
 	args := []string{
 		"run", "-d",
-		"--name", HalStatusContainerName,
+		"--name", HalHealthContainerName,
 		"--network", "hal-net",
 		"--entrypoint", "/usr/local/bin/hal",
-		"-e", fmt.Sprintf("HAL_STATUS_DATA=%s", string(data)),
-		"-e", fmt.Sprintf("HAL_STATUS_PORT=%d", HalStatusPort),
-		HalStatusImage,
+		"-e", fmt.Sprintf("HAL_HEALTH_DATA=%s", string(data)),
+		"-e", fmt.Sprintf("HAL_HEALTH_PORT=%d", HalHealthPort),
+		HalHealthImage,
 		"health", "_serve",
 	}
 	if out, err := exec.Command(engine, args...).CombinedOutput(); err != nil {
 		if Debug {
-			fmt.Printf("[DEBUG] hal-status: container start failed: %v\n%s\n", err, string(out))
+			fmt.Printf("[DEBUG] hal-health: container start failed: %v\n%s\n", err, string(out))
 		}
 	} else if Debug {
-		fmt.Printf("[DEBUG] hal-status: container refreshed (snapshot ts=%s)\n",
+		fmt.Printf("[DEBUG] hal-health: container refreshed (snapshot ts=%s)\n",
 			time.Now().UTC().Format(time.RFC3339))
 	}
 }
 
-// RemoveHalStatus stops and removes the hal-status container.
-func RemoveHalStatus(engine string) {
-	_ = exec.Command(engine, "rm", "-f", HalStatusContainerName).Run()
+// RemoveHalHealth stops and removes the hal-health container.
+func RemoveHalHealth(engine string) {
+	_ = exec.Command(engine, "rm", "-f", HalHealthContainerName).Run()
 }
 
 func buildProductStatus(engine, product string, containers []string, features map[string]string, endpoint string) ProductStatus {

--- a/internal/skills/data/health/SKILL.md
+++ b/internal/skills/data/health/SKILL.md
@@ -25,8 +25,8 @@ hal health delete    # remove the hal-health container
 
 - The `hal-health` container reuses `ghcr.io/hashimiche/hal-mcp:latest` with `--entrypoint /usr/local/bin/hal` and `health _serve` as args.
 - The snapshot shape: `{ timestamp, engine, products: [{ product, state, health, reason, endpoint, containers, features: [...] }] }`.
-- The container is a no-op host — it reads the `HAL_STATUS_DATA` env var injected at start time and never touches the container engine socket.
-- `global.RefreshHalStatus` is called automatically after all product `create`/`delete` commands — manual `hal health update` is only needed for out-of-band changes.
+- The container is a no-op host — it reads the `HAL_HEALTH_DATA` env var injected at start time and never touches the container engine socket.
+- `global.RefreshHalHealth` is called automatically after all product `create`/`delete` commands — manual `hal health update` is only needed for out-of-band changes.
 - `hal health` is a no-op if `hal-net` does not exist or `ghcr.io/hashimiche/hal-mcp:latest` is not present locally.
 
 ## Lab Assumptions


### PR DESCRIPTION
## fix: rename hal-status → hal-health across the health command

The `hal health` command was managing a container named `hal-status` and using `HAL_STATUS_*` env vars, creating confusion with the unrelated `hal status` command. This PR renames everything scoped to the health command to use `health` consistently.

### Changes

- `cmd/halhealth/halstatus.go` → `cmd/health/health.go` (directory, file, and package all renamed)
- `internal/global/global.go`: `HalStatusContainerName = "hal-status"` → `HalHealthContainerName = "hal-health"`, `HalStatusPort` → `HalHealthPort`
- `internal/global/status_snapshot.go`: `HalStatusImage` → `HalHealthImage`, `RefreshHalStatus` → `RefreshHalHealth`, `RemoveHalStatus` → `RemoveHalHealth`, env vars `HAL_STATUS_DATA/PORT` → `HAL_HEALTH_DATA/PORT`, debug log strings updated
- `cmd/root.go`: updated import path and `AddCommand` call
- All 21 product command callers of `RefreshHalHealth` / `RemoveHalHealth` updated automatically via semantic rename (vault, consul, boundary, terraform, observability, plus)
- `cmd/catalog.go`: updated health command description
- `LLM_CONTEXT.md`, both `SKILL.md` copies, `hal-plus/design.md`: updated all references


close #30 