### PR TITLE
feat: split all container image refs into <component>-image + <compon…

### DIFF
--- a/cmd/boundary/create.go
+++ b/cmd/boundary/create.go
@@ -14,7 +14,9 @@ import (
 
 var (
 	boundaryVersion    string
+	boundaryImage      string
 	pgVersion          string
+	pgImage            string
 	boundaryUpdate     bool
 	boundaryJoinConsul bool
 )
@@ -45,7 +47,7 @@ var deployCmd = &cobra.Command{
 
 		global.EnsureNetwork(engine)
 
-		fmt.Printf("⚙️  Provisioning Boundary Control Plane Database (postgres:%s-alpine)...\n", pgVersion)
+		fmt.Printf("⚙️  Provisioning Boundary Control Plane Database (%s:%s)...\n", pgImage, pgVersion)
 		backendArgs := []string{
 			"run", "-d",
 			"--name", "hal-boundary-backend",
@@ -53,7 +55,7 @@ var deployCmd = &cobra.Command{
 			"-e", "POSTGRES_USER=boundary",
 			"-e", "POSTGRES_PASSWORD=boundary",
 			"-e", "POSTGRES_DB=boundary",
-			fmt.Sprintf("postgres:%s-alpine", pgVersion),
+			fmt.Sprintf("%s:%s", pgImage, pgVersion),
 		}
 
 		if global.DryRun {
@@ -80,7 +82,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		boundaryArgs = append(boundaryArgs,
-			fmt.Sprintf("hashicorp/boundary:%s", boundaryVersion),
+			fmt.Sprintf("%s:%s", boundaryImage, boundaryVersion),
 			"boundary", "dev",
 			"-api-listen-address=0.0.0.0:9200",
 			"-proxy-listen-address=0.0.0.0:9202",
@@ -162,8 +164,10 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&boundaryVersion, "version", "v", "0.15.2", "Boundary version to deploy")
-	cmd.Flags().StringVar(&pgVersion, "pg-version", "16", "PostgreSQL version for Boundary backend")
+	cmd.Flags().StringVarP(&boundaryVersion, "boundary-tag", "v", "0.15.2", "Boundary container image tag")
+	cmd.Flags().StringVar(&boundaryImage, "boundary-image", "hashicorp/boundary", "Boundary container image name")
+	cmd.Flags().StringVar(&pgVersion, "boundary-pg-tag", "16-alpine", "PostgreSQL image tag for Boundary backend")
+	cmd.Flags().StringVar(&pgImage, "boundary-pg-image", "postgres", "PostgreSQL image name for Boundary backend")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&boundaryUpdate, "update", "u", false, "Reconcile an existing Boundary deployment in place")
 	}

--- a/cmd/boundary/mariadb.go
+++ b/cmd/boundary/mariadb.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	mariadbEnable    bool
-	mariadbDisable   bool
-	mariadbUpdate    bool
-	mariadbWithVault bool
-	targetMariadbVer string
+	mariadbEnable     bool
+	mariadbDisable    bool
+	mariadbUpdate     bool
+	mariadbWithVault  bool
+	targetMariadbVer  string
+	targetMariadbImage string
 )
 
 var mariadbCmd = &cobra.Command{
@@ -100,7 +101,7 @@ var mariadbCmd = &cobra.Command{
 			} else {
 				fmt.Println("🚀 Deploying standalone MariaDB...")
 				global.EnsureNetwork(engine)
-				out, err = exec.Command(engine, "run", "-d", "--name", dbContainerName, "--network", "hal-net", "-p", "3306:3306", "-e", "MARIADB_ROOT_PASSWORD=password", "-e", "MARIADB_DATABASE=targetdb", "-e", "MARIADB_USER=admin", "-e", "MARIADB_PASSWORD=password", fmt.Sprintf("mariadb:%s", targetMariadbVer)).CombinedOutput()
+				out, err = exec.Command(engine, "run", "-d", "--name", dbContainerName, "--network", "hal-net", "-p", "3306:3306", "-e", "MARIADB_ROOT_PASSWORD=password", "-e", "MARIADB_DATABASE=targetdb", "-e", "MARIADB_USER=admin", "-e", "MARIADB_PASSWORD=password", fmt.Sprintf("%s:%s", targetMariadbImage, targetMariadbVer)).CombinedOutput()
 				if err != nil {
 					fmt.Printf("❌ Failed to start MariaDB container: %v\n%s\n", err, strings.TrimSpace(string(out)))
 					return
@@ -132,7 +133,8 @@ func init() {
 	_ = mariadbCmd.Flags().MarkHidden("disable")
 	_ = mariadbCmd.Flags().MarkHidden("update")
 	mariadbCmd.Flags().BoolVar(&mariadbWithVault, "with-vault", false, "Link with Vault Dynamic Creds")
-	mariadbCmd.Flags().StringVar(&targetMariadbVer, "mariadb-version", "11.4", "Version")
+	mariadbCmd.Flags().StringVar(&targetMariadbVer, "boundary-mariadb-tag", "11.4", "MariaDB container image tag")
+	mariadbCmd.Flags().StringVar(&targetMariadbImage, "boundary-mariadb-image", "mariadb", "MariaDB container image name")
 	Cmd.AddCommand(mariadbCmd)
 }
 

--- a/cmd/consul/create.go
+++ b/cmd/consul/create.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	consulVersion string
+	consulImage   string
 	consulUpdate  bool
 )
 
@@ -45,7 +46,7 @@ var deployCmd = &cobra.Command{
 			"--name", "hal-consul",
 			"--network", "hal-net",
 			"-p", "8500:8500", // The magic UI/API port
-			fmt.Sprintf("hashicorp/consul:%s", consulVersion),
+			fmt.Sprintf("%s:%s", consulImage, consulVersion),
 			"agent", "-server", "-ui", "-node=hal-server", "-bootstrap-expect=1", "-client=0.0.0.0",
 		}
 
@@ -83,7 +84,8 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&consulVersion, "version", "v", "1.15.0", "Consul version to deploy")
+	cmd.Flags().StringVarP(&consulVersion, "consul-tag", "v", "1.15.0", "Consul container image tag")
+	cmd.Flags().StringVar(&consulImage, "consul-image", "hashicorp/consul", "Consul container image name")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&consulUpdate, "update", "u", false, "Reconcile an existing Consul deployment in place")
 	}

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -54,11 +54,12 @@ const (
 )
 
 var (
-	createCommandName string
-	createBinaryPath  string
-	createJSONOnly    bool
-	createHTTPImage   bool
-	createHTTPTag     string
+	createCommandName   string
+	createBinaryPath    string
+	createJSONOnly      bool
+	createHTTPImage     bool
+	mcpContainerImage   string
+	mcpContainerTag     string
 	upTransport       string
 	upHTTPHost        string
 	upHTTPPort        int
@@ -87,20 +88,20 @@ var createCmd = &cobra.Command{
 				return
 			}
 
-			imageTag := strings.TrimSpace(createHTTPTag)
-			if imageTag == "" {
-				fmt.Println("❌ Image tag cannot be empty (use --http-tag).")
+			imageRef := strings.TrimSpace(mcpContainerImage) + ":" + strings.TrimSpace(mcpContainerTag)
+			if mcpContainerImage == "" || mcpContainerTag == "" {
+				fmt.Println("❌ Image name and tag cannot be empty (use --mcp-image and --mcp-tag).")
 				return
 			}
 
-			if err := buildManagedMCPHTTPImage(engine, imageTag); err != nil {
+			if err := buildManagedMCPHTTPImage(engine, imageRef); err != nil {
 				fmt.Printf("❌ Failed to build HAL MCP HTTP image: %v\n", err)
 				return
 			}
 
 			fmt.Println("✅ HAL MCP HTTP image created locally.")
 			fmt.Printf("🐳 Engine:      %s\n", engine)
-			fmt.Printf("🐳 Image:       %s\n", imageTag)
+			fmt.Printf("🐳 Image:       %s\n", imageRef)
 			fmt.Println("🧭 Next:        Start this image on hal-net and point HAL Plus to HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp")
 			return
 		}
@@ -980,7 +981,8 @@ func init() {
 	createCmd.Flags().StringVar(&createBinaryPath, "binary-path", "", "Path to write the managed HAL binary used by MCP clients (default ~/.hal/bin/hal-mcp)")
 	createCmd.Flags().BoolVar(&createJSONOnly, "json", false, "Only generate/replace MCP config JSON (skip managed binary provisioning)")
 	createCmd.Flags().BoolVar(&createHTTPImage, "http", false, "Build a local HAL MCP container image for streamable-http transport")
-	createCmd.Flags().StringVar(&createHTTPTag, "http-tag", "ghcr.io/hashimiche/hal-mcp:latest", "Image tag used when --http is set")
+	createCmd.Flags().StringVar(&mcpContainerImage, "mcp-image", "ghcr.io/hashimiche/hal-mcp", "HAL MCP container image name (used when --http is set)")
+	createCmd.Flags().StringVar(&mcpContainerTag, "mcp-tag", "latest", "HAL MCP container image tag (used when --http is set)")
 	upCmd.Flags().StringVar(&upTransport, "transport", transportStdio, "MCP transport to use: stdio or streamable-http")
 	upCmd.Flags().StringVar(&upHTTPHost, "http-host", "0.0.0.0", "Host/interface to bind when --transport=streamable-http")
 	upCmd.Flags().IntVar(&upHTTPPort, "http-port", 8080, "TCP port to listen on when --transport=streamable-http")

--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -16,9 +16,13 @@ import (
 var (
 	obsUpdate       bool
 	lokiVer         string
+	lokiImage       string
 	grafanaVer      string
+	grafanaImage    string
 	promVer         string
+	promImage       string
 	promtailVer     string
+	promtailImage   string
 	promConfigPath  string
 	obsJobName      string
 	obsMetricsPath  string
@@ -67,10 +71,10 @@ var deployCmd = &cobra.Command{
 
 		fmt.Println("📥 Pulling Observability images (this might take a minute)...")
 		images := []string{
-			"prom/prometheus:" + promVer,
-			"grafana/loki:" + lokiVer,
-			"grafana/promtail:" + promtailVer,
-			"grafana/grafana:" + grafanaVer,
+			promImage + ":" + promVer,
+			lokiImage + ":" + lokiVer,
+			promtailImage + ":" + promtailVer,
+			grafanaImage + ":" + grafanaVer,
 		}
 
 		for _, img := range images {
@@ -222,10 +226,10 @@ providers:
 			}
 		}
 
-		bootContainer("Prometheus", "run", "-d", "--name", "hal-prometheus", "--network", "hal-net", "-p", "9090:9090", "-v", filepath.Join(configDir, "prometheus.yml")+":/etc/prometheus/prometheus.yml", "-v", targetsDir+":/etc/prometheus/targets", "prom/prometheus:"+promVer)
-		bootContainer("Loki", "run", "-d", "--name", "hal-loki", "--network", "hal-net", "-p", "3100:3100", "-v", filepath.Join(configDir, "loki-config.yaml")+":/etc/loki/local-config.yaml", "grafana/loki:"+lokiVer, "-config.file=/etc/loki/local-config.yaml")
-		bootContainer("Promtail", "run", "-d", "--name", "hal-promtail", "--network", "hal-net", "-v", "hal-vault-logs:/vault/logs:ro", "-v", filepath.Join(configDir, "promtail-config.yaml")+":/etc/promtail/config.yml", "grafana/promtail:"+promtailVer, "-config.file=/etc/promtail/config.yml")
-		bootContainer("Grafana", "run", "-d", "--name", "hal-grafana", "--network", "hal-net", "-p", "3000:3000", "-v", filepath.Join(configDir, "datasources.yml")+":/etc/grafana/provisioning/datasources/datasources.yml", "-v", filepath.Join(configDir, "dashboards.yml")+":/etc/grafana/provisioning/dashboards/dashboards.yml", "-v", dashboardsDir+":/var/lib/grafana/dashboards", "-e", "GF_AUTH_ANONYMOUS_ENABLED=true", "-e", "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin", "grafana/grafana:"+grafanaVer)
+		bootContainer("Prometheus", "run", "-d", "--name", "hal-prometheus", "--network", "hal-net", "-p", "9090:9090", "-v", filepath.Join(configDir, "prometheus.yml")+":/etc/prometheus/prometheus.yml", "-v", targetsDir+":/etc/prometheus/targets", promImage+":"+promVer)
+		bootContainer("Loki", "run", "-d", "--name", "hal-loki", "--network", "hal-net", "-p", "3100:3100", "-v", filepath.Join(configDir, "loki-config.yaml")+":/etc/loki/local-config.yaml", lokiImage+":"+lokiVer, "-config.file=/etc/loki/local-config.yaml")
+		bootContainer("Promtail", "run", "-d", "--name", "hal-promtail", "--network", "hal-net", "-v", "hal-vault-logs:/vault/logs:ro", "-v", filepath.Join(configDir, "promtail-config.yaml")+":/etc/promtail/config.yml", promtailImage+":"+promtailVer, "-config.file=/etc/promtail/config.yml")
+		bootContainer("Grafana", "run", "-d", "--name", "hal-grafana", "--network", "hal-net", "-p", "3000:3000", "-v", filepath.Join(configDir, "datasources.yml")+":/etc/grafana/provisioning/datasources/datasources.yml", "-v", filepath.Join(configDir, "dashboards.yml")+":/etc/grafana/provisioning/dashboards/dashboards.yml", "-v", dashboardsDir+":/var/lib/grafana/dashboards", "-e", "GF_AUTH_ANONYMOUS_ENABLED=true", "-e", "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin", grafanaImage+":"+grafanaVer)
 
 		fmt.Println("⏳ Waiting for Prometheus, Loki, and Grafana health checks...")
 		if err := waitForObsHealth(engine); err != nil {
@@ -394,10 +398,14 @@ func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&obsUpdate, "update", "u", false, "Reconcile an existing observability stack in place")
 	}
-	cmd.Flags().StringVar(&lokiVer, "loki-version", "3.7", "Tag for the grafana/loki image")
-	cmd.Flags().StringVar(&grafanaVer, "grafana-version", "main", "Tag for the grafana/grafana image")
-	cmd.Flags().StringVar(&promVer, "prom-version", "main", "Tag for the prom/prometheus image")
-	cmd.Flags().StringVar(&promtailVer, "promtail-version", "3.6", "Tag for the grafana/promtail image")
+	cmd.Flags().StringVar(&lokiVer, "loki-tag", "3.7", "Tag for the Loki image")
+	cmd.Flags().StringVar(&lokiImage, "loki-image", "grafana/loki", "Loki container image name")
+	cmd.Flags().StringVar(&grafanaVer, "grafana-tag", "main", "Tag for the Grafana image")
+	cmd.Flags().StringVar(&grafanaImage, "grafana-image", "grafana/grafana", "Grafana container image name")
+	cmd.Flags().StringVar(&promVer, "prometheus-tag", "main", "Tag for the Prometheus image")
+	cmd.Flags().StringVar(&promImage, "prometheus-image", "prom/prometheus", "Prometheus container image name")
+	cmd.Flags().StringVar(&promtailVer, "promtail-tag", "3.6", "Tag for the Promtail image")
+	cmd.Flags().StringVar(&promtailImage, "promtail-image", "grafana/promtail", "Promtail container image name")
 	cmd.Flags().StringVar(&promConfigPath, "prom-config-path", "", "Path to a custom prometheus.yml; skips the generated config when set")
 	cmd.Flags().StringVar(&obsJobName, "job-name", "", "Register a custom Prometheus scrape job with this name (no local TFE required)")
 	cmd.Flags().StringVar(&obsMetricsPath, "metrics-path", "/metrics", "Metrics path for the custom job (only used when --job-name is set)")

--- a/cmd/plus/plus.go
+++ b/cmd/plus/plus.go
@@ -19,7 +19,11 @@ const (
 
 var (
 	plusImage          string
+	plusImageName      string
+	plusImageTag       string
 	mcpImage           string
+	mcpImageName       string
+	mcpImageTag        string
 	plusPull           bool
 	plusPort           int
 	plusModel          string
@@ -34,6 +38,11 @@ var Cmd = &cobra.Command{
 	Use:   "plus",
 	Short: "Manage HAL Plus web UI runtime",
 	Args:  cobra.NoArgs,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Combine image name + tag into the full refs used by all subcommands.
+		plusImage = plusImageName + ":" + plusImageTag
+		mcpImage = mcpImageName + ":" + mcpImageTag
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		statusCmd.Run(cmd, args)
 	},
@@ -153,8 +162,12 @@ func prettyJSON(v interface{}) string {
 }
 
 func init() {
-	plusImage = "ghcr.io/hashimiche/hal-plus:latest"
-	mcpImage = "ghcr.io/hashimiche/hal-mcp:latest"
+	plusImageName = "ghcr.io/hashimiche/hal-plus"
+	plusImageTag = "latest"
+	mcpImageName = "ghcr.io/hashimiche/hal-mcp"
+	mcpImageTag = "latest"
+	plusImage = plusImageName + ":" + plusImageTag
+	mcpImage = mcpImageName + ":" + mcpImageTag
 	plusPort = 9000
 	plusModel = "qwen3.5"
 	plusModelConfig = ""
@@ -162,8 +175,10 @@ func init() {
 	ollamaContainerURL = ""
 	ollamaKeepAlive = defaultOllamaKeepAlive
 
-	createCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image to run")
-	createCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected to exist locally")
+	createCmd.Flags().StringVar(&plusImageName, "plus-image", plusImageName, "HAL Plus container image name")
+	createCmd.Flags().StringVar(&plusImageTag, "plus-tag", plusImageTag, "HAL Plus container image tag")
+	createCmd.Flags().StringVar(&mcpImageName, "plus-mcp-image", mcpImageName, "HAL MCP container image name (must exist locally)")
+	createCmd.Flags().StringVar(&mcpImageTag, "plus-mcp-tag", mcpImageTag, "HAL MCP container image tag")
 	createCmd.Flags().BoolVar(&plusPull, "pull", false, "Force pull latest GHCR images before starting (no-op for localhost/ images)")
 	createCmd.Flags().IntVar(&plusPort, "port", plusPort, "Host port for HAL Plus UI")
 	createCmd.Flags().StringVar(&plusModel, "model", plusModel, supportedOllamaModelsHelp())
@@ -172,13 +187,17 @@ func init() {
 	createCmd.Flags().StringVar(&ollamaContainerURL, "ollama-base-url", ollamaContainerURL, "Container-side OLLAMA_BASE_URL override (defaults by engine)")
 	createCmd.Flags().StringVar(&ollamaKeepAlive, "keep-alive", ollamaKeepAlive, "Ollama model keep-alive duration for HAL Plus chat requests (for example 10m or 0)")
 
-	statusCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image expected")
-	statusCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected")
+	statusCmd.Flags().StringVar(&plusImageName, "plus-image", plusImageName, "HAL Plus container image name")
+	statusCmd.Flags().StringVar(&plusImageTag, "plus-tag", plusImageTag, "HAL Plus container image tag")
+	statusCmd.Flags().StringVar(&mcpImageName, "plus-mcp-image", mcpImageName, "HAL MCP container image name")
+	statusCmd.Flags().StringVar(&mcpImageTag, "plus-mcp-tag", mcpImageTag, "HAL MCP container image tag")
 
 	Cmd.AddCommand(createCmd)
 	Cmd.AddCommand(statusCmd)
 	Cmd.AddCommand(deleteCmd)
 
-	deleteCmd.Flags().StringVar(&plusImage, "image", plusImage, "HAL Plus image expected")
-	deleteCmd.Flags().StringVar(&mcpImage, "mcp-image", mcpImage, "HAL MCP image expected")
+	deleteCmd.Flags().StringVar(&plusImageName, "plus-image", plusImageName, "HAL Plus container image name")
+	deleteCmd.Flags().StringVar(&plusImageTag, "plus-tag", plusImageTag, "HAL Plus container image tag")
+	deleteCmd.Flags().StringVar(&mcpImageName, "plus-mcp-image", mcpImageName, "HAL MCP container image name")
+	deleteCmd.Flags().StringVar(&mcpImageTag, "plus-mcp-tag", mcpImageTag, "HAL MCP container image tag")
 }

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -24,13 +24,18 @@ import (
 
 var (
 	tfeVersion          string
+	tfeImage            string
 	tfePassword         string
 	pgVersion           string
+	pgImage             string
 	redisVersion        string
+	redisImage          string
 	minioVersion        string
+	minioImage          string
 	minioAPIPort        int
 	minioConsolePort    int
 	tfeProxyNginxTag    string
+	tfeProxyImage       string
 	tfeUpdate           bool
 	deployTFEOrg        string
 	deployTFEProject    string
@@ -110,13 +115,15 @@ var deployCmd = &cobra.Command{
 
 		fmt.Printf("🚀 Deploying Terraform Enterprise %s (PG: %s, Redis: %s) via %s...\n", tfeVersion, pgVersion, redisVersion, engine)
 
-		// 3. SECURE REGISTRY AUTHENTICATION
-		fmt.Println("🔑 Authenticating with HashiCorp private image registry...")
-		loginCmd := exec.Command(engine, "login", "images.releases.hashicorp.com", "-u", "terraform", "--password-stdin")
-		loginCmd.Stdin = strings.NewReader(license)
-		if err := loginCmd.Run(); err != nil {
-			fmt.Println("❌ Error: Failed to authenticate with images.releases.hashicorp.com.")
-			return
+		// 3. SECURE REGISTRY AUTHENTICATION (only for the default HashiCorp registry)
+		if strings.Contains(tfeImage, "images.releases.hashicorp.com") {
+			fmt.Println("🔑 Authenticating with HashiCorp private image registry...")
+			loginCmd := exec.Command(engine, "login", "images.releases.hashicorp.com", "-u", "terraform", "--password-stdin")
+			loginCmd.Stdin = strings.NewReader(license)
+			if err := loginCmd.Run(); err != nil {
+				fmt.Println("❌ Error: Failed to authenticate with images.releases.hashicorp.com.")
+				return
+			}
 		}
 
 		// 4. Ensure the global HAL network exists
@@ -128,19 +135,19 @@ var deployCmd = &cobra.Command{
 		fmt.Printf("⚙️  Provisioning TFE PostgreSQL Database...\n")
 		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-db", "--network", "hal-net",
 			"-e", "POSTGRES_USER=tfe", "-e", "POSTGRES_PASSWORD=tfe_password", "-e", "POSTGRES_DB=tfe",
-			fmt.Sprintf("postgres:%s-alpine", pgVersion)).Run()
+			fmt.Sprintf("%s:%s", pgImage, pgVersion)).Run()
 
 		// 6. Deploy Redis
 		fmt.Printf("⚙️  Provisioning TFE Redis Cache...\n")
 		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-redis", "--network", "hal-net",
-			fmt.Sprintf("redis:%s-alpine", redisVersion)).Run()
+			fmt.Sprintf("%s:%s", redisImage, redisVersion)).Run()
 
 		// 7. Deploy MinIO (S3 Mock)
 		fmt.Println("⚙️  Provisioning TFE Object Storage (MinIO)...")
 		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-minio", "--network", "hal-net",
 			"-p", fmt.Sprintf("%d:9000", minioAPIPort), "-p", fmt.Sprintf("%d:9001", minioConsolePort),
 			"-e", "MINIO_ROOT_USER=minioadmin", "-e", "MINIO_ROOT_PASSWORD=minioadmin",
-			fmt.Sprintf("minio/minio:%s", minioVersion), "server", "/data", "--console-address", ":9001").Run()
+			fmt.Sprintf("%s:%s", minioImage, minioVersion), "server", "/data", "--console-address", ":9001").Run()
 
 		time.Sleep(3 * time.Second)
 		_ = exec.Command(engine, "exec", "hal-tfe-minio", "sh", "-c", "mkdir -p /data/tfe-data").Run()
@@ -201,7 +208,7 @@ var deployCmd = &cobra.Command{
 			"-e", "TFE_OBJECT_STORAGE_S3_SECRET_ACCESS_KEY=minioadmin",
 			"-e", "TFE_OBJECT_STORAGE_S3_FORCE_PATH_STYLE=true",
 			"-e", "TFE_CAPACITY_CONCURRENCY=5",
-			fmt.Sprintf("images.releases.hashicorp.com/hashicorp/terraform-enterprise:%s", tfeVersion),
+			fmt.Sprintf("%s:%s", tfeImage, tfeVersion),
 		)
 
 		out, err := exec.Command(engine, tfeArgs...).CombinedOutput()
@@ -289,7 +296,7 @@ http {
 			"-p", "8443:8443", // 🎯 Only the proxy exposes port 8443 to the host OS
 			"-v", fmt.Sprintf("%s:/etc/ssl/tfe:ro", certDir),
 			"-v", fmt.Sprintf("%s:/etc/nginx/nginx.conf:ro", proxyConfPath),
-			fmt.Sprintf("nginx:%s", tfeProxyNginxTag)).Run()
+			fmt.Sprintf("%s:%s", tfeProxyImage, tfeProxyNginxTag)).Run()
 
 		// 9. THE HEALTH CHECK PHASE
 		fmt.Println("⏳ Waiting for TFE to initialize (WARNING: This can take 3-5 minutes!)...")
@@ -471,13 +478,18 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&tfeVersion, "version", "v", "1.2.0", "Terraform Enterprise Docker image tag")
-	cmd.Flags().StringVar(&pgVersion, "pg-version", "16", "PostgreSQL version for TFE backend")
-	cmd.Flags().StringVar(&redisVersion, "redis-version", "7", "Redis version for TFE background jobs")
-	cmd.Flags().StringVar(&minioVersion, "minio-version", "latest", "MinIO image tag for TFE object storage")
+	cmd.Flags().StringVarP(&tfeVersion, "tfe-tag", "v", "1.2.0", "TFE container image tag")
+	cmd.Flags().StringVar(&tfeImage, "tfe-image", "images.releases.hashicorp.com/hashicorp/terraform-enterprise", "TFE container image name")
+	cmd.Flags().StringVar(&pgVersion, "tfe-pg-tag", "16-alpine", "PostgreSQL image tag for TFE backend")
+	cmd.Flags().StringVar(&pgImage, "tfe-pg-image", "postgres", "PostgreSQL image name for TFE backend")
+	cmd.Flags().StringVar(&redisVersion, "tfe-redis-tag", "7-alpine", "Redis image tag for TFE background jobs")
+	cmd.Flags().StringVar(&redisImage, "tfe-redis-image", "redis", "Redis image name for TFE background jobs")
+	cmd.Flags().StringVar(&minioVersion, "tfe-minio-tag", "latest", "MinIO image tag for TFE object storage")
+	cmd.Flags().StringVar(&minioImage, "tfe-minio-image", "minio/minio", "MinIO image name for TFE object storage")
 	cmd.Flags().IntVar(&minioAPIPort, "minio-api-port", 19000, "Host port mapped to MinIO S3 API container port 9000")
 	cmd.Flags().IntVar(&minioConsolePort, "minio-console-port", 19001, "Host port mapped to MinIO console container port 9001")
-	cmd.Flags().StringVar(&tfeProxyNginxTag, "proxy-nginx-version", "alpine", "Nginx image tag for the TFE ingress proxy")
+	cmd.Flags().StringVar(&tfeProxyNginxTag, "tfe-proxy-tag", "alpine", "Nginx image tag for the TFE ingress proxy")
+	cmd.Flags().StringVar(&tfeProxyImage, "tfe-proxy-image", "nginx", "Nginx image name for the TFE ingress proxy")
 	cmd.Flags().StringVarP(&tfePassword, "password", "p", "hal-secret-encryption-password", "TFE Encryption Password")
 	cmd.Flags().StringVar(&deployTFEOrg, "tfe-org", "hal", "Terraform Enterprise organization name to auto-bootstrap during deploy")
 	cmd.Flags().StringVar(&deployTFEProject, "tfe-project", "Dave", "Terraform Enterprise project name to auto-bootstrap during deploy")

--- a/cmd/terraform/twin.go
+++ b/cmd/terraform/twin.go
@@ -28,6 +28,7 @@ var (
 	tfeTwinDisable             bool
 	tfeTwinUpdate              bool
 	tfeTwinVersion             string
+	tfeTwinImage               string
 	tfeTwinPassword            string
 	tfeTwinOrg                 string
 	tfeTwinProject             string
@@ -35,6 +36,7 @@ var (
 	tfeTwinAdminEmail          string
 	tfeTwinAdminPass           string
 	tfeTwinProxyNginxTag       string
+	tfeTwinProxyImage          string
 	tfeTwinHTTPSPort           int
 	tfeTwinHostname            string
 	tfeTwinContainerName       string
@@ -144,12 +146,15 @@ var twinCmd = &cobra.Command{
 
 		fmt.Printf("🚀 Deploying twin Terraform Enterprise %s using shared PG/Redis/MinIO via %s...\n", tfeTwinVersion, engine)
 
-		fmt.Println("🔑 Authenticating with HashiCorp private image registry...")
-		loginCmd := exec.Command(engine, "login", "images.releases.hashicorp.com", "-u", "terraform", "--password-stdin")
-		loginCmd.Stdin = strings.NewReader(license)
-		if err := loginCmd.Run(); err != nil {
-			fmt.Println("❌ Error: Failed to authenticate with images.releases.hashicorp.com.")
-			return
+		// Only auth with the HashiCorp registry when using the default image
+		if strings.Contains(tfeTwinImage, "images.releases.hashicorp.com") {
+			fmt.Println("🔑 Authenticating with HashiCorp private image registry...")
+			loginCmd := exec.Command(engine, "login", "images.releases.hashicorp.com", "-u", "terraform", "--password-stdin")
+			loginCmd.Stdin = strings.NewReader(license)
+			if err := loginCmd.Run(); err != nil {
+				fmt.Println("❌ Error: Failed to authenticate with images.releases.hashicorp.com.")
+				return
+			}
 		}
 
 		global.EnsureNetwork(engine)
@@ -224,7 +229,7 @@ var twinCmd = &cobra.Command{
 			"-e", fmt.Sprintf("TFE_OBJECT_STORAGE_S3_SECRET_ACCESS_KEY=%s", tfeTwinMinioRootPassword),
 			"-e", "TFE_OBJECT_STORAGE_S3_FORCE_PATH_STYLE=true",
 			"-e", "TFE_CAPACITY_CONCURRENCY=5",
-			fmt.Sprintf("images.releases.hashicorp.com/hashicorp/terraform-enterprise:%s", tfeTwinVersion),
+			fmt.Sprintf("%s:%s", tfeTwinImage, tfeTwinVersion),
 		)
 
 		out, err := exec.Command(engine, tfeArgs...).CombinedOutput()
@@ -304,7 +309,7 @@ http {
 			"-p", fmt.Sprintf("%d:%d", tfeTwinHTTPSPort, tfeTwinHTTPSPort),
 			"-v", fmt.Sprintf("%s:/etc/ssl/tfe:ro", layout.CertDir),
 			"-v", fmt.Sprintf("%s:/etc/nginx/nginx.conf:ro", layout.ProxyConfPath),
-			fmt.Sprintf("nginx:%s", tfeTwinProxyNginxTag)).Run()
+			fmt.Sprintf("%s:%s", tfeTwinProxyImage, tfeTwinProxyNginxTag)).Run()
 
 		fmt.Println("⏳ Waiting for twin TFE to initialize (WARNING: This can take 3-5 minutes!)...")
 		if err := waitForTwinService(layout.HealthURL, 60); err != nil {
@@ -678,14 +683,16 @@ func runTFETwinLifecycle(enable, disable, update bool) {
 }
 
 func bindTwinFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&tfeTwinVersion, "twin-version", "1.2.0", "Terraform Enterprise Docker image tag for the twin instance")
+	cmd.Flags().StringVar(&tfeTwinVersion, "twin-tag", "1.2.0", "TFE container image tag for the twin instance")
+	cmd.Flags().StringVar(&tfeTwinImage, "twin-image", "images.releases.hashicorp.com/hashicorp/terraform-enterprise", "TFE container image name for the twin instance")
 	cmd.Flags().StringVar(&tfeTwinPassword, "twin-password", "hal-secret-encryption-password", "Twin TFE encryption password")
 	cmd.Flags().StringVar(&tfeTwinOrg, "twin-tfe-org", "hal-bis", "Terraform Enterprise organization name to auto-bootstrap for the twin instance")
 	cmd.Flags().StringVar(&tfeTwinProject, "twin-tfe-project", "Dave-bis", "Terraform Enterprise project name to auto-bootstrap for the twin instance")
 	cmd.Flags().StringVar(&tfeTwinAdminUser, "twin-tfe-admin-username", "haladmin", "Initial twin TFE admin username used when bootstrapping via IACT")
 	cmd.Flags().StringVar(&tfeTwinAdminEmail, "twin-tfe-admin-email", "haladmin@localhost", "Initial twin TFE admin email used when bootstrapping via IACT")
 	cmd.Flags().StringVar(&tfeTwinAdminPass, "twin-tfe-admin-password", "hal9000FTW", "Initial twin TFE admin password used when bootstrapping via IACT")
-	cmd.Flags().StringVar(&tfeTwinProxyNginxTag, "twin-proxy-nginx-version", "alpine", "Nginx image tag for the twin ingress proxy")
+	cmd.Flags().StringVar(&tfeTwinProxyNginxTag, "twin-proxy-tag", "alpine", "Nginx image tag for the twin ingress proxy")
+	cmd.Flags().StringVar(&tfeTwinProxyImage, "twin-proxy-image", "nginx", "Nginx image name for the twin ingress proxy")
 	cmd.Flags().IntVar(&tfeTwinHTTPSPort, "twin-https-port", 9443, "Host HTTPS port exposed by the twin TFE ingress proxy")
 	cmd.Flags().StringVar(&tfeTwinHostname, "twin-hostname", "tfe-bis.localhost", "TLS hostname used by the twin TFE instance")
 	cmd.Flags().StringVar(&tfeTwinContainerName, "twin-container-name", "hal-tfe-bis", "Container name used for the twin TFE core application")

--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -16,7 +16,9 @@ import (
 var (
 	vaultVersion     string
 	vaultEdition     string // ce or ent
+	vaultImage       string // optional override for the computed per-edition image name
 	vaultHelperImage string
+	vaultHelperTag   string
 	vaultUpdate      bool
 	vaultJoinConsul  bool
 )
@@ -84,10 +86,14 @@ var deployCmd = &cobra.Command{
 		if vaultEdition == "ent" || vaultEdition == "enterprise" {
 			imageRepo = "hashicorp/vault-enterprise"
 
-			// If the user didn't explicitly specify a version, give them the Enterprise default
-			if !cmd.Flags().Changed("version") {
+			// If the user didn't explicitly specify a tag, give them the Enterprise default
+			if !cmd.Flags().Changed("vault-tag") {
 				actualVersion = "2.0-ent"
 			}
+		}
+		// --vault-image overrides the per-edition image name entirely
+		if vaultImage != "" {
+			imageRepo = vaultImage
 		}
 
 		fmt.Printf("🚀 Deploying Vault %s (%s) via %s...\n", actualVersion, strings.ToUpper(vaultEdition), engine)
@@ -97,8 +103,9 @@ var deployCmd = &cobra.Command{
 
 		// Correction des permissions du volume d'audit pour l'utilisateur Vault (UID 100)
 		fmt.Println("⚙️  Preparing shared volume permissions...")
-		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-logs:/vault/logs", vaultHelperImage, "chown", "-R", "100:1000", "/vault/logs").Run()
-		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-plugins:/vault/plugins", vaultHelperImage, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
+		helperRef := vaultHelperImage + ":" + vaultHelperTag
+		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-logs:/vault/logs", helperRef, "chown", "-R", "100:1000", "/vault/logs").Run()
+		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-plugins:/vault/plugins", helperRef, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
 
 		// 2. Build the Docker run arguments
 		vaultArgs := []string{
@@ -223,9 +230,11 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&vaultVersion, "version", "v", "2.0", "Vault version to deploy")
+	cmd.Flags().StringVarP(&vaultVersion, "vault-tag", "v", "2.0", "Vault container image tag")
+	cmd.Flags().StringVar(&vaultImage, "vault-image", "", "Vault container image name (overrides per-edition default: hashicorp/vault or hashicorp/vault-enterprise)")
 	cmd.Flags().StringVarP(&vaultEdition, "edition", "e", "ce", "Vault edition to deploy: 'ce' (Community) or 'ent' (Enterprise)")
-	cmd.Flags().StringVar(&vaultHelperImage, "helper-image", "alpine:3.22", "Helper image used for one-shot setup tasks during Vault deploy")
+	cmd.Flags().StringVar(&vaultHelperImage, "vault-helper-image", "alpine", "Helper container image name for one-shot setup tasks during Vault deploy")
+	cmd.Flags().StringVar(&vaultHelperTag, "vault-helper-tag", "3.22", "Helper container image tag for one-shot setup tasks during Vault deploy")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&vaultUpdate, "update", "u", false, "Reconcile an existing Vault deployment in place")
 	}

--- a/cmd/vault/database.go
+++ b/cmd/vault/database.go
@@ -18,6 +18,7 @@ var (
 	databaseUpdate       bool
 	databaseBackend      string
 	mariadbVersion       string
+	mariadbImage         string
 	dbUsernamePrefix     string
 )
 
@@ -67,7 +68,7 @@ var vaultDatabaseCmd = &cobra.Command{
 			"--network-alias", "mariadb.localhost",
 			"-p", "3306:3306",
 			"-e", "MARIADB_ROOT_PASSWORD=vaultroot",
-			fmt.Sprintf("mariadb:%s", mariadbVersion),
+			fmt.Sprintf("%s:%s", mariadbImage, mariadbVersion),
 		}
 
 		client, vaultErr := GetHealthyClient()
@@ -299,7 +300,8 @@ func init() {
 
 	// Backend selection and version pinning
 	vaultDatabaseCmd.Flags().StringVarP(&databaseBackend, "backend", "b", "mariadb", "Database backend to use (mariadb; pgsql planned, postgres alias accepted)")
-	vaultDatabaseCmd.Flags().StringVar(&mariadbVersion, "mariadb-version", "11.4", "Version of the MariaDB container image to deploy")
+	vaultDatabaseCmd.Flags().StringVar(&mariadbVersion, "vault-mariadb-tag", "11.4", "MariaDB container image tag")
+	vaultDatabaseCmd.Flags().StringVar(&mariadbImage, "vault-mariadb-image", "mariadb", "MariaDB container image name")
 	vaultDatabaseCmd.Flags().StringVar(&dbUsernamePrefix, "username-prefix", "v", "Prefix for dynamically generated database usernames (e.g. 'myapp' → 'myapp-AbCdEfGhIj')")
 
 	Cmd.AddCommand(vaultDatabaseCmd)

--- a/cmd/vault/jwt.go
+++ b/cmd/vault/jwt.go
@@ -18,10 +18,13 @@ import (
 )
 
 var (
-	jwtEnable     bool
-	jwtDisable    bool
-	jwtUpdate     bool
-	gitlabVersion string
+	jwtEnable          bool
+	jwtDisable         bool
+	jwtUpdate          bool
+	gitlabVersion      string
+	gitlabImage        string
+	gitlabRunnerImage  string
+	gitlabRunnerTag    string
 )
 
 var vaultJwtCmd = &cobra.Command{
@@ -171,7 +174,7 @@ var vaultJwtCmd = &cobra.Command{
 
 			global.EnsureNetwork(engine)
 
-			reused, err := integrations.EnsureGitLabCE(engine, gitlabVersion, "hal9000FTW")
+			reused, err := integrations.EnsureGitLabCE(engine, gitlabImage+":"+gitlabVersion, "hal9000FTW")
 			if err != nil {
 				fmt.Printf("❌ %v\n", err)
 				return
@@ -179,7 +182,7 @@ var vaultJwtCmd = &cobra.Command{
 			if reused {
 				fmt.Println("ℹ️  Reusing existing GitLab CE shared service.")
 			} else {
-				fmt.Printf("🚀 Booted GitLab CE shared service (gitlab/gitlab-ce:%s).\n", gitlabVersion)
+				fmt.Printf("🚀 Booted GitLab CE shared service (%s:%s).\n", gitlabImage, gitlabVersion)
 			}
 
 			fmt.Println("⏳ Waiting for GitLab API...")
@@ -479,7 +482,7 @@ func ensureJWTGitLabRunner(engine, token, projectID string) error {
 			"--network", "hal-net",
 			"--add-host", fmt.Sprintf("gitlab.localhost:%s", gitlabIP),
 			"-v", fmt.Sprintf("%s:/etc/gitlab-runner", runnerConfigDir),
-			"gitlab/gitlab-runner:alpine",
+			gitlabRunnerImage + ":" + gitlabRunnerTag,
 		}
 
 		if out, err := exec.Command(engine, runnerArgs...).CombinedOutput(); err != nil {
@@ -635,7 +638,10 @@ func init() {
 	_ = vaultJwtCmd.Flags().MarkHidden("update")
 
 	// 2. Feature-Specific Flags
-	vaultJwtCmd.Flags().StringVar(&gitlabVersion, "gitlab-version", "18.10.1-ce.0", "Version of the GitLab CE container image to deploy")
+	vaultJwtCmd.Flags().StringVar(&gitlabVersion, "vault-gitlab-tag", "18.10.1-ce.0", "GitLab CE container image tag")
+	vaultJwtCmd.Flags().StringVar(&gitlabImage, "vault-gitlab-image", "gitlab/gitlab-ce", "GitLab CE container image name")
+	vaultJwtCmd.Flags().StringVar(&gitlabRunnerImage, "vault-gitlab-runner-image", "gitlab/gitlab-runner", "GitLab Runner container image name")
+	vaultJwtCmd.Flags().StringVar(&gitlabRunnerTag, "vault-gitlab-runner-tag", "alpine", "GitLab Runner container image tag")
 
 	Cmd.AddCommand(vaultJwtCmd)
 }

--- a/cmd/vault/k8s.go
+++ b/cmd/vault/k8s.go
@@ -23,7 +23,9 @@ var (
 	kindNodeImage   string
 	vsoChartVersion string
 	webBackendImage string
+	webBackendTag   string
 	webProxyImage   string
+	webProxyTag     string
 )
 
 func isVaultEnterprise(client *vault.Client) bool {
@@ -590,7 +592,7 @@ spec:
 			port: 80
 			targetPort: 80
 			nodePort: 30080
-`, vaultIP, webBackendImage, webProxyImage)
+`, vaultIP, webBackendImage+":"+webBackendTag, webProxyImage+":"+webProxyTag)
 			} else {
 				appManifests = fmt.Sprintf(`
 ---
@@ -756,7 +758,7 @@ spec:
 			port: 80
 			targetPort: 80
 			nodePort: 30080
-`, vaultIP, webBackendImage, webProxyImage)
+`, vaultIP, webBackendImage+":"+webBackendTag, webProxyImage+":"+webProxyTag)
 			}
 
 			if !applyK8s(appManifests) {
@@ -840,8 +842,10 @@ func init() {
 	vaultK8sCmd.Flags().BoolVar(&jwtAuth, "jwt", false, "Use the advanced jwt-k8s OIDC architecture (experimental)")
 	vaultK8sCmd.Flags().StringVar(&kindNodeImage, "kind-node-image", "kindest/node:v1.31.1", "KinD node image used when creating the cluster")
 	vaultK8sCmd.Flags().StringVar(&vsoChartVersion, "vso-chart-version", "", "Helm chart version for hashicorp/vault-secrets-operator (empty uses latest)")
-	vaultK8sCmd.Flags().StringVar(&webBackendImage, "web-backend-image", "httpd:2.4-alpine", "Demo backend container image")
-	vaultK8sCmd.Flags().StringVar(&webProxyImage, "web-proxy-image", "nginx:alpine", "Demo reverse proxy container image")
+	vaultK8sCmd.Flags().StringVar(&webBackendImage, "vault-k8s-web-backend-image", "httpd", "Demo backend container image name")
+	vaultK8sCmd.Flags().StringVar(&webBackendTag, "vault-k8s-web-backend-tag", "2.4-alpine", "Demo backend container image tag")
+	vaultK8sCmd.Flags().StringVar(&webProxyImage, "vault-k8s-web-proxy-image", "nginx", "Demo reverse proxy container image name")
+	vaultK8sCmd.Flags().StringVar(&webProxyTag, "vault-k8s-web-proxy-tag", "alpine", "Demo reverse proxy container image tag")
 
 	Cmd.AddCommand(vaultK8sCmd)
 }

--- a/cmd/vault/pki.go
+++ b/cmd/vault/pki.go
@@ -35,7 +35,9 @@ var (
 	pkiKindNodeImage      string
 	pkiCertManagerVersion string
 	pkiWebBackendImage    string
+	pkiWebBackendTag      string
 	pkiCaddyImage         string
+	pkiCaddyTag           string
 	pkiACMECertTTL        string
 )
 
@@ -635,7 +637,7 @@ path "%s/issue/hal-role" { capabilities = ["create", "update"] }
 	// Phase 1: Namespace, Deployment, Service — standard K8s resources, no cert-manager
 	// webhook validation. Apply immediately with no retry needed.
 	fmt.Println("⚙️  Applying core manifests (Namespace, Deployment, Service)...")
-	coreManifests := buildPKIK8sCoreManifests(intMount, pkiWebBackendImage)
+	coreManifests := buildPKIK8sCoreManifests(intMount, pkiWebBackendImage+":"+pkiWebBackendTag)
 	coreCmd := exec.Command("kubectl", "apply", "-f", "-")
 	coreCmd.Stdin = strings.NewReader(coreManifests)
 	coreCmd.Stdout = os.Stdout
@@ -718,7 +720,7 @@ path "%s/issue/hal-role" { capabilities = ["create", "update"] }
 	fmt.Println("    - cert-manager (namespace: cert-manager, Jetstack chart)")
 	fmt.Printf("    - ClusterIssuer vault-pki-issuer → %s/sign/hal-role\n", intMount)
 	fmt.Println("    - Certificate hal-web-pki-cert (namespace: pki-demo)")
-	fmt.Printf("    - Web pod hal-web-pki (%s, TLS cert mounted at /tls)\n", pkiWebBackendImage)
+	fmt.Printf("    - Web pod hal-web-pki (%s, TLS cert mounted at /tls)\n", pkiWebBackendImage+":"+pkiWebBackendTag)
 	fmt.Println("\n  Access:")
 	fmt.Println("    → https://pki.localhost:8089")
 	fmt.Println("\n  Inspect the certificate:")
@@ -1076,7 +1078,7 @@ func runPKIACMEEnable(client *vault.Client, engine string, isPodman bool, intMou
 
 	// ---- Apply Caddy manifests ----
 	fmt.Println("⚙️  Applying ACME/Caddy manifests (Namespace, ConfigMaps, Deployments, Services)...")
-	manifests := buildPKIACMEManifests(vaultIP, intMount, pkiCaddyImage)
+	manifests := buildPKIACMEManifests(vaultIP, intMount, pkiCaddyImage+":"+pkiCaddyTag)
 	// Guard against accidental tab indentation in embedded YAML blocks.
 	manifests = strings.ReplaceAll(manifests, "\t", "  ")
 	applyCmd := exec.Command("kubectl", "apply", "-f", "-")
@@ -1127,7 +1129,7 @@ func runPKIACMEEnable(client *vault.Client, engine string, isPodman bool, intMou
 	fmt.Println("    - hostNetwork ACME gateway on Kind node :80 for Vault HTTP-01 callbacks")
 	fmt.Printf("    - ACME directory: http://vault.localhost:8200/v1/%s/roles/acme-demo/acme/directory\n", intMount)
 	fmt.Printf("    - Cert TTL: %s\n", pkiACMECertTTL)
-	fmt.Printf("    - Caddy image: %s\n", pkiCaddyImage)
+	fmt.Printf("    - Caddy image: %s\n", pkiCaddyImage+":"+pkiCaddyTag)
 	fmt.Println("\n  Access:")
 	fmt.Println("    → https://acme.localhost:8090")
 	fmt.Println("\n  Inspect the certificate:")
@@ -1579,8 +1581,10 @@ func init() {
 	vaultPKICmd.Flags().BoolVar(&pkiForce, "force", false, "With --k8s/--acme update: also rebuild Root CA and Intermediate CA from scratch")
 	vaultPKICmd.Flags().StringVar(&pkiKindNodeImage, "kind-node-image", "kindest/node:v1.31.1", "KinD node image (used only when creating a new cluster)")
 	vaultPKICmd.Flags().StringVar(&pkiCertManagerVersion, "cert-manager-version", "", "Jetstack cert-manager Helm chart version (empty = latest)")
-	vaultPKICmd.Flags().StringVar(&pkiWebBackendImage, "web-backend-image", "nginx:alpine", "Demo backend container image (cert-manager/--k8s demo)")
-	vaultPKICmd.Flags().StringVar(&pkiCaddyImage, "caddy-image", "caddy:alpine", "Caddy container image (ACME/--acme demo)")
+	vaultPKICmd.Flags().StringVar(&pkiWebBackendImage, "vault-pki-web-backend-image", "nginx", "Demo backend container image name (cert-manager/--k8s demo)")
+	vaultPKICmd.Flags().StringVar(&pkiWebBackendTag, "vault-pki-web-backend-tag", "alpine", "Demo backend container image tag (cert-manager/--k8s demo)")
+	vaultPKICmd.Flags().StringVar(&pkiCaddyImage, "vault-pki-caddy-image", "caddy", "Caddy container image name (ACME/--acme demo)")
+	vaultPKICmd.Flags().StringVar(&pkiCaddyTag, "vault-pki-caddy-tag", "alpine", "Caddy container image tag (ACME/--acme demo)")
 	vaultPKICmd.Flags().StringVar(&pkiACMECertTTL, "acme-cert-ttl", "5m", "TTL for certs issued to Caddy via ACME (short = visible auto-renewal in the web page)")
 
 	Cmd.AddCommand(vaultPKICmd)

--- a/internal/integrations/gitlab.go
+++ b/internal/integrations/gitlab.go
@@ -114,7 +114,7 @@ func GitLabGet(urlStr, token string) ([]byte, error) {
 	return body, nil
 }
 
-func EnsureGitLabCE(engine, version, rootPassword string) (bool, error) {
+func EnsureGitLabCE(engine, image, rootPassword string) (bool, error) {
 	if out, err := exec.Command(engine, "inspect", "-f", "{{.State.Running}}", "hal-gitlab").Output(); err == nil {
 		if string(bytes.TrimSpace(out)) == "true" {
 			return true, nil
@@ -134,7 +134,7 @@ func EnsureGitLabCE(engine, version, rootPassword string) (bool, error) {
 		"--privileged",
 		"-v", fmt.Sprintf("%s:/etc/gitlab/trusted-certs/tfe.localhost.crt:z", certPath), // 🎯 FIX: Inject CA
 		"-e", fmt.Sprintf("GITLAB_OMNIBUS_CONFIG=external_url 'http://gitlab.localhost:8080'; nginx['listen_port'] = 8080; nginx['listen_addresses'] = ['0.0.0.0', '[::]']; puma['port'] = 8081; gitlab_rails['initial_root_password'] = '%s';", rootPassword),
-		fmt.Sprintf("gitlab/gitlab-ce:%s", version),
+		image,
 	}
 
 	if out, err := exec.Command(engine, args...).CombinedOutput(); err != nil {


### PR DESCRIPTION
…ent>-tag flags

Each product now exposes two override flags per container:
  --<component>-image  (image name/registry, no tag)
  --<component>-tag    (image tag, replaces old --version/--xxx-version)

Products and components covered:
  vault:        --vault-image, --vault-tag, --vault-helper-image, --vault-helper-tag
  consul:       --consul-image, --consul-tag
  boundary:     --boundary-image, --boundary-tag, --boundary-pg-image, --boundary-pg-tag
  boundary:     --boundary-mariadb-image, --boundary-mariadb-tag
  terraform:    --tfe-image, --tfe-tag, --tfe-pg-image, --tfe-pg-tag
                --tfe-redis-image, --tfe-redis-tag, --tfe-minio-image, --tfe-minio-tag
                --tfe-proxy-image, --tfe-proxy-tag
  terraform twin: --twin-image, --twin-tag, --twin-proxy-image, --twin-proxy-tag
  obs:          --prometheus-image, --prometheus-tag, --loki-image, --loki-tag
                --promtail-image, --promtail-tag, --grafana-image, --grafana-tag
  vault db:     --vault-mariadb-image, --vault-mariadb-tag
  vault jwt:    --vault-gitlab-image, --vault-gitlab-tag
                --vault-gitlab-runner-image, --vault-gitlab-runner-tag
  vault k8s:    --vault-k8s-web-backend-image/tag, --vault-k8s-web-proxy-image/tag
  vault pki:    --vault-pki-web-backend-image/tag, --vault-pki-caddy-image/tag
  mcp:          --mcp-image, --mcp-tag (replaces --http-tag full ref)
  plus:         --plus-image, --plus-tag, --plus-mcp-image, --plus-mcp-tag

TFE/twin registry auth is now conditional: only triggered when tfeImage contains 'images.releases.hashicorp.com' (custom image skips login).

integrations.EnsureGitLabCE signature updated: now accepts full image ref instead of constructing gitlab/gitlab-ce:<version> internally.

close #33 