### PR TITLE
Feature/vault SCIM

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,3 +64,19 @@ Every `hal` CLI change must land on a named branch before merging to `main`:
 - Bug fixes or corrections: `bugfix/<short-description>`
 
 Before writing any code, ask the user to create or confirm the target branch.
+
+---
+
+## Commit Discipline
+
+**NEVER commit automatically.** Always present a summary of changed files and proposed commit message, then wait for explicit user approval before running `git commit` or `git push`.
+
+Before every commit, verify that all relevant documentation is updated in the same cycle:
+- `README.md` — if contributor-facing behavior changed
+- `LLM_CONTEXT.md` — if command behavior, flags, or product workflows changed
+- `docs/cli-lifecycle-model.md` — if lifecycle semantics changed
+- `docs/commands/*.md` — if a specific command was added or modified
+- `.github/copilot-instructions.md` — if policy or conventions changed
+- `HAL_MCP_CONTRACT.json` + `cmd/mcp/testdata/*_help_snapshot.json` — if command syntax changed
+
+If any of these are stale relative to the code changes, update them before proposing the commit.

--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -96,10 +96,43 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
     - The `hal-health` container reuses `hashimiche/hal-mcp:latest` (same image as `hal-mcp`) with `--entrypoint /usr/local/bin/hal` and `health _serve` as args.
     - It reads a frozen `HAL_HEALTH_DATA` JSON env var at startup and serves it at `http://hal-health:9001/api/status` on `hal-net`.
     - The snapshot is built on the **host** (which has engine socket access) by `global.RefreshHalHealth(engine)`, injected as an env var, then the container is recreated. The container itself never touches the engine.
-    - `global.RefreshHalHealth(engine)` is called after every product lifecycle event that changes ecosystem state: all product `create`/`delete` commands, and all vault/boundary extension enable/disable commands (`vault k8s`, `vault oidc`, `vault jwt`, `vault ldap`, `vault database`, `boundary mariadb`, `boundary ssh`).
+- `global.RefreshHalHealth(engine)` is called after every product lifecycle event that changes ecosystem state: all product `create`/`delete` commands, and all vault/boundary extension enable/disable commands (`vault k8s`, `vault oidc`, `vault jwt`, `vault ldap`, `vault database`, `boundary mariadb`, `boundary ssh`).
     - `RefreshHalHealth` is a no-op if `hal-net` does not exist or the `hashimiche/hal-mcp:latest` image is not present — safe to call unconditionally.
     - HAL Plus fetches `http://hal-health:9001/api/status` as its primary product state source (via `fetchHalStatusProducts()` in `server/index.mjs`), with `fallbackProductsFromEndpoints()` as a fallback for local dev without containers.
     - The snapshot shape: `{ timestamp, engine, products: [{ product, state, health, reason, endpoint, containers, features: [{ feature, state, health, reason }] }] }`.
+- `hal vault oidc` deploys Authentik as a shared IdP and wires Vault OIDC auth. See `docs/scim-idp-spec.md` for full architecture.
+    - **Command**: `hal vault oidc enable|disable|update|status`. Flags: `--scim` (Vault Enterprise), `--authentik-image`, `--authentik-tag`.
+    - **Authentik containers**: `hal-authentik-pg` (postgres:16-alpine), `hal-authentik-server`, `hal-authentik-worker` — all on `hal-net`. No static IPs (Docker DNS). No Docker socket mounted.
+    - **Ports**: HTTP `9100`, HTTPS `9143`. `AUTHENTIK_LISTEN__HTTP=0.0.0.0:9100` must be set explicitly so internal and external port match. Internal port defaults to 9000 otherwise.
+    - **Canonical URL**: `authentik.localhost:9100` via `--network-alias authentik.localhost`. macOS resolves `*.localhost` → 127.0.0.1; Docker containers resolve via network alias. This keeps the OIDC issuer URL identical from host browser and from the Vault container.
+    - **Bootstrap token**: `AUTHENTIK_BOOTSTRAP_TOKEN` must be set on **both server and worker** containers. The worker runs Celery tasks that actually create the token record in the database — if the worker does not have it, the token is never persisted and all API calls get 403.
+    - **Bootstrap token race**: After `WaitAuthentikHealthy()` (polls `/api/v3/root/config/` — unauthenticated), always call `WaitAuthentikTokenReady(token)` before any API calls. It polls `GET /api/v3/core/groups/` with `Authorization: Bearer <token>` until 200 (60 s timeout). This ensures admin-level access is ready, not just server health.
+    - **`update` pattern**: cleans Vault OIDC mounts/policies, deletes the Authentik application + OAuth2 provider by name, then falls through to the enable path for fresh re-provision. Does not bounce the Authentik stack. Always calls `WaitAuthentikTokenReady` even when Authentik is already running.
+    - **Authentik REST API (version 2026.x / 2024.4+ changes)**:
+        - Scope mappings: `/api/v3/propertymappings/provider/scope/` (was `/propertymappings/scope/` before 2024.4)
+        - `CreateOAuth2Provider` requires both `authorization_flow` AND `invalidation_flow` fields — use `GetDefaultInvalidationFlowPK()` which prefers the `default-provider-invalidation-flow` slug.
+        - `GetDefaultAuthorizationFlowPK()` prefers slugs containing `"implicit"` — prevents picking `explicit-consent` which orphans the OAuth state and causes "Expired or missing OAuth state" on the second login attempt.
+        - Groups scope mapping no longer ships as a default in 2026.x — `GetGroupsScopeMappingPK()` creates it automatically if not found (`scope_name: groups`, expression: `list(request.user.ak_groups.values_list("name", flat=True))`).
+        - `CreateApplication` sets `meta_launch_url` to `http://vault.localhost:8200/ui/vault/auth/oidc` so the Authentik tile points to the host-reachable URL, not the SCIM backchannel URL.
+    - **Secrets file**: `~/.hal/authentik/env` (mode 0600). Keys: `PG_PASS`, `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_BOOTSTRAP_PASSWORD`. Loaded on every start — secrets are stable across restarts.
+    - **Shared service registry**: service key `"authentik-idp"`, consumer `"vault-oidc"`. Authentik stack is torn down on disable only when no consumers remain.
+    - **Demo users**: `alice / password` → group `admin` → Vault policy `admin` (all paths); `bob / password` → group `user-ro` → Vault policy `user-ro` (kv-oidc/team1 read).
+    - **OIDC role redirect URIs**: `http://localhost:8250/oidc/callback`, `http://127.0.0.1:8250/oidc/callback`, `http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback` — all three required for CLI and browser flows.
+    - **SCIM (`--scim`, Vault Enterprise only)**:
+        - Performs an early Enterprise gate check (`sys/license/status`) before any provisioning. Exits with a clear error if not Enterprise.
+        - Step 0: if a prior non-SCIM `hal vault oidc enable` ran, external groups `admin`/`user-ro` exist without a `scim_client_id`. These are deleted before SCIM setup so Authentik can take ownership without 409 conflicts.
+        - Activates SCIM feature flag via `sys/activation-flags/enable-scim/activate` (one-way, permanent).
+        - Creates `scim-client` policy covering `identity/scim/v2/*` with **create/read/update/patch/delete/list**. The `patch` capability is critical — Vault 1.14+ treats HTTP PATCH as a separate capability from `update`; without it group membership PATCH returns `permission denied` and member lists stay empty forever.
+        - Creates entity `scim-client-authentik` and token role `authentik-scim` (32-day renewable orphan).
+        - Creates SCIM client `authentik-scim` with `alias_mount_accessor = oidc/` — ensures SCIM-provisioned entities merge with OIDC-authenticated entities so group policies apply on login.
+        - Creates Authentik outbound SCIM provider `vault-scim-provider` with `compatibility_mode: "aws"`. Without AWS mode, Authentik 2026.x includes `"schemas"` inside PATCH Operation objects which Vault SCIM rejects with 400/`invalidValue` — member lists stay empty.
+        - Assigns SCIM provider as backchannel on `hashicorp-vault` application (required for outbound sync activation).
+        - OIDC path skips pre-creating external groups when `--scim` is active; Authentik SCIM owns group creation.
+        - **Group membership is NOT auto-propagated** when a user is added to a group (Authentik 2026.x ManyToMany table changes don't fire outbound SCIM events). Must use per-object sync endpoint: `POST /api/v3/providers/scim/{pk}/sync/object/` with `sync_object_model: "authentik.core.models.Group"` and `sync_object_id: "<group-pk>"`. The completion output prints exact curl commands with real token and provider PK.
+        - Valid `sync_object_model` enum values: `"authentik.core.models.Group"`, `"authentik.core.models.User"` (Python module path, from `SyncObjectModelEnum` in OpenAPI schema).
+        - SCIM endpoint inside containers: `http://hal-vault:8200/v1/identity/scim/v2`.
+    - **Future**: `hal tf saml enable [--scim]` on a separate branch will reuse the same Authentik stack with `AuthentikSharedServiceKey`.
+    - **Implementation files**: `cmd/vault/oidc.go`, `cmd/vault/scim.go`, `internal/integrations/authentik.go`.
 - Shared runtime helpers live under `internal/global`, especially engine detection and network management.
 - Engine resource advisory helpers live under `internal/global`; reuse them instead of open-coding engine-specific capacity checks in individual commands.
 - Vault k8s demo (`hal vault k8s`) now supports two explicit demo modes behind the same nginx endpoint (`http://web.localhost:8088`):

--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ hal vault delete                          # remove Vault container and volumes
 **Feature subcommands** — `enable` / `update` / `disable`
 
 ```bash
-# OIDC auth method (deploys Keycloak as the provider)
-hal vault oidc enable --keycloak-version 24.0.4
+# OIDC auth method (deploys Authentik as the IdP)
+hal vault oidc enable
+hal vault oidc enable --authentik-tag 2026.2.3  # pin the image tag
+hal vault oidc enable --scim                     # also configure SCIM (Vault Enterprise only)
 hal vault oidc update
 hal vault oidc disable
 

--- a/cmd/creds/creds.go
+++ b/cmd/creds/creds.go
@@ -1,0 +1,190 @@
+package creds
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"hal/internal/global"
+	"hal/internal/integrations"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "creds",
+	Short: "Manage active lab credentials",
+	Long:  `Commands for inspecting active credentials across running lab services.`,
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show active lab credentials",
+	Long:  `Display credentials for all currently running lab services. Only active services are shown.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine, err := global.DetectEngine()
+		if err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+
+		printed := false
+
+		// ── Vault ────────────────────────────────────────────────────────────
+		vaultUp := global.CheckContainer(engine, "hal-vault")
+		if vaultUp {
+			printed = true
+			fmt.Println("🔐 Vault")
+			fmt.Println("   URL        : http://vault.localhost:8200")
+			fmt.Println("   Root token : root")
+			fmt.Println()
+			fmt.Println("   export VAULT_ADDR='http://vault.localhost:8200'")
+			fmt.Println("   export VAULT_TOKEN='root'")
+			fmt.Println()
+		}
+
+		// ── Vault OIDC + Authentik ────────────────────────────────────────────
+		oidcConsumers := global.GetSharedServiceConsumers(integrations.AuthentikSharedServiceKey)
+		oidcActive := false
+		for _, c := range oidcConsumers {
+			if c == "vault-oidc" {
+				oidcActive = true
+				break
+			}
+		}
+		if oidcActive || global.CheckContainer(engine, integrations.AuthentikServerContainer) {
+			printed = true
+			fmt.Println("🔑 Vault OIDC — demo users")
+			fmt.Println("   alice / password  →  Vault policy: admin  (all paths)")
+			fmt.Println("   bob   / password  →  Vault policy: user-ro  (kv-oidc/team1 read)")
+			fmt.Println()
+			fmt.Println("   vault login -method=oidc")
+			fmt.Println()
+
+			fmt.Println("🌐 Authentik IdP")
+			fmt.Printf("   URL      : http://authentik.localhost:%s/if/admin/\n", integrations.AuthentikHTTPPort)
+			fmt.Println("   Username : akadmin")
+			adminPass := loadAuthentikAdminPassword()
+			if adminPass != "" {
+				fmt.Printf("   Password : %s\n", adminPass)
+			} else {
+				fmt.Printf("   Password : (see %s)\n", integrations.AuthentikEnvPath())
+			}
+			fmt.Println()
+		}
+
+		// ── Vault LDAP ───────────────────────────────────────────────────────
+		if global.CheckContainer(engine, "hal-openldap") {
+			printed = true
+			fmt.Println("📂 Vault LDAP — demo users")
+			fmt.Println("   alice / password  →  group: admin")
+			fmt.Println("   bob   / password  →  group: readers")
+			fmt.Println()
+			fmt.Println("   vault login -method=ldap username=bob password=password")
+			fmt.Println()
+		}
+
+		// ── Vault UserPass ───────────────────────────────────────────────────
+		if vaultUp && vaultAuthMountExists("userpass") {
+			printed = true
+			fmt.Println("👤 Vault UserPass — demo user")
+			fmt.Println("   michaelScott / threat-level-midnight")
+			fmt.Println()
+			fmt.Println("   vault login -method=userpass username=michaelScott password=threat-level-midnight")
+			fmt.Println()
+		}
+
+		// ── Vault Database (dynamic) ─────────────────────────────────────────
+		if global.CheckContainer(engine, "hal-vault-mariadb") {
+			printed = true
+			fmt.Println("🗄️  Vault Database — dynamic credentials")
+			fmt.Println("   vault read database/creds/writer")
+			fmt.Println("   vault read database/creds/reader")
+			fmt.Println()
+		}
+
+		// ── Boundary ─────────────────────────────────────────────────────────
+		if global.CheckContainer(engine, "hal-boundary") {
+			printed = true
+			fmt.Println("🔒 Boundary")
+			fmt.Println("   URL      : http://boundary.localhost:9200")
+			fmt.Println("   Username : admin")
+			fmt.Println("   Password : password")
+			fmt.Println()
+			if global.CheckContainer(engine, "hal-ssh-target") {
+				fmt.Println("   SSH lab users (Boundary auth method: ssh-lab-auth)")
+				fmt.Println("     ssh-operator / password")
+				fmt.Println("     ssh-auditor  / password")
+				fmt.Println()
+			}
+			if global.CheckContainer(engine, "hal-mariadb-target") {
+				fmt.Println("   MariaDB target")
+				fmt.Println("     host: localhost:3306  user: admin  password: password")
+				fmt.Println()
+			}
+		}
+
+		// ── TFE ──────────────────────────────────────────────────────────────
+		if global.CheckContainer(engine, "hal-tfe") {
+			printed = true
+			token := global.LoadCachedTFEAPIToken()
+			fmt.Println("🏗️  Terraform Enterprise")
+			fmt.Println("   URL      : https://tfe.localhost")
+			fmt.Println("   Username : admin")
+			if token != "" {
+				fmt.Printf("   API token: %s\n", token)
+			} else {
+				fmt.Println("   API token: (run `hal terraform status` to retrieve)")
+			}
+			fmt.Println()
+		}
+
+		if !printed {
+			fmt.Println("No active lab services detected.")
+			fmt.Println("Start a service first, e.g.:")
+			fmt.Println("  hal vault create")
+			fmt.Println("  hal vault oidc enable")
+		}
+	},
+}
+
+func init() {
+	Cmd.AddCommand(statusCmd)
+}
+
+// vaultAuthMountExists returns true if the named auth mount is enabled in Vault.
+func vaultAuthMountExists(method string) bool {
+	cfg := vault.DefaultConfig()
+	if os.Getenv("VAULT_ADDR") == "" {
+		cfg.Address = "http://127.0.0.1:8200"
+	}
+	client, err := vault.NewClient(cfg)
+	if err != nil {
+		return false
+	}
+	if os.Getenv("VAULT_TOKEN") == "" {
+		client.SetToken("root")
+	}
+	auths, err := client.Sys().ListAuth()
+	if err != nil {
+		return false
+	}
+	_, ok := auths[strings.TrimSuffix(method, "/")+"/"]
+	return ok
+}
+
+// loadAuthentikAdminPassword reads AUTHENTIK_BOOTSTRAP_PASSWORD from ~/.hal/authentik/env.
+func loadAuthentikAdminPassword() string {
+	data, err := os.ReadFile(integrations.AuthentikEnvPath())
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), "=", 2)
+		if len(parts) == 2 && parts[0] == "AUTHENTIK_BOOTSTRAP_PASSWORD" {
+			return parts[1]
+		}
+	}
+	return ""
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"hal/cmd/boundary"
 	"hal/cmd/consul"
+	"hal/cmd/creds"
 	"hal/cmd/health"
 	"hal/cmd/mcp"
 	"hal/cmd/nomad"
@@ -55,4 +56,5 @@ func init() {
 	rootCmd.AddCommand(terraform.Cmd)
 	rootCmd.AddCommand(observability.Cmd)
 	rootCmd.AddCommand(health.Cmd)
+	rootCmd.AddCommand(creds.Cmd)
 }

--- a/cmd/vault/oidc.go
+++ b/cmd/vault/oidc.go
@@ -2,12 +2,7 @@ package vault
 
 import (
 	"fmt"
-	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"hal/internal/global"
 	"hal/internal/integrations"
@@ -16,330 +11,441 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	authentikVaultSlug   = "hashicorp-vault"
+	oidcSharedServiceKey = "vault-oidc"
+	oidcKVMount          = "kv-oidc"
+)
+
 var (
-	oidcEnable      bool
-	oidcDisable     bool
-	oidcUpdate      bool
-	keycloakVersion string
+	oidcEnable         bool
+	oidcDisable        bool
+	oidcUpdate         bool
+	oidcWithSCIM       bool
+	oidcAuthentikImage string
+	oidcAuthentikTag   string
 )
 
 var vaultOidcCmd = &cobra.Command{
 	Use:   "oidc [status|enable|disable|update]",
-	Short: "Deploy Keycloak and fully configure Vault OIDC auth",
-	Args:  cobra.MaximumNArgs(1),
+	Short: "Deploy Authentik IdP and configure Vault OIDC auth",
+	Long: `Spin up Authentik as a shared Identity Provider and wire up Vault OIDC auth.
+
+The same Authentik stack is reused by 'hal tf saml' — it is only torn down
+when no other product has registered against it.
+
+Actions:
+  status   Show Authentik stack health and Vault OIDC state (default)
+  enable   Start Authentik, provision demo users/groups, configure Vault OIDC
+  disable  Remove Vault OIDC and tear down Authentik if no other product uses it
+  update   Re-provision Vault OIDC providers (keeps Authentik running)
+
+Demo users created in Authentik:
+  alice / password  → group: admin  → Vault policy: admin (all paths)
+  bob   / password  → group: user-ro → Vault policy: user-ro (kv-oidc/team1 read)
+
+Flags:
+  --scim   [Vault Enterprise] Also wire SCIM provisioning from Authentik to Vault`,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := parseLifecycleAction(args, &oidcEnable, &oidcDisable, &oidcUpdate); err != nil {
 			fmt.Printf("❌ %v\n", err)
 			return
 		}
 
+		// Early exit: --scim requires Vault Enterprise. Check before doing any work.
+		if oidcWithSCIM {
+			if client, err := GetHealthyClient(); err == nil {
+				if health, err := client.Sys().Health(); err == nil {
+					v := health.Version
+					if !strings.Contains(v, "ent") && !strings.Contains(v, "+") {
+						fmt.Println("❌ Error: --scim requires Vault Enterprise.")
+						fmt.Println("   💡 Your current Vault version is Community Edition.")
+						fmt.Println()
+						fmt.Println("   To deploy Vault Enterprise, run:")
+						fmt.Println("   hal vault delete")
+						fmt.Println("   export VAULT_LICENSE='your_license_string'")
+						fmt.Println("   # or: export VAULT_LICENSE_PATH='/path/to/vault.hclic'")
+						fmt.Println("   hal vault create --edition ent")
+						return
+					}
+				}
+			}
+		}
+
 		engine, err := global.DetectEngine()
 		if err != nil {
-			fmt.Printf("❌ Error: %v\n", err)
+			fmt.Printf("❌ %v\n", err)
 			return
 		}
 
 		client, vaultErr := GetHealthyClient()
-		isPodman := strings.Contains(engine, "podman")
 
-		// ==========================================
-		// 1. SMART STATUS MODE (Default behavior)
-		// ==========================================
+		// ── STATUS ──────────────────────────────────────────────────────────────
 		if !oidcEnable && !oidcDisable && !oidcUpdate {
-			fmt.Println("🔍 Checking Vault OIDC / Keycloak Status...")
-
-			// Check Docker
-			kcExists := (exec.Command(engine, "inspect", "hal-keycloak").Run() == nil)
-
-			// Check Vault API (if Vault is alive)
-			authMounted := false
-			kvMounted := false
-			if vaultErr == nil {
-				auths, _ := client.Sys().ListAuth()
-				_, authMounted = auths["oidc/"]
-
-				mounts, _ := client.Sys().ListMounts()
-				_, kvMounted = mounts["kv-oidc/"]
-			}
-
-			// Output Status
-			if kcExists {
-				fmt.Printf("  ✅ Keycloak IdP  : Active (http://keycloak.localhost:8081)\n")
-			} else {
-				fmt.Printf("  ❌ Keycloak IdP  : Not running\n")
-			}
-
-			if authMounted {
-				fmt.Printf("  ✅ Vault OIDC    : Configured (oidc/)\n")
-			} else {
-				fmt.Printf("  ❌ Vault OIDC    : Not configured\n")
-			}
-
-			if kvMounted {
-				fmt.Printf("  ✅ Sandbox KV    : Configured (kv-oidc/)\n")
-			} else {
-				fmt.Printf("  ⚠️  Sandbox KV    : Not configured (Optional)\n")
-			}
-
-			// Smart Assistant Logic
-			fmt.Println("\n💡 Next Step:")
-			if !kcExists && !authMounted {
-				fmt.Println("   To deploy Keycloak and wire up Vault OIDC, run:")
-				fmt.Println("   hal vault oidc enable")
-			} else if kcExists && authMounted {
-				fmt.Println("   Demo is ready! Test the integration:")
-				fmt.Println("   vault login -method=oidc")
-				fmt.Println("\n   To completely remove this demo environment, run:")
-				fmt.Println("   hal vault oidc disable")
-			} else {
-				fmt.Println("   Environment is partially degraded. To safely reset, run:")
-				fmt.Println("   hal vault oidc update")
-			}
+			runOIDCStatus(engine, client, vaultErr)
 			return
 		}
 
-		// ==========================================
-		// 2. TEARDOWN / RESET PATH (--disable / --update)
-		// ==========================================
-		if oidcDisable || oidcUpdate {
-			if global.DryRun {
-				fmt.Println("[DRY RUN] Would execute: docker rm -f hal-keycloak")
-				fmt.Println("[DRY RUN] Would call API to clean up Vault OIDC mounts, identity groups, and policies")
-			} else {
-				if oidcDisable {
-					fmt.Println("🛑 Tearing down OIDC environment...")
-				} else {
-					fmt.Println("♻️  Update requested. Destroying OIDC environment for reset...")
-				}
+		// ── DISABLE ─────────────────────────────────────────────────────────────
+		if oidcDisable {
+			runOIDCDisable(engine, client, vaultErr)
+			return
+		}
 
-				if vaultErr == nil && client != nil {
-					fmt.Println("⚙️  Connecting to Vault API for cleanup...")
-					_ = client.Sys().DisableAuth("oidc")
-					_ = client.Sys().Unmount("kv-oidc")
-					_ = client.Sys().DeletePolicy("admin")
-					_ = client.Sys().DeletePolicy("user-ro")
+		// ── UPDATE ──────────────────────────────────────────────────────────────
+		if oidcUpdate {
+			fmt.Println("♻️  Update: cleaning Vault OIDC configuration for re-provision...")
+			cleanVaultOIDC(client, vaultErr)
 
-					fmt.Println("⚙️  Removing Sandbox Identity Groups and Entities...")
-					_, _ = client.Logical().Delete("identity/group/name/admin")
-					_, _ = client.Logical().Delete("identity/group/name/user-ro")
-					_, _ = client.Logical().Delete("identity/entity/name/alice")
-					_, _ = client.Logical().Delete("identity/entity/name/bob")
-				} else {
-					fmt.Println("⚠️  Vault is offline. Skipped Vault-internal cleanup.")
-				}
-
-				fmt.Println("⚙️  Removing Keycloak container...")
-				_ = exec.Command(engine, "rm", "-f", "hal-keycloak").Run()
-				_ = global.ClearSharedService("keycloak")
-
-				if oidcDisable {
-					fmt.Println("✅ OIDC integration, KV engine, and identity data successfully removed!")
-					global.RefreshHalHealth(engine)
-				}
-			}
-
-			if oidcDisable && !global.DryRun {
-				return
+			// Remove the Authentik application + provider so they can be re-created
+			// with fresh credentials on the re-provision pass below.
+			secrets, err := integrations.LoadOrCreateAuthentikSecrets()
+			if err == nil {
+				aktClient := integrations.NewAuthentikClient(secrets.BootstrapToken)
+				fmt.Println("  ⚙️  Removing Authentik application and provider for re-creation...")
+				_ = aktClient.DeleteApplicationBySlug(authentikVaultSlug)
+				_ = aktClient.DeleteOAuth2ProviderByName("vault-oidc-provider")
+				_ = aktClient.DeleteSCIMProviderByName("vault-scim-provider")
 			}
 		}
 
-		// ==========================================
-		// 3. DEPLOY / ENABLE PATH (--enable / --update)
-		// ==========================================
-		if oidcEnable || oidcUpdate {
-			if vaultErr != nil {
-				fmt.Printf("❌ Cannot deploy: Vault must be running and healthy. %v\n", vaultErr)
-				return
-			}
+		// ── ENABLE / UPDATE (continue) ───────────────────────────────────────────
+		runOIDCEnable(engine, client, vaultErr)
+	},
+}
 
-			if global.DryRun {
-				fmt.Println("[DRY RUN] Would execute Docker run command for Keycloak.")
-				fmt.Println("[DRY RUN] Would mount 'kv-oidc' and 'oidc' auth method.")
-				fmt.Println("[DRY RUN] Would create Vault policies and external Identity Groups.")
-				return
-			}
+// ─── status ───────────────────────────────────────────────────────────────────
 
-			fmt.Println("⚙️  Preparing Keycloak IdP configuration...")
-			realmJSON := `{
-				"realm": "hal",
-				"enabled": true,
-				"users": [
-					{ 
-						"username": "alice", 
-						"enabled": true, 
-						"email": "alice@hal.local",
-						"firstName": "Alice",
-						"lastName": "Admin",
-						"emailVerified": true,
-						"credentials": [{"type": "password", "value": "password"}], 
-						"groups": ["admin"] 
-					},
-					{ 
-						"username": "bob", 
-						"enabled": true, 
-						"email": "bob@hal.local",
-						"firstName": "Bob",
-						"lastName": "Builder",
-						"emailVerified": true,
-						"credentials": [{"type": "password", "value": "password"}], 
-						"groups": ["user-ro"] 
-					}
-				],
-				"groups": [
-					{ "name": "admin" },
-					{ "name": "user-ro" }
-				],
-				"clients": [
-					{
-						"clientId": "vault",
-						"enabled": true,
-						"clientAuthenticatorType": "client-secret",
-						"secret": "supersecret",
-						"redirectUris": ["http://localhost:8250/oidc/callback", "http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback", "http://127.0.0.1:8250/oidc/callback"],
-						"standardFlowEnabled": true,
-						"protocolMappers": [
-							{
-								"name": "groups",
-								"protocol": "openid-connect",
-								"protocolMapper": "oidc-group-membership-mapper",
-								"config": {
-									"claim.name": "groups",
-									"full.path": "false",
-									"id.token.claim": "true",
-									"access.token.claim": "true",
-									"userinfo.token.claim": "true"
-								}
-							}
-						]
-					}
-				]
-			}`
+func runOIDCStatus(engine string, client *vault.Client, vaultErr error) {
+	fmt.Println("🔍 Vault OIDC / Authentik IdP Status")
+	fmt.Println()
 
-			homeDir, _ := os.UserHomeDir()
-			configDir := filepath.Join(homeDir, ".hal", "keycloak")
-			os.MkdirAll(configDir, 0755)
-			realmPath := filepath.Join(configDir, "hal-realm.json")
-			_ = os.WriteFile(realmPath, []byte(realmJSON), 0644)
+	integrations.PrintAuthentikStatus(engine)
+	fmt.Println()
 
-			fmt.Printf("🚀 Booting Keycloak container (quay.io/keycloak/keycloak:%s)...\n", keycloakVersion)
-			if global.IsContainerRunning(engine, "hal-keycloak") {
-				fmt.Println("ℹ️  Reusing existing Keycloak shared service.")
-			} else {
+	authMounted := false
+	kvMounted := false
+	if vaultErr == nil {
+		auths, _ := client.Sys().ListAuth()
+		_, authMounted = auths["oidc/"]
+		mounts, _ := client.Sys().ListMounts()
+		_, kvMounted = mounts[oidcKVMount+"/"]
+	}
 
-				kcArgs := []string{
-					"run", "-d",
-					"--name", "hal-keycloak",
-					"--network", "hal-net",
-					"--network-alias", "keycloak.localhost",
-					"-p", "8081:8081",
-					"-e", "KEYCLOAK_ADMIN=admin",
-					"-e", "KEYCLOAK_ADMIN_PASSWORD=admin",
-					"-e", "KC_HTTP_PORT=8081",
-				}
+	icon := func(ok bool) string {
+		if ok {
+			return "✅"
+		}
+		return "❌"
+	}
 
-				volFlag := fmt.Sprintf("%s:/opt/keycloak/data/import/hal-realm.json", realmPath)
-				if isPodman {
-					volFlag += ":Z"
-				}
-				kcArgs = append(kcArgs, "-v", volFlag)
-				kcArgs = append(kcArgs, fmt.Sprintf("quay.io/keycloak/keycloak:%s", keycloakVersion), "start-dev", "--import-realm")
+	fmt.Printf("  %s Vault OIDC auth   : oidc/\n", icon(authMounted))
+	fmt.Printf("  %s Vault KV sandbox  : %s/\n", icon(kvMounted), oidcKVMount)
+	fmt.Println()
 
-				if err := exec.Command(engine, kcArgs...).Run(); err != nil {
-					fmt.Printf("❌ Failed to boot Keycloak: %v\n", err)
-					return
-				}
-			}
+	fmt.Println("💡 Next Step:")
+	akt := integrations.IsAuthentikRunning(engine)
+	switch {
+	case !akt && !authMounted:
+		fmt.Println("   hal vault oidc enable")
+	case akt && authMounted:
+		fmt.Println("   vault login -method=oidc")
+		fmt.Printf("   Authentik UI: %s/if/admin/\n", integrations.AuthentikAdminURL())
+	default:
+		fmt.Println("   Environment partially degraded — run: hal vault oidc update")
+	}
+}
 
-			fmt.Println("⏳ Waiting for Keycloak OIDC endpoints to become active...")
-			keycloakOIDC := integrations.KeycloakRealm("http://127.0.0.1:8081", "hal")
-			if err := waitForKeycloak(keycloakOIDC.DiscoveryURL, 45); err != nil {
-				fmt.Println("❌ Keycloak failed to start in time.")
-				return
-			}
+// ─── enable ───────────────────────────────────────────────────────────────────
 
-			vaultKeycloakOIDC := integrations.KeycloakRealm("http://keycloak.localhost:8081", "hal")
-			if err := waitForVaultVisibleKeycloak(engine, vaultKeycloakOIDC.DiscoveryURL, 30); err != nil {
-				fmt.Printf("❌ Keycloak is up on the host, but Vault still cannot reach its discovery URL: %v\n", err)
-				return
-			}
+func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
+	if vaultErr != nil {
+		fmt.Printf("❌ Vault must be running and healthy: %v\n", vaultErr)
+		return
+	}
 
-			fmt.Println("⚙️  Configuring Vault OIDC Auth, KV Engine, Policies, and External Groups...")
+	if global.DryRun {
+		fmt.Println("[DRY RUN] Would start Authentik, provision users/groups, configure Vault OIDC")
+		return
+	}
 
-			// 1. Enable KV-V2 Secrets Engine
-			_ = client.Sys().Mount("kv-oidc", &vault.MountInput{
-				Type: "kv",
-				Options: map[string]string{
-					"version": "2",
-				},
-			})
+	fmt.Println("🔐 hal vault oidc — deploying Authentik IdP + Vault OIDC")
+	fmt.Println()
 
-			// 2. Seed a test secret for Bob to read
-			_, err = client.Logical().Write("kv-oidc/data/team1", map[string]interface{}{
-				"data": map[string]interface{}{
-					"example": "password",
-				},
-			})
-			if err != nil {
-				fmt.Printf("⚠️  Warning: Failed to seed test secret: %v\n", err)
-			}
+	// 1. Load or generate Authentik secrets
+	secrets, err := integrations.LoadOrCreateAuthentikSecrets()
+	if err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
+	}
 
-			// 3. Create Policies
-			_ = client.Sys().PutPolicy("admin", `path "*" { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }`)
-			_ = client.Sys().PutPolicy("user-ro", `
+	// 2. Start Authentik if not already up
+	firstBoot := false
+	if integrations.IsAuthentikRunning(engine) {
+		fmt.Println("  ✅ Authentik stack already running — skipping start")
+	} else {
+		firstBoot = true
+		fmt.Println("  Starting Authentik stack...")
+		if err := integrations.StartAuthentikStack(engine, oidcAuthentikImage, oidcAuthentikTag, secrets); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+		if err := integrations.WaitAuthentikHealthy(); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+	}
+
+	// Always verify the bootstrap token is accepted before any API calls.
+	// The token is created by the worker async, so it may not be ready even
+	// if the server health check passed — and on a re-provision (update) the
+	// container is already running but we still need a valid token.
+	if err := integrations.WaitAuthentikTokenReady(secrets.BootstrapToken); err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
+	}
+
+	if firstBoot {
+		printAuthentikCredentials(secrets)
+	}
+
+	// 3. Register this product as a consumer
+	if err := global.AddSharedServiceConsumer(integrations.AuthentikSharedServiceKey, oidcSharedServiceKey); err != nil {
+		fmt.Printf("⚠️  Could not register shared service consumer: %v\n", err)
+	}
+
+	// 4. Provision Authentik: groups, users, OAuth2 provider, application
+	fmt.Println("  ⚙️  Provisioning Authentik (users, groups, OAuth2 provider, application)...")
+	aktClient := integrations.NewAuthentikClient(secrets.BootstrapToken)
+	clientID, clientSecret, err := provisionAuthentikForVault(aktClient)
+	if err != nil {
+		fmt.Printf("❌ Authentik provisioning failed: %v\n", err)
+		return
+	}
+
+	// 5. Verify Vault container can reach the discovery URL
+	issuer := integrations.AuthentikOIDCIssuer(authentikVaultSlug)
+	fmt.Println("  ⏳ Verifying Vault can reach Authentik OIDC discovery URL...")
+	if err := integrations.WaitVaultVisibleAuthentik(engine, issuer); err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
+	}
+
+	// 6. Configure Vault OIDC
+	fmt.Println("  ⚙️  Configuring Vault OIDC auth, policies, and identity groups...")
+	if err := configureVaultOIDC(client, issuer, clientID, clientSecret); err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return
+	}
+
+	// 7. SCIM provisioning (Vault Enterprise + Authentik outbound sync)
+	if oidcWithSCIM {
+		fmt.Println()
+		fmt.Println("🔗 Configuring SCIM provisioning (Authentik → Vault)...")
+		if err := configureSCIM(client, aktClient, authentikVaultSlug); err != nil {
+			fmt.Printf("❌ SCIM setup failed: %v\n", err)
+			fmt.Println("   OIDC is still active. Fix the error and re-run with --scim to retry.")
+		}
+	}
+
+	global.RefreshHalHealth(engine)
+	printOIDCSuccess(issuer, secrets)
+}
+
+// ─── disable ──────────────────────────────────────────────────────────────────
+
+func runOIDCDisable(engine string, client *vault.Client, vaultErr error) {
+	if global.DryRun {
+		fmt.Println("[DRY RUN] Would remove Vault OIDC mounts, policies, and external groups")
+		fmt.Println("[DRY RUN] Would deregister vault-oidc from Authentik shared service")
+		return
+	}
+
+	fmt.Println("🛑 Tearing down Vault OIDC environment...")
+	cleanVaultOIDC(client, vaultErr)
+
+	remaining, err := global.RemoveSharedServiceConsumer(integrations.AuthentikSharedServiceKey, oidcSharedServiceKey)
+	if err != nil {
+		fmt.Printf("⚠️  Could not update shared service registry: %v\n", err)
+	}
+
+	if len(remaining) == 0 {
+		fmt.Println("  No other products depend on Authentik — stopping the stack...")
+		if err := integrations.StopAuthentikStack(engine, true); err != nil {
+			fmt.Printf("⚠️  Warning during stack teardown: %v\n", err)
+		}
+		fmt.Println("  ✅ Authentik stack stopped and volumes removed")
+	} else {
+		// Authentik stays up for other consumers — remove the SCIM provider that pointed at Vault.
+		fmt.Printf("  ℹ️  Authentik still in use by: %s — stack left running\n", strings.Join(remaining, ", "))
+		if secrets, err := integrations.LoadOrCreateAuthentikSecrets(); err == nil {
+			aktClient := integrations.NewAuthentikClient(secrets.BootstrapToken)
+			_ = aktClient.DeleteSCIMProviderByName("vault-scim-provider")
+		}
+	}
+
+	global.RefreshHalHealth(engine)
+	fmt.Println("✅ Vault OIDC removed")
+}
+
+// ─── Authentik provisioning ───────────────────────────────────────────────────
+
+// provisionAuthentikForVault creates the demo users, groups, OAuth2 provider, and
+// application in Authentik. Returns (clientID, clientSecret, error).
+func provisionAuthentikForVault(c *integrations.AuthentikClient) (string, string, error) {
+	// Groups
+	adminGroupPK, err := c.CreateGroup("admin")
+	if err != nil {
+		return "", "", fmt.Errorf("create group admin: %w", err)
+	}
+	userROGroupPK, err := c.CreateGroup("user-ro")
+	if err != nil {
+		return "", "", fmt.Errorf("create group user-ro: %w", err)
+	}
+
+	// Users
+	if err := c.CreateUser("alice", "Alice Admin", "alice@hal.local", "password", []string{adminGroupPK}); err != nil {
+		return "", "", fmt.Errorf("create user alice: %w", err)
+	}
+	if err := c.CreateUser("bob", "Bob Builder", "bob@hal.local", "password", []string{userROGroupPK}); err != nil {
+		return "", "", fmt.Errorf("create user bob: %w", err)
+	}
+
+	// OAuth2 provider prerequisites
+	flowPK, err := c.GetDefaultAuthorizationFlowPK()
+	if err != nil {
+		return "", "", fmt.Errorf("get authorization flow: %w", err)
+	}
+	invalidationFlowPK, err := c.GetDefaultInvalidationFlowPK()
+	if err != nil {
+		return "", "", fmt.Errorf("get invalidation flow: %w", err)
+	}
+	keyPK, err := c.GetFirstSigningKeyPK()
+	if err != nil {
+		return "", "", fmt.Errorf("get signing key: %w", err)
+	}
+	groupsScopePK, err := c.GetGroupsScopeMappingPK()
+	if err != nil {
+		return "", "", fmt.Errorf("get groups scope: %w", err)
+	}
+
+	// OAuth2 provider
+	redirectURIs := []integrations.AuthentikRedirectURI{
+		{MatchingMode: "strict", URL: "http://localhost:8250/oidc/callback"},
+		{MatchingMode: "strict", URL: "http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback"},
+		{MatchingMode: "strict", URL: "http://127.0.0.1:8250/oidc/callback"},
+	}
+	providerPK, clientID, clientSecret, err := c.CreateOAuth2Provider(
+		"vault-oidc-provider", flowPK, invalidationFlowPK, keyPK, groupsScopePK, redirectURIs,
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("create OAuth2 provider: %w", err)
+	}
+
+	// Application — set meta_launch_url so the Authentik portal tile points to the
+	// browser-accessible Vault UI OIDC page, not an auto-computed internal URL.
+	vaultUIURL := "http://vault.localhost:8200/ui/vault/auth/oidc"
+	if err := c.CreateApplication("HashiCorp Vault", authentikVaultSlug, providerPK, vaultUIURL); err != nil {
+		return "", "", fmt.Errorf("create application: %w", err)
+	}
+
+	return clientID, clientSecret, nil
+}
+
+// ─── Vault OIDC configuration ─────────────────────────────────────────────────
+
+func configureVaultOIDC(client *vault.Client, issuer, clientID, clientSecret string) error {
+	// KV-V2 secrets engine
+	_ = client.Sys().Mount(oidcKVMount, &vault.MountInput{
+		Type:    "kv",
+		Options: map[string]string{"version": "2"},
+	})
+
+	// Seed a demo secret for bob
+	_, _ = client.Logical().Write(oidcKVMount+"/data/team1", map[string]interface{}{
+		"data": map[string]interface{}{"example": "password"},
+	})
+
+	// Policies
+	_ = client.Sys().PutPolicy("admin", `path "*" { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }`)
+	_ = client.Sys().PutPolicy("user-ro", `
 path "kv-oidc/+/" { capabilities = ["list"] }
 path "kv-oidc/data/team1" { capabilities = ["read", "list"] }
 path "kv-oidc/metadata/team1" { capabilities = ["read", "list"] }
 `)
 
-			// 4. Enable OIDC Auth
-			_ = client.Sys().EnableAuthWithOptions("oidc", &vault.EnableAuthOptions{Type: "oidc"})
+	// Enable OIDC auth
+	_ = client.Sys().EnableAuthWithOptions("oidc", &vault.EnableAuthOptions{Type: "oidc"})
 
-			// 5. Configure OIDC
-			_, err = writeOIDCConfigWithRetry(client, vaultKeycloakOIDC.Issuer, 15)
-			if err != nil {
-				fmt.Printf("❌ Failed to configure Vault OIDC: %v\n", err)
-				return
-			}
-
-			// 6. Configure Default Role
-			_, _ = client.Logical().Write("auth/oidc/role/default", map[string]interface{}{
-				"user_claim":   "preferred_username",
-				"groups_claim": "groups",
-				"allowed_redirect_uris": []string{
-					"http://localhost:8250/oidc/callback",
-					"http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback",
-				},
-				"oidc_scopes": []string{"openid", "profile", "email"},
-			})
-
-			// 7. Map Groups
-			auths, _ := client.Sys().ListAuth()
-			oidcAccessor := auths["oidc/"].Accessor
-
-			setupExternalGroup(client, "admin", oidcAccessor, []string{"admin"})
-			setupExternalGroup(client, "user-ro", oidcAccessor, []string{"user-ro"})
-
-			fmt.Println("\n✅ Vault OIDC & KV Integration Complete!")
-			global.RefreshHalHealth(engine)
-			fmt.Println("---------------------------------------------------------")
-			fmt.Println("🔗 UI Login:    http://vault.localhost:8200")
-			fmt.Println("                (Select 'OIDC' and leave the role blank)")
-			fmt.Println("\n🔗 CLI Login:   vault login -method=oidc")
-			fmt.Println("\n👤 Test Users:  alice / password (Admin)")
-			fmt.Println("                bob   / password (Read-Only on kv-oidc/team1)")
-			fmt.Println("---------------------------------------------------------")
-			if err := global.AddSharedServiceConsumer("keycloak", "vault-oidc"); err != nil {
-				fmt.Printf("⚠️  Could not persist shared ownership metadata: %v\n", err)
-			}
+	// Configure OIDC — retry because the token endpoint may still initialise
+	var writeErr error
+	for i := 0; i < 15; i++ {
+		_, writeErr = client.Logical().Write("auth/oidc/config", map[string]interface{}{
+			"oidc_discovery_url": issuer,
+			"oidc_client_id":     clientID,
+			"oidc_client_secret": clientSecret,
+			"default_role":       "default",
+		})
+		if writeErr == nil {
+			break
 		}
-	},
+		if !strings.Contains(strings.ToLower(writeErr.Error()), "error checking oidc discovery url") {
+			return writeErr
+		}
+	}
+	if writeErr != nil {
+		return writeErr
+	}
+
+	// Default role — groups claim is "groups" (populated by Authentik's groups scope)
+	// 127.0.0.1 is included alongside localhost because macOS may use either address
+	// for the loopback listener opened by `vault login -method=oidc`.
+	_, _ = client.Logical().Write("auth/oidc/role/default", map[string]interface{}{
+		"user_claim":   "preferred_username",
+		"groups_claim": "groups",
+		"allowed_redirect_uris": []string{
+			"http://localhost:8250/oidc/callback",
+			"http://127.0.0.1:8250/oidc/callback",
+			"http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback",
+		},
+		"oidc_scopes": []string{"openid", "profile", "email", "groups"},
+	})
+
+	// External groups with group aliases.
+	// When SCIM is enabled, group creation and membership are fully managed by
+	// Authentik outbound SCIM — skip creating them here to avoid 409 conflicts
+	// when Authentik tries to push the same group names.
+	if !oidcWithSCIM {
+		auths, _ := client.Sys().ListAuth()
+		accessor := auths["oidc/"].Accessor
+		setupExternalGroup(client, "admin", accessor, []string{"admin"})
+		setupExternalGroup(client, "user-ro", accessor, []string{"user-ro"})
+	}
+
+	return nil
 }
 
-// -----------------------------------------------------------------------------
-// Helper Functions
-// -----------------------------------------------------------------------------
+func cleanVaultOIDC(client *vault.Client, vaultErr error) {
+	if vaultErr != nil || client == nil {
+		fmt.Println("  ⚠️  Vault offline — skipping Vault-internal cleanup")
+		return
+	}
+	cleanVaultSCIM(client)
+	_ = client.Sys().DisableAuth("oidc")
+	_ = client.Sys().Unmount(oidcKVMount)
+	_ = client.Sys().DeletePolicy("admin")
+	_ = client.Sys().DeletePolicy("user-ro")
+	// Delete identity groups by name. SCIM-managed groups are owned by Vault's
+	// SCIM layer and can't be deleted via the identity API — those are cleaned up
+	// by cleanVaultSCIM above (which deletes the SCIM client, removing its groups).
+	_, _ = client.Logical().Delete("identity/group/name/admin")
+	_, _ = client.Logical().Delete("identity/group/name/user-ro")
+}
 
-func setupExternalGroup(client *vault.Client, groupName string, accessor string, policies []string) {
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+func setupExternalGroup(client *vault.Client, groupName, accessor string, policies []string) {
 	grpResp, err := client.Logical().Write("identity/group", map[string]interface{}{
 		"name":     groupName,
 		"type":     "external",
@@ -348,9 +454,7 @@ func setupExternalGroup(client *vault.Client, groupName string, accessor string,
 	if err != nil || grpResp == nil {
 		return
 	}
-
 	groupID := grpResp.Data["id"].(string)
-
 	_, _ = client.Logical().Write("identity/group-alias", map[string]interface{}{
 		"name":           groupName,
 		"mount_accessor": accessor,
@@ -358,71 +462,44 @@ func setupExternalGroup(client *vault.Client, groupName string, accessor string,
 	})
 }
 
-func waitForKeycloak(url string, maxRetries int) error {
-	client := http.Client{Timeout: 2 * time.Second}
-	for i := 0; i < maxRetries; i++ {
-		resp, err := client.Get(url)
-		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == 200 {
-				return nil
-			}
-		}
-		time.Sleep(2 * time.Second)
-	}
-	return fmt.Errorf("timeout")
+func printAuthentikCredentials(secrets *integrations.AuthentikSecrets) {
+	fmt.Println()
+	fmt.Println("  🔑 Authentik — first boot credentials")
+	fmt.Printf("     Admin UI  : %s/if/admin/\n", integrations.AuthentikAdminURL())
+	fmt.Println("     Username  : akadmin")
+	fmt.Printf("     Password  : %s\n", secrets.AdminPassword)
+	fmt.Printf("     Saved at  : %s\n", integrations.AuthentikEnvPath())
+	fmt.Println()
+	fmt.Println("     To reset: docker exec hal-authentik-server ak changepassword akadmin")
+	fmt.Println()
 }
 
-func waitForVaultVisibleKeycloak(engine, discoveryURL string, maxRetries int) error {
-	for i := 0; i < maxRetries; i++ {
-		cmd := exec.Command(
-			engine,
-			"exec",
-			"hal-vault",
-			"sh",
-			"-lc",
-			fmt.Sprintf("command -v curl >/dev/null 2>&1 && curl -fsS %q >/dev/null || wget -qO- %q >/dev/null", discoveryURL, discoveryURL),
-		)
-		if err := cmd.Run(); err == nil {
-			return nil
-		}
-		time.Sleep(2 * time.Second)
-	}
-	return fmt.Errorf("timeout waiting for Vault-visible discovery URL")
-}
-
-func writeOIDCConfigWithRetry(client *vault.Client, discoveryURL string, maxRetries int) (*vault.Secret, error) {
-	var lastErr error
-	for i := 0; i < maxRetries; i++ {
-		secret, err := client.Logical().Write("auth/oidc/config", map[string]interface{}{
-			"oidc_discovery_url": discoveryURL,
-			"oidc_client_id":     "vault",
-			"oidc_client_secret": "supersecret",
-			"default_role":       "default",
-		})
-		if err == nil {
-			return secret, nil
-		}
-		lastErr = err
-		if !strings.Contains(strings.ToLower(err.Error()), "error checking oidc discovery url") {
-			return nil, err
-		}
-		time.Sleep(2 * time.Second)
-	}
-	return nil, lastErr
+func printOIDCSuccess(issuer string, _ *integrations.AuthentikSecrets) {
+	fmt.Println()
+	fmt.Println("✅ Vault OIDC + Authentik IdP ready!")
+	fmt.Println()
+	fmt.Println("  UI login   : http://vault.localhost:8200  (select 'OIDC', leave role blank)")
+	fmt.Println("  CLI login  : vault login -method=oidc")
+	fmt.Println()
+	fmt.Println("  Demo users:")
+	fmt.Println("    alice / password  →  admin policy (full access)")
+	fmt.Println("    bob   / password  →  user-ro policy (kv-oidc/team1 read)")
+	fmt.Println()
+	fmt.Printf("  Authentik  : %s/if/admin/\n", integrations.AuthentikAdminURL())
+	fmt.Printf("  OIDC issuer: %s\n", issuer)
 }
 
 func init() {
-	// Standard Lifecycle Flags
-	vaultOidcCmd.Flags().BoolVarP(&oidcEnable, "enable", "e", false, "Deploy Keycloak and fully configure Vault OIDC auth")
-	vaultOidcCmd.Flags().BoolVarP(&oidcDisable, "disable", "d", false, "Remove Keycloak and strip the OIDC configuration from Vault")
-	vaultOidcCmd.Flags().BoolVarP(&oidcUpdate, "update", "u", false, "Reconcile Keycloak and Vault OIDC integration")
+	vaultOidcCmd.Flags().BoolVarP(&oidcEnable, "enable", "e", false, "Start Authentik and configure Vault OIDC")
+	vaultOidcCmd.Flags().BoolVarP(&oidcDisable, "disable", "d", false, "Remove Vault OIDC and tear down Authentik if unused")
+	vaultOidcCmd.Flags().BoolVarP(&oidcUpdate, "update", "u", false, "Re-provision Vault OIDC providers")
 	_ = vaultOidcCmd.Flags().MarkHidden("enable")
 	_ = vaultOidcCmd.Flags().MarkHidden("disable")
 	_ = vaultOidcCmd.Flags().MarkHidden("update")
 
-	// Feature-Specific Flags
-	vaultOidcCmd.Flags().StringVar(&keycloakVersion, "keycloak-version", "24.0.4", "Version of the Keycloak container image to deploy")
+	vaultOidcCmd.Flags().BoolVar(&oidcWithSCIM, "scim", false, "[Vault Enterprise] Also configure SCIM provisioning from Authentik")
+	vaultOidcCmd.Flags().StringVar(&oidcAuthentikImage, "authentik-image", integrations.AuthentikDefaultImage, "Authentik container image")
+	vaultOidcCmd.Flags().StringVar(&oidcAuthentikTag, "authentik-tag", integrations.AuthentikDefaultTag, "Authentik image tag")
 
 	Cmd.AddCommand(vaultOidcCmd)
 }

--- a/cmd/vault/scim.go
+++ b/cmd/vault/scim.go
@@ -1,0 +1,261 @@
+package vault
+
+// SCIM provisioning — Vault Enterprise + Authentik outbound sync.
+//
+// Vault SCIM maps:
+//   SCIM User  → Vault Entity
+//   SCIM Group → Vault internal identity Group
+//
+// alias_mount_accessor is intentionally omitted — the OIDC auth method handles
+// entity alias creation when users log in. SCIM's primary role here is group
+// sync: groups created in Authentik automatically appear in Vault.
+//
+// Vault SCIM is a beta feature requiring Vault Enterprise.
+
+import (
+	"fmt"
+	"strings"
+
+	"hal/internal/integrations"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+const (
+	scimClientName = "authentik-scim"
+	scimEntityName = "scim-client-authentik"
+	scimTokenRole  = "authentik-scim"
+	scimPolicyName = "scim-client"
+	// Authentik reaches Vault via Docker internal DNS on hal-net.
+	scimVaultBaseURL = "http://hal-vault:8200/v1/identity/scim/v2"
+)
+
+// configureSCIM activates Vault Enterprise SCIM, creates a bearer-token-authenticated
+// SCIM client, and wires Authentik to push groups and users into Vault.
+// appSlug is the Authentik application slug to assign the SCIM backchannel provider to.
+func configureSCIM(client *vault.Client, aktClient *integrations.AuthentikClient, appSlug string) error {
+	// 0. Remove any groups that were pre-created by a prior non-SCIM OIDC enable.
+	// When `hal vault oidc enable` is run first, it creates `admin` and `user-ro` as
+	// external Vault groups. If the user then re-runs with --scim, those groups are
+	// still present and Authentik SCIM will hit 409 trying to create the same names.
+	// Only delete groups that are NOT already SCIM-managed (scim_client_id empty).
+	fmt.Println("  ⚙️  Checking for pre-existing non-SCIM identity groups...")
+	for _, name := range []string{"admin", "user-ro"} {
+		resp, err := client.Logical().Read("identity/group/name/" + name)
+		if err != nil || resp == nil {
+			continue // doesn't exist — nothing to do
+		}
+		if scimID, _ := resp.Data["scim_client_id"].(string); scimID != "" {
+			fmt.Printf("  ℹ️  Group %q already SCIM-managed — skipping\n", name)
+			continue
+		}
+		// External group created by the non-SCIM path — remove it so SCIM can own it.
+		if _, err := client.Logical().Delete("identity/group/name/" + name); err != nil {
+			fmt.Printf("  ⚠️  Could not remove pre-existing group %q: %v\n", name, err)
+		} else {
+			fmt.Printf("  🗑️  Removed pre-existing non-SCIM group %q\n", name)
+		}
+	}
+
+	// 1. Activate the SCIM feature flag.
+	// "Activating the SCIM flag is a one-time action" — ignore errors that indicate
+	// the flag is already set so re-runs are safe.
+	fmt.Println("  ⚙️  Activating Vault SCIM feature flag...")
+	if _, err := client.Logical().Write("sys/activation-flags/enable-scim/activate", nil); err != nil {
+		if !strings.Contains(err.Error(), "already") && !strings.Contains(err.Error(), "activated") {
+			return fmt.Errorf("activate SCIM flag: %w", err)
+		}
+		fmt.Println("  ℹ️  SCIM flag already active — continuing")
+	}
+
+	// 2. SCIM client policy.
+	// "patch" capability is required in addition to "update" for HTTP PATCH requests
+	// (Vault 1.14+). Without it, Authentik's group membership PATCH is rejected with
+	// permission denied, leaving group member_entity_ids permanently empty.
+	fmt.Println("  ⚙️  Writing scim-client policy...")
+	if err := client.Sys().PutPolicy(scimPolicyName, `
+path "identity/scim/v2/*" {
+  capabilities = ["create", "read", "update", "patch", "delete", "list"]
+}
+`); err != nil {
+		return fmt.Errorf("write scim policy: %w", err)
+	}
+
+	// 3. Vault entity representing the SCIM client.
+	fmt.Println("  ⚙️  Creating Vault entity for SCIM client...")
+	entityID, err := upsertEntity(client, scimEntityName)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  ℹ️  SCIM entity ID: %s\n", entityID)
+
+	// 4. Auth mount accessors.
+	auths, err := client.Sys().ListAuth()
+	if err != nil {
+		return fmt.Errorf("list auth mounts: %w", err)
+	}
+	tokenMount, ok := auths["token/"]
+	if !ok {
+		return fmt.Errorf("token auth mount not found")
+	}
+	tokenAccessor := tokenMount.Accessor
+	oidcMount, ok := auths["oidc/"]
+	if !ok {
+		return fmt.Errorf("oidc auth mount not found — run 'hal vault oidc enable' first")
+	}
+	oidcAccessor := oidcMount.Accessor
+	fmt.Printf("  ℹ️  Token accessor: %s  OIDC accessor: %s\n", tokenAccessor, oidcAccessor)
+
+	// 5. Vault SCIM client.
+	// alias_mount_accessor = oidc/ so each SCIM-provisioned user gets an entity alias
+	// on the OIDC mount automatically. This means the SCIM entity and the OIDC login
+	// entity are the same — group memberships sync'd via SCIM are immediately visible
+	// when the user logs in via OIDC.
+	// alias_mount_accessor is immutable after creation, so we skip create if the client
+	// already exists and let cleanVaultSCIM handle full teardown on disable.
+	fmt.Println("  ⚙️  Creating Vault SCIM client (authentik-scim)...")
+	existing, _ := client.Logical().Read("identity/scim/client/" + scimClientName)
+	if existing == nil {
+		_, err := client.Logical().Write("identity/scim/client/"+scimClientName, map[string]interface{}{
+			"access_grant_principal": entityID,
+			"alias_mount_accessor":   oidcAccessor,
+		})
+		if err != nil {
+			return fmt.Errorf("create scim client: %w\n\n  Diagnostics: entityID=%q oidcAccessor=%q\n  Hint: run 'vault delete identity/scim/client/%s' then retry",
+				err, entityID, oidcAccessor, scimClientName)
+		}
+	} else {
+		fmt.Println("  ℹ️  SCIM client already exists — skipping creation")
+	}
+
+	// 6. Entity alias on token auth mount so a minted token resolves to the SCIM entity.
+	fmt.Println("  ⚙️  Creating entity alias on token mount...")
+	_, aliasErr := client.Logical().Write("identity/entity-alias", map[string]interface{}{
+		"name":           scimClientName,
+		"mount_accessor": tokenAccessor,
+		"canonical_id":   entityID,
+	})
+	if aliasErr != nil && !strings.Contains(aliasErr.Error(), "combination of mount and entity alias already exists") {
+		return fmt.Errorf("create entity alias: %w", aliasErr)
+	}
+
+	// 7. Token role that pins allowed entity aliases.
+	fmt.Println("  ⚙️  Creating SCIM token role...")
+	if _, err := client.Logical().Write("auth/token/roles/"+scimTokenRole, map[string]interface{}{
+		"allowed_entity_aliases":  []string{scimClientName},
+		"orphan":                  true,
+		"token_no_default_policy": true,
+		"token_period":            "768h", // 32-day renewable
+	}); err != nil {
+		return fmt.Errorf("create token role: %w", err)
+	}
+
+	// 8. Mint bearer token that Authentik will send to Vault SCIM endpoints.
+	fmt.Println("  ⚙️  Minting SCIM bearer token...")
+	sec, err := client.Auth().Token().CreateWithRole(&vault.TokenCreateRequest{
+		Policies:        []string{scimPolicyName},
+		NoDefaultPolicy: true,
+		EntityAlias:     scimClientName,
+	}, scimTokenRole)
+	if err != nil {
+		return fmt.Errorf("mint scim bearer token: %w", err)
+	}
+	bearerToken := sec.Auth.ClientToken
+
+	// 9. Configure Authentik outbound SCIM provider → Vault.
+	fmt.Println("  ⚙️  Configuring Authentik SCIM provider → Vault...")
+	userMappings, groupMappings, err := aktClient.GetDefaultSCIMPropertyMappings()
+	if err != nil {
+		return fmt.Errorf("get scim property mappings: %w", err)
+	}
+
+	providerPK, err := aktClient.CreateSCIMProvider(
+		"vault-scim-provider",
+		scimVaultBaseURL,
+		bearerToken,
+		userMappings,
+		groupMappings,
+	)
+	if err != nil {
+		return fmt.Errorf("create authentik scim provider: %w", err)
+	}
+
+	// 10. Assign the SCIM provider as a backchannel provider on the Vault application.
+	// Without this step, Authentik never activates the outbound sync.
+	fmt.Println("  ⚙️  Assigning SCIM provider as backchannel on Vault application...")
+	if err := aktClient.SetApplicationBackchannelProviders(appSlug, []int{providerPK}); err != nil {
+		return fmt.Errorf("assign backchannel provider: %w", err)
+	}
+
+	// 11. Verify the provider is reachable and show sync status.
+	fmt.Println("  🔍 Checking SCIM provider sync status...")
+	if status, err := aktClient.GetSCIMSyncStatus(providerPK); err == nil && status != nil {
+		if healthy, ok := status["healthy"].(bool); ok {
+			if healthy {
+				fmt.Println("  ✅ SCIM provider healthy")
+			} else {
+				fmt.Println("  ⚠️  SCIM provider reports unhealthy — check Authentik task log")
+			}
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("  ✅ SCIM provisioning configured")
+	fmt.Printf("     Endpoint : %s\n", scimVaultBaseURL)
+	fmt.Println()
+	fmt.Println("  📋 SCIM behaviour:")
+	fmt.Println("     • User creation   → auto-propagated to Vault  ✅")
+	fmt.Println("     • Group creation  → auto-propagated to Vault  ✅")
+	fmt.Println("     • Group membership changes → NOT auto-propagated ⚠️")
+	fmt.Println()
+	fmt.Println("     Authentik does not fire an outbound SCIM event when a user is")
+	fmt.Println("     added to / removed from a group. To propagate membership changes,")
+	fmt.Println("     trigger a per-object group sync as an Authentik admin:")
+	fmt.Println()
+	fmt.Printf("     # 1. Find the group PK\n")
+	fmt.Printf("     curl -s -H 'Authorization: Bearer %s' \\\n", aktClient.Token())
+	fmt.Printf("       '%s/api/v3/core/groups/?search=<group-name>' | jq '.results[0].pk'\n", aktClient.BaseURL())
+	fmt.Println()
+	fmt.Printf("     # 2. Trigger per-object sync for that group (replace <pk>)\n")
+	fmt.Printf("     curl -s -X POST -H 'Authorization: Bearer %s' \\\n", aktClient.Token())
+	fmt.Printf("       -H 'Content-Type: application/json' \\\n")
+	fmt.Printf("       -d '{\"sync_object_model\":\"authentik.core.models.Group\",\"sync_object_id\":\"<pk>\"}' \\\n")
+	fmt.Printf("       '%s/api/v3/providers/scim/%d/sync/object/'\n", aktClient.BaseURL(), providerPK)
+	fmt.Println()
+	fmt.Println("     Verify in Vault:")
+	fmt.Println("       vault list identity/group/name")
+	fmt.Println("       vault read identity/group/name/<group-name>")
+	fmt.Println()
+	return nil
+}
+
+// upsertEntity creates a Vault entity by name, or reads the existing one if it
+// already exists. Returns the entity ID.
+func upsertEntity(client *vault.Client, name string) (string, error) {
+	resp, err := client.Logical().Write("identity/entity", map[string]interface{}{"name": name})
+	if err == nil && resp != nil && resp.Data != nil {
+		if id, ok := resp.Data["id"].(string); ok && id != "" {
+			return id, nil
+		}
+	}
+	// Entity already exists or response body was empty — look up by name.
+	lookup, err2 := client.Logical().Read("identity/entity/name/" + name)
+	if err2 != nil || lookup == nil {
+		if err != nil {
+			return "", fmt.Errorf("create entity %q: %w", name, err)
+		}
+		return "", fmt.Errorf("entity %q not found after create", name)
+	}
+	id, _ := lookup.Data["id"].(string)
+	if id == "" {
+		return "", fmt.Errorf("entity %q has empty ID", name)
+	}
+	return id, nil
+}
+
+// cleanVaultSCIM removes Vault SCIM configuration. No-op if resources do not exist.
+func cleanVaultSCIM(client *vault.Client) {
+	_, _ = client.Logical().Delete("identity/scim/client/" + scimClientName)
+	_, _ = client.Logical().Delete("auth/token/roles/" + scimTokenRole)
+	_ = client.Sys().DeletePolicy(scimPolicyName)
+}

--- a/docs/commands/vault-oidc.md
+++ b/docs/commands/vault-oidc.md
@@ -4,28 +4,112 @@
 - `hal vault oidc`
 
 ## Purpose
-Deploy Keycloak and configure Vault OIDC authentication flow.
+Deploy Authentik as a shared Identity Provider and configure Vault OIDC authentication.
+With `--scim` (Vault Enterprise only), also wire Authentik outbound SCIM to provision users and groups into Vault automatically.
 
 ## Related
 - Parent namespace: [vault.md](vault.md)
+- Architecture: [../scim-idp-spec.md](../scim-idp-spec.md)
 
 ## Prerequisites
 - HAL CLI is available in your local environment.
-- The relevant product base deployment should be running when this command targets an existing stack.
+- Vault must be running and healthy (`hal vault create`).
+- For `--scim`: Vault Enterprise image required (`hal vault create --edition ent`).
+
 ## Flags
-- Deprecated: older HAL docs may reference `hal vault oidc --force`. That flag has been removed from the CLI. Use `hal vault oidc update`.
-- Command flags from `hal vault oidc --help`:
 ```text
--h, --help                      help for oidc
---keycloak-version string   Version of the Keycloak container image to deploy (default "24.0.4")
--u, --update                    Reconcile Keycloak and Vault OIDC integration
+-h, --help                        help for oidc
+    --authentik-image string      Authentik container image (default "ghcr.io/goauthentik/server")
+    --authentik-tag string        Authentik image tag (default "2026.2.3")
+    --scim                        [Vault Enterprise] Also configure SCIM provisioning from Authentik
+-u, --update                      Re-provision Vault OIDC providers (keeps Authentik running)
+-e, --enable                      Start Authentik and configure Vault OIDC
+-d, --disable                     Remove Vault OIDC and tear down Authentik if unused
 ```
 - Global flags: `--debug`, `--dry-run`
 
-## Side Effects
-- This command may create, mutate, or remove local lab resources depending on its operation.
+## Lifecycle Actions
 
-## Example
+| Action | Command | Description |
+|--------|---------|-------------|
+| status | `hal vault oidc` | Show Authentik stack health + Vault OIDC mount state (default) |
+| enable | `hal vault oidc enable` | Start Authentik, provision demo users/groups, configure Vault OIDC |
+| update | `hal vault oidc update` | Re-provision Vault OIDC with fresh credentials (Authentik stays running) |
+| disable | `hal vault oidc disable` | Remove Vault OIDC; stop Authentik only if no other product uses it |
+
+## What Gets Deployed
+
+**Authentik containers** (all on `hal-net`):
+- `hal-authentik-pg` — PostgreSQL database
+- `hal-authentik-server` — API + UI at `http://authentik.localhost:9100`
+- `hal-authentik-worker` — Celery background tasks
+
+**Authentik objects**:
+- Groups: `admin`, `user-ro`
+- Users: `alice / password` (admin), `bob / password` (user-ro)
+- OAuth2 provider: `vault-oidc-provider` (implicit-consent flow, groups scope)
+- Application slug: `hashicorp-vault` (tile launch URL: `http://vault.localhost:8200/ui/vault/auth/oidc`)
+
+**Vault objects (OIDC only)**:
+- OIDC auth mount: `oidc/`
+- KV-V2 mount: `kv-oidc/`
+- Policies: `admin` (all paths), `user-ro` (kv-oidc/team1 read)
+- External identity groups `admin` and `user-ro` with OIDC accessor aliases
+
+**Additional Vault objects with `--scim` (Enterprise)**:
+- SCIM feature flag activated (one-way, permanent)
+- Policy `scim-client` (`identity/scim/v2/*` — create/read/update/patch/delete/list)
+- Entity `scim-client-authentik` with alias on token mount
+- Token role `authentik-scim` (32-day renewable, orphan)
+- SCIM client `authentik-scim` with `alias_mount_accessor = oidc/`
+- Authentik: outbound SCIM provider `vault-scim-provider` (AWS compatibility mode) targeting `http://hal-vault:8200/v1/identity/scim/v2`
+- Authentik: SCIM provider assigned as backchannel on `hashicorp-vault` application
+- External groups (`admin`, `user-ro`) are **not** pre-created — Authentik SCIM owns group creation
+
+## SCIM Behaviour
+
+| Event | Propagated automatically |
+|-------|--------------------------|
+| User created in Authentik | ✅ Yes |
+| Group created in Authentik | ✅ Yes |
+| User added to / removed from group | ❌ No — requires manual per-object sync |
+
+To force-sync group membership after adding a user to a group, the bootstrap token and SCIM provider PK are printed at enable time. Run:
 ```bash
-hal vault oidc enable
+# 1. Find the group PK
+curl -s -H 'Authorization: Bearer <bootstrap-token>' \
+  'http://authentik.localhost:9100/api/v3/core/groups/?search=<group-name>' | jq '.results[0].pk'
+
+# 2. Trigger per-object sync
+curl -s -X POST -H 'Authorization: Bearer <bootstrap-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"sync_object_model":"authentik.core.models.Group","sync_object_id":"<pk>"}' \
+  'http://authentik.localhost:9100/api/v3/providers/scim/<scim-provider-pk>/sync/object/'
 ```
+
+## Side Effects
+- Creates/removes containers `hal-authentik-pg`, `hal-authentik-server`, `hal-authentik-worker`.
+- Registers/deregisters `vault-oidc` in `~/.hal/shared-services.json` under key `authentik-idp`.
+- Authentik secrets are generated once and persisted at `~/.hal/authentik/env` (mode 0600).
+- Authentik stack is only torn down when no other product is registered as a consumer.
+
+## Examples
+```bash
+# First-time setup
+hal vault oidc enable
+
+# First-time setup with SCIM (Vault Enterprise)
+export VAULT_LICENSE='...'
+hal vault create --edition ent
+hal vault oidc enable --scim
+
+# Re-provision after Vault restart (keeps Authentik running)
+hal vault oidc update
+
+# Check current state
+hal vault oidc
+
+# Login with OIDC (browser opens Authentik login)
+vault login -method=oidc
+```
+

--- a/docs/scim-idp-spec.md
+++ b/docs/scim-idp-spec.md
@@ -1,0 +1,267 @@
+# HAL SCIM / IdP Spec — Authentik Stack
+
+## Overview
+
+Authentik is the shared Identity Provider (IdP) for HAL lab products. It is managed as a shared service — multiple products can register against the same running stack.
+
+**Current status**:
+- ✅ `hal vault oidc enable` — Authentik IdP + Vault OIDC auth, fully working
+- ✅ `hal vault oidc enable --scim` — Vault Enterprise SCIM provisioning, fully working
+- 🔜 `hal tf saml enable [--scim]` — TFE SAML + optional SCIM (separate branch)
+
+---
+
+## User-Facing Commands
+
+```bash
+# Deploy Authentik, provision demo users/groups, configure Vault OIDC
+hal vault oidc enable
+
+# Re-provision Vault OIDC (keeps Authentik running, fresh clientID/secret)
+hal vault oidc update
+
+# Remove Vault OIDC; stop Authentik only if no other product is using it
+hal vault oidc disable
+
+# Show Authentik stack health + Vault OIDC mount state
+hal vault oidc status
+```
+
+Flags:
+| Flag | Default | Description |
+|---|---|---|
+| `--scim` | `false` | [Vault Enterprise] Also configure SCIM provisioning from Authentik |
+| `--authentik-image` | `ghcr.io/goauthentik/server` | Authentik image name |
+| `--authentik-tag` | `2026.2.3` | Authentik image tag |
+
+---
+
+## Container Architecture
+
+### Names and roles
+
+| Container | Image | Role |
+|---|---|---|
+| `hal-authentik-pg` | `docker.io/library/postgres:16-alpine` | Authentik database |
+| `hal-authentik-server` | `ghcr.io/goauthentik/server:<tag>` | Authentik API + UI (cmd: `server`) |
+| `hal-authentik-worker` | `ghcr.io/goauthentik/server:<tag>` | Celery background tasks (cmd: `worker`) |
+
+All three containers join `hal-net`. **No static IPs** — Docker DNS handles name resolution. Static IPs require `hal-net` to be created with an explicit `--subnet`; HAL does not enforce one.
+
+### Ports
+
+| Host port | Container port | Service |
+|---|---|---|
+| `9100` | `9100` | Authentik HTTP |
+| `9143` | `9143` | Authentik HTTPS |
+
+Port 9100/9143 avoids conflicts with 9000 (hal-plus/MinIO), 9001 (hal-health/MinIO console), 9443 (TFE twin HTTPS).
+
+`AUTHENTIK_LISTEN__HTTP=0.0.0.0:9100` **must** be set on the server container so the internal listening port matches the external port. Without this, Authentik listens on 9000 internally and the OIDC issuer URL becomes `http://authentik.localhost:9000/...` while the host port is 9100, breaking OIDC discovery.
+
+### Canonical URL
+
+`authentik.localhost:9100` via `--network-alias authentik.localhost` on the server container.
+- macOS resolves `*.localhost` → 127.0.0.1 (host browser)
+- Docker containers on `hal-net` resolve via network alias (container-to-container)
+
+This keeps the OIDC issuer URL identical from both contexts.
+
+### No Docker socket
+
+`AUTHENTIK_OUTPOSTS__DISCOVER=false` on both server and worker. HAL does not use Authentik Outposts (proxy/LDAP) and does not mount the Docker socket. This works identically with podman rootless and Docker.
+
+### Volumes
+
+| Name | Mount | Type |
+|---|---|---|
+| `hal-authentik-db` | `/var/lib/postgresql/data` in pg container | Named volume |
+| `~/.hal/authentik/data` | `/data` in server + worker | Bind mount |
+
+### Secrets file
+
+`~/.hal/authentik/env` (mode 0600). Generated once, reused on every start.
+
+```
+PG_PASS=<32-char hex>
+AUTHENTIK_SECRET_KEY=<64-char hex>
+AUTHENTIK_BOOTSTRAP_TOKEN=<40-char hex>
+AUTHENTIK_BOOTSTRAP_PASSWORD=<24-char hex>
+```
+
+`AUTHENTIK_BOOTSTRAP_TOKEN` and `AUTHENTIK_BOOTSTRAP_PASSWORD` must be set on **both server and worker**. The worker runs the Celery tasks that create the API token record in the database — if the worker doesn't have `AUTHENTIK_BOOTSTRAP_TOKEN`, the token is never persisted.
+
+---
+
+## Startup Sequence and Known Race Conditions
+
+### Bootstrap token race
+
+`WaitAuthentikHealthy()` polls `GET /api/v3/root/config/` (unauthenticated) until 200. This returns 200 as soon as the server starts — but the worker creates the bootstrap token asynchronously after migrations. There is a window where the server is healthy but the token does not exist yet.
+
+**Fix**: always call `WaitAuthentikTokenReady(token)` after `WaitAuthentikHealthy()`, on every path including when Authentik is already running. It polls `GET /api/v3/core/groups/` with `Authorization: Bearer <token>` until 200 (60 s timeout). This tests an admin-only endpoint — same permission class as the provisioning calls.
+
+---
+
+## Authentik REST API — Version Notes (2026.x / 2024.4+)
+
+These endpoints changed and broke against the original implementation:
+
+| What | Old path | New path |
+|---|---|---|
+| Scope property mappings | `/api/v3/propertymappings/scope/` | `/api/v3/propertymappings/provider/scope/` |
+
+Additional required fields added in 2024.x:
+
+- `POST /api/v3/providers/oauth2/` now requires **`invalidation_flow`** in addition to `authorization_flow`. Use `GetDefaultInvalidationFlowPK()` which prefers the `default-provider-invalidation-flow` slug.
+
+Removed defaults:
+
+- The built-in **groups scope mapping** (`scope_name: groups`) no longer ships in Authentik 2024.x+. `GetGroupsScopeMappingPK()` creates it automatically when absent:
+  ```python
+  # scope_name: groups
+  return list(request.user.ak_groups.values_list("name", flat=True))
+  ```
+
+---
+
+## Vault OIDC Topology
+
+### What gets provisioned in Authentik
+
+| Object | Value |
+|---|---|
+| Group | `admin` |
+| Group | `user-ro` |
+| User | `alice / password` → group `admin` |
+| User | `bob / password` → group `user-ro` |
+| Scope mapping | `hal: OIDC groups scope` (created if absent) |
+| OAuth2 provider | `vault-oidc-provider` (confidential, implicit-consent flow, `sub_mode: user_username`) |
+| Application | slug `hashicorp-vault`, `meta_launch_url: http://vault.localhost:8200/ui/vault/auth/oidc` |
+
+### What gets provisioned in Vault
+
+| Object | Value |
+|---|---|
+| KV-V2 mount | `kv-oidc` |
+| Demo secret | `kv-oidc/data/team1` |
+| Policy | `admin` (all paths) |
+| Policy | `user-ro` (kv-oidc/team1 read) |
+| OIDC auth method | `oidc/` mount |
+| OIDC role | `default` (groups claim, allowed redirect URIs) |
+| External group | `admin` + alias bound to OIDC accessor |
+| External group | `user-ro` + alias bound to OIDC accessor |
+
+### OIDC redirect URIs
+
+```
+http://localhost:8250/oidc/callback        (Vault CLI)
+http://127.0.0.1:8250/oidc/callback       (Vault CLI fallback)
+http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback   (Vault UI)
+```
+
+### Authorization flow
+
+The OAuth2 provider uses the **implicit-consent** authorization flow so the Authentik popup redirects directly back to Vault without showing an intermediate consent page. The explicit-consent flow caused OAuth state to be orphaned on the second auth attempt ("Expired or missing OAuth state" error).
+
+### Login
+
+```bash
+vault login -method=oidc     # CLI — browser opens Authentik login
+# or open http://vault.localhost:8200 → select OIDC, leave role blank
+```
+
+---
+
+## update Behavior
+
+`hal vault oidc update`:
+1. Cleans Vault: disables `oidc` auth, unmounts `kv-oidc`, deletes policies and identity groups.
+2. Cleans Authentik: deletes the `hashicorp-vault` application and `vault-oidc-provider` OAuth2 provider by name (no-op if absent).
+3. Falls through to the enable path — Authentik stack stays running, `WaitAuthentikTokenReady` always runs, full re-provision with fresh clientID/clientSecret.
+
+---
+
+## Shared Service Registry
+
+Service key: `"authentik-idp"` in `~/.hal/shared-services.json`.
+
+Consumer values registered today:
+- `"vault-oidc"` — registered by `hal vault oidc enable`
+- `"vault-saml"` — future: `hal tf saml enable`
+
+Authentik stack is torn down on disable only when the consumer list reaches zero.
+
+---
+
+## SCIM — Vault Enterprise (`--scim`)
+
+`hal vault oidc enable --scim` wires Authentik outbound SCIM to Vault. Requires Vault Enterprise (`hal vault create --edition ent`).
+
+### What it does
+
+1. **Activates SCIM flag** in Vault (`sys/activation-flags/enable-scim/activate`) — one-way, permanent.
+2. **Writes `scim-client` policy** covering `identity/scim/v2/*` with create/read/update/patch/delete/list.
+   - `patch` capability is required (Vault 1.14+) for group membership PATCH requests. Without it members list stays empty.
+3. **Creates entity** `scim-client-authentik` — the Vault identity that the SCIM bearer token resolves to.
+4. **Creates SCIM client** `authentik-scim` with `alias_mount_accessor = oidc/` so SCIM-provisioned entities and OIDC-logged-in users share the same Vault entity (group policies apply immediately on login).
+5. **Mints a bearer token** via token role `authentik-scim` (32-day renewable orphan).
+6. **Creates Authentik outbound SCIM provider** `vault-scim-provider` in `compatibility_mode: aws`.
+   - AWS mode avoids including `"schemas"` inside PATCH Operation objects. Vault SCIM rejects that with 400/invalidValue, which leaves group membership permanently empty.
+7. **Assigns SCIM provider as backchannel** on the `hashicorp-vault` application — required for Authentik to activate outbound sync.
+
+### Group ownership
+
+When `--scim` is used:
+- External groups (`admin`, `user-ro`) are **not** pre-created in Vault — Authentik SCIM owns them.
+- If a prior non-SCIM `hal vault oidc enable` created them, they are detected and removed before SCIM setup so Authentik can take ownership without 409 conflicts.
+
+### SCIM event behaviour
+
+| Event | Propagated automatically |
+|-------|--------------------------|
+| User created in Authentik | ✅ Yes (event-driven) |
+| Group created in Authentik | ✅ Yes (event-driven) |
+| User added to / removed from group | ❌ No — Authentik does not fire an outbound SCIM event for ManyToMany membership changes |
+
+To propagate group membership changes, trigger a per-object sync as Authentik admin. The exact `curl` commands with the real bootstrap token and SCIM provider PK are printed by `hal vault oidc enable --scim`:
+
+```bash
+# Valid sync_object_model values: authentik.core.models.Group | authentik.core.models.User
+curl -s -X POST -H 'Authorization: Bearer <bootstrap-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"sync_object_model":"authentik.core.models.Group","sync_object_id":"<group-pk>"}' \
+  'http://authentik.localhost:9100/api/v3/providers/scim/<scim-provider-pk>/sync/object/'
+```
+
+### Drift recovery
+
+If Vault is re-created while Authentik stays running (SCIM groups/users still in Authentik, Vault is empty):
+
+```bash
+hal vault oidc update    # tears down and re-provisions everything including SCIM
+```
+
+This re-activates the SCIM flag, recreates the SCIM client + provider, and triggers fresh pushes for all objects.
+
+---
+
+## TFE SAML + SCIM — Future Track (`feature/tf-saml`)
+
+`hal tf saml enable [--scim]`:
+- Shares the same Authentik stack via `"authentik-idp"` shared service key.
+- SAML provider in Authentik targeting TFE SAML endpoint.
+- Optional SCIM to `https://tfe.localhost/api/scim/v2/`.
+- Separate branch — do not implement on `feature/vault-scim`.
+
+---
+
+## File Locations
+
+| File | Role |
+|---|---|
+| `cmd/vault/oidc.go` | `hal vault oidc` command — enable/disable/update/status flows |
+| `internal/integrations/authentik.go` | Shared Authentik stack lifecycle + REST API client |
+| `internal/global/shared_services.go` | Shared service consumer tracking |
+| `~/.hal/authentik/env` | Generated secrets (mode 0600) |
+| `~/.hal/shared-services.json` | Consumer registry |

--- a/internal/global/shared_services.go
+++ b/internal/global/shared_services.go
@@ -115,3 +115,13 @@ func ClearSharedService(service string) error {
 	delete(state, service)
 	return saveSharedServicesState(state)
 }
+
+// GetSharedServiceConsumers returns the list of consumers registered for a service key.
+// Returns an empty slice when the service has no consumers or the file does not exist.
+func GetSharedServiceConsumers(service string) []string {
+	state, err := loadSharedServicesState()
+	if err != nil {
+		return nil
+	}
+	return state[service]
+}

--- a/internal/integrations/authentik.go
+++ b/internal/integrations/authentik.go
@@ -1,0 +1,940 @@
+package integrations
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"hal/internal/global"
+)
+
+const (
+	AuthentikPGContainer     = "hal-authentik-pg"
+	AuthentikServerContainer = "hal-authentik-server"
+	AuthentikWorkerContainer = "hal-authentik-worker"
+
+	AuthentikDefaultImage = "ghcr.io/goauthentik/server"
+	AuthentikDefaultTag   = "2026.2.3"
+
+	// Host ports — chosen to avoid all existing HAL port usage.
+	// 9000: hal-plus / MinIO internal
+	// 9001: hal-health / MinIO console internal
+	// 9443: TFE twin HTTPS
+	AuthentikHTTPPort  = "9100"
+	AuthentikHTTPSPort = "9143"
+
+	// Shared-services key used in ~/.hal/shared-services.json
+	AuthentikSharedServiceKey = "authentik-idp"
+)
+
+// AuthentikSecrets holds the secrets loaded from / generated into ~/.hal/authentik/env.
+type AuthentikSecrets struct {
+	PGPass         string
+	SecretKey      string
+	BootstrapToken string
+	AdminPassword  string
+}
+
+// AuthentikAdminURL returns the canonical base URL for the Authentik UI/API.
+// Uses authentik.localhost so the URL is identical from the host browser
+// (macOS resolves *.localhost → 127.0.0.1) and from containers on hal-net
+// (via --network-alias authentik.localhost). This guarantees a consistent
+// OIDC issuer in tokens so Vault validation never fails.
+func AuthentikAdminURL() string {
+	return fmt.Sprintf("http://authentik.localhost:%s", AuthentikHTTPPort)
+}
+
+// AuthentikOIDCIssuer returns the OIDC issuer URL for a given application slug.
+// Vault must use this URL for both oidc_discovery_url and callback validation.
+func AuthentikOIDCIssuer(slug string) string {
+	return fmt.Sprintf("http://authentik.localhost:%s/application/o/%s/", AuthentikHTTPPort, slug)
+}
+
+// authentikDir returns ~/.hal/authentik.
+func authentikDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hal", "authentik")
+}
+
+// AuthentikEnvPath returns the path to the persistent secrets file.
+func AuthentikEnvPath() string {
+	return filepath.Join(authentikDir(), "env")
+}
+
+// AuthentikDataDir returns the bind-mount path for /data in server/worker containers.
+func AuthentikDataDir() string {
+	return filepath.Join(authentikDir(), "data")
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// LoadOrCreateAuthentikSecrets reads ~/.hal/authentik/env or generates fresh values.
+// The file is created with mode 0600.
+func LoadOrCreateAuthentikSecrets() (*AuthentikSecrets, error) {
+	envPath := AuthentikEnvPath()
+	s := &AuthentikSecrets{}
+
+	data, err := os.ReadFile(envPath)
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			parts := strings.SplitN(strings.TrimSpace(line), "=", 2)
+			if len(parts) != 2 || parts[0] == "" {
+				continue
+			}
+			switch parts[0] {
+			case "PG_PASS":
+				s.PGPass = parts[1]
+			case "AUTHENTIK_SECRET_KEY":
+				s.SecretKey = parts[1]
+			case "AUTHENTIK_BOOTSTRAP_TOKEN":
+				s.BootstrapToken = parts[1]
+			case "AUTHENTIK_BOOTSTRAP_PASSWORD":
+				s.AdminPassword = parts[1]
+			}
+		}
+		if s.PGPass != "" && s.SecretKey != "" && s.BootstrapToken != "" && s.AdminPassword != "" {
+			return s, nil
+		}
+	}
+
+	// Generate any missing values.
+	if s.PGPass == "" {
+		s.PGPass = randomHex(16) // 32-char hex; stays well under pg 99-char limit
+	}
+	if s.SecretKey == "" {
+		s.SecretKey = randomHex(32) // 64-char hex
+	}
+	if s.BootstrapToken == "" {
+		s.BootstrapToken = randomHex(20) // 40-char hex, used as static API token
+	}
+	if s.AdminPassword == "" {
+		s.AdminPassword = randomHex(12) // 24-char hex, printed once to user
+	}
+
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create authentik config dir: %w", err)
+	}
+
+	content := fmt.Sprintf(
+		"PG_PASS=%s\nAUTHENTIK_SECRET_KEY=%s\nAUTHENTIK_BOOTSTRAP_TOKEN=%s\nAUTHENTIK_BOOTSTRAP_PASSWORD=%s\n",
+		s.PGPass, s.SecretKey, s.BootstrapToken, s.AdminPassword,
+	)
+	if err := os.WriteFile(envPath, []byte(content), 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write authentik env: %w", err)
+	}
+
+	return s, nil
+}
+
+// IsAuthentikRunning returns true if hal-authentik-server container is up.
+func IsAuthentikRunning(engine string) bool {
+	return global.CheckContainer(engine, AuthentikServerContainer)
+}
+
+// StartAuthentikStack brings up hal-authentik-pg → hal-authentik-server → hal-authentik-worker.
+// image and tag control the Authentik image (defaults: AuthentikDefaultImage / AuthentikDefaultTag).
+func StartAuthentikStack(engine, image, tag string, secrets *AuthentikSecrets) error {
+	if image == "" {
+		image = AuthentikDefaultImage
+	}
+	if tag == "" {
+		tag = AuthentikDefaultTag
+	}
+	imgRef := fmt.Sprintf("%s:%s", image, tag)
+
+	dataDir := AuthentikDataDir()
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create authentik data dir: %w", err)
+	}
+
+	global.EnsureNetwork(engine)
+
+	// ── 1. PostgreSQL ────────────────────────────────────────────────────────────
+	fmt.Println("  ⏳ Starting Authentik PostgreSQL...")
+	pgArgs := []string{
+		"run", "-d",
+		"--name", AuthentikPGContainer,
+		"--network", global.HalNetName,
+		"--restart", "unless-stopped",
+		"-e", "POSTGRES_DB=authentik",
+		"-e", "POSTGRES_USER=authentik",
+		"-e", fmt.Sprintf("POSTGRES_PASSWORD=%s", secrets.PGPass),
+		"-v", "hal-authentik-db:/var/lib/postgresql/data",
+		"docker.io/library/postgres:16-alpine",
+	}
+	if out, err := exec.Command(engine, pgArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to start authentik pg: %w\n%s", err, string(out))
+	}
+
+	// ── 2. Wait for pg ───────────────────────────────────────────────────────────
+	fmt.Print("  ⏳ Waiting for PostgreSQL")
+	deadline := time.Now().Add(30 * time.Second)
+	pgReady := false
+	for time.Now().Before(deadline) {
+		if exec.Command(engine, "exec", AuthentikPGContainer,
+			"pg_isready", "-d", "authentik", "-U", "authentik").Run() == nil {
+			pgReady = true
+			break
+		}
+		fmt.Print(".")
+		time.Sleep(2 * time.Second)
+	}
+	fmt.Println()
+	if !pgReady {
+		return fmt.Errorf("postgresql did not become ready within 30s")
+	}
+	fmt.Println("  ✅ PostgreSQL ready")
+
+	// ── 3. Server ────────────────────────────────────────────────────────────────
+	fmt.Println("  ⏳ Starting Authentik server...")
+	serverArgs := []string{
+		"run", "-d",
+		"--name", AuthentikServerContainer,
+		"--network", global.HalNetName,
+		"--restart", "unless-stopped",
+		// Use the same port inside and outside the container so the OIDC issuer
+		// URL (derived from the Host header) is consistent across browser and
+		// container-to-container traffic.
+		"-p", fmt.Sprintf("%s:%s", AuthentikHTTPPort, AuthentikHTTPPort),
+		"-p", fmt.Sprintf("%s:%s", AuthentikHTTPSPort, AuthentikHTTPSPort),
+		"--network-alias", "authentik.localhost",
+		"--shm-size", "512mb",
+		"-e", fmt.Sprintf("AUTHENTIK_POSTGRESQL__HOST=%s", AuthentikPGContainer),
+		"-e", "AUTHENTIK_POSTGRESQL__NAME=authentik",
+		"-e", "AUTHENTIK_POSTGRESQL__USER=authentik",
+		"-e", fmt.Sprintf("AUTHENTIK_POSTGRESQL__PASSWORD=%s", secrets.PGPass),
+		"-e", fmt.Sprintf("AUTHENTIK_SECRET_KEY=%s", secrets.SecretKey),
+		"-e", fmt.Sprintf("AUTHENTIK_BOOTSTRAP_TOKEN=%s", secrets.BootstrapToken),
+		"-e", fmt.Sprintf("AUTHENTIK_BOOTSTRAP_PASSWORD=%s", secrets.AdminPassword),
+		"-e", fmt.Sprintf("AUTHENTIK_LISTEN__HTTP=0.0.0.0:%s", AuthentikHTTPPort),
+		"-e", fmt.Sprintf("AUTHENTIK_LISTEN__HTTPS=0.0.0.0:%s", AuthentikHTTPSPort),
+		"-e", "AUTHENTIK_OUTPOSTS__DISCOVER=false",
+		"-e", "AUTHENTIK_STORAGE__MEDIA__BACKEND=file",
+		"-e", "AUTHENTIK_ERROR_REPORTING__ENABLED=false",
+		"-e", "AUTHENTIK_DISABLE_UPDATE_CHECK=true",
+		"-v", fmt.Sprintf("%s:/data", dataDir),
+		imgRef,
+		"server",
+	}
+	if out, err := exec.Command(engine, serverArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to start authentik server: %w\n%s", err, string(out))
+	}
+
+	// ── 4. Worker (no docker socket) ─────────────────────────────────────────────
+	fmt.Println("  ⏳ Starting Authentik worker...")
+	workerArgs := []string{
+		"run", "-d",
+		"--name", AuthentikWorkerContainer,
+		"--network", global.HalNetName,
+		"--restart", "unless-stopped",
+		"--shm-size", "512mb",
+	}
+	// Docker (non-rootless) requires root user for the worker; podman rootless does not need it.
+	if !strings.Contains(engine, "podman") {
+		workerArgs = append(workerArgs, "--user", "root")
+	}
+	workerArgs = append(workerArgs,
+		"-e", fmt.Sprintf("AUTHENTIK_POSTGRESQL__HOST=%s", AuthentikPGContainer),
+		"-e", "AUTHENTIK_POSTGRESQL__NAME=authentik",
+		"-e", "AUTHENTIK_POSTGRESQL__USER=authentik",
+		"-e", fmt.Sprintf("AUTHENTIK_POSTGRESQL__PASSWORD=%s", secrets.PGPass),
+		"-e", fmt.Sprintf("AUTHENTIK_SECRET_KEY=%s", secrets.SecretKey),
+		// Bootstrap vars must also be on the worker — it runs Celery tasks that
+		// create the initial API token. Without them the token is never created.
+		"-e", fmt.Sprintf("AUTHENTIK_BOOTSTRAP_TOKEN=%s", secrets.BootstrapToken),
+		"-e", fmt.Sprintf("AUTHENTIK_BOOTSTRAP_PASSWORD=%s", secrets.AdminPassword),
+		"-e", "AUTHENTIK_OUTPOSTS__DISCOVER=false",
+		"-e", "AUTHENTIK_STORAGE__MEDIA__BACKEND=file",
+		"-e", "AUTHENTIK_ERROR_REPORTING__ENABLED=false",
+		"-e", "AUTHENTIK_DISABLE_UPDATE_CHECK=true",
+		"-v", fmt.Sprintf("%s:/data", dataDir),
+		imgRef,
+		"worker",
+	)
+	if out, err := exec.Command(engine, workerArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to start authentik worker: %w\n%s", err, string(out))
+	}
+
+	return nil
+}
+
+// WaitAuthentikHealthy polls GET /api/v3/root/config/ until Authentik responds 200.
+// Timeout: 90 seconds (Authentik runs migrations on first boot which takes time).
+func WaitAuthentikHealthy() error {
+	url := fmt.Sprintf("http://localhost:%s/api/v3/root/config/", AuthentikHTTPPort)
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(90 * time.Second)
+
+	fmt.Print("  ⏳ Waiting for Authentik API")
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				fmt.Println(" ✅")
+				return nil
+			}
+		}
+		fmt.Print(".")
+		time.Sleep(3 * time.Second)
+	}
+	fmt.Println()
+	return fmt.Errorf("authentik did not become ready within 90s — check: docker logs %s", AuthentikServerContainer)
+}
+
+// WaitAuthentikTokenReady polls GET /api/v3/core/groups/ with the bootstrap token
+// until the endpoint returns 200. This verifies the token has admin-level API access,
+// not just basic authentication — the worker creates it asynchronously after migrations.
+// Timeout: 60 seconds.
+func WaitAuthentikTokenReady(token string) error {
+	// Use an admin-only endpoint (requires is_superuser) so we confirm the token
+	// has the same class of permissions that CreateGroup/CreateUser need.
+	url := fmt.Sprintf("http://localhost:%s/api/v3/core/groups/", AuthentikHTTPPort)
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(60 * time.Second)
+
+	fmt.Print("  ⏳ Waiting for Authentik bootstrap token")
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				fmt.Println(" ✅")
+				return nil
+			}
+		}
+		fmt.Print(".")
+		time.Sleep(3 * time.Second)
+	}
+	fmt.Println()
+	return fmt.Errorf("authentik bootstrap token not ready within 60s — check: docker logs %s", AuthentikWorkerContainer)
+}
+
+// StopAuthentikStack stops and removes all Authentik containers.
+// If removeVolumes is true, the named volume hal-authentik-db is also removed.
+func StopAuthentikStack(engine string, removeVolumes bool) error {
+	for _, name := range []string{AuthentikWorkerContainer, AuthentikServerContainer, AuthentikPGContainer} {
+		_ = exec.Command(engine, "rm", "-f", name).Run()
+	}
+	if removeVolumes {
+		_ = exec.Command(engine, "volume", "rm", "-f", "hal-authentik-db").Run()
+	}
+	return nil
+}
+
+// PrintAuthentikStatus prints a one-line health summary for each Authentik container.
+func PrintAuthentikStatus(engine string) {
+	pg := global.CheckContainer(engine, AuthentikPGContainer)
+	server := global.CheckContainer(engine, AuthentikServerContainer)
+	worker := global.CheckContainer(engine, AuthentikWorkerContainer)
+
+	icon := func(up bool) string {
+		if up {
+			return "✅"
+		}
+		return "❌"
+	}
+
+	fmt.Printf("  %s Authentik PostgreSQL  : %s\n", icon(pg), AuthentikPGContainer)
+	fmt.Printf("  %s Authentik Server      : %s  (http://localhost:%s)\n", icon(server), AuthentikServerContainer, AuthentikHTTPPort)
+	fmt.Printf("  %s Authentik Worker      : %s\n", icon(worker), AuthentikWorkerContainer)
+
+	if server {
+		// Quick API probe
+		client := &http.Client{Timeout: 3 * time.Second}
+		url := fmt.Sprintf("http://localhost:%s/api/v3/root/config/", AuthentikHTTPPort)
+		resp, err := client.Get(url)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			fmt.Printf("  ✅ Authentik API        : reachable\n")
+		} else {
+			if resp != nil {
+				resp.Body.Close()
+			}
+			fmt.Printf("  ⚠️  Authentik API        : server running but API not responding yet\n")
+		}
+	}
+}
+
+// WaitVaultVisibleAuthentik verifies that the hal-vault container can reach
+// Authentik's OIDC discovery URL. This is required before configuring Vault OIDC
+// because Vault fetches the discovery document at write time.
+func WaitVaultVisibleAuthentik(engine, issuer string) error {
+	discoveryURL := strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration"
+	for i := 0; i < 30; i++ {
+		cmd := exec.Command(engine, "exec", "hal-vault", "sh", "-lc",
+			fmt.Sprintf(
+				"command -v curl >/dev/null 2>&1 && curl -fsS %q >/dev/null || wget -qO- %q >/dev/null",
+				discoveryURL, discoveryURL,
+			),
+		)
+		if cmd.Run() == nil {
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout: Vault container cannot reach %s\n  Check that hal-vault is running and on hal-net", discoveryURL)
+}
+
+// ─── Authentik REST API client ────────────────────────────────────────────────
+
+// AuthentikClient makes authenticated calls to the Authentik REST API using
+// the bootstrap token created by AUTHENTIK_BOOTSTRAP_TOKEN on first boot.
+type AuthentikClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// NewAuthentikClient returns a client pointed at the host-accessible Authentik URL.
+func NewAuthentikClient(token string) *AuthentikClient {
+	return &AuthentikClient{
+		baseURL: fmt.Sprintf("http://authentik.localhost:%s", AuthentikHTTPPort),
+		token:   token,
+		http:    &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// BaseURL returns the host-accessible Authentik base URL (e.g. http://authentik.localhost:9100).
+func (c *AuthentikClient) BaseURL() string { return c.baseURL }
+
+// Token returns the API token used by this client (the Authentik bootstrap token).
+func (c *AuthentikClient) Token() string { return c.token }
+
+// do executes a JSON API call, decodes the response and returns it as a generic map.
+// body may be nil for GET requests. Returns (nil, statusCode, nil) on 204 No Content.
+func (c *AuthentikClient) do(method, path string, body interface{}) (map[string]interface{}, int, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, fmt.Errorf("marshal: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		return nil, resp.StatusCode, fmt.Errorf("authentik %s %s → %d: %s", method, path, resp.StatusCode, string(raw))
+	}
+	if len(raw) == 0 {
+		return nil, resp.StatusCode, nil
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("decode response: %w", err)
+	}
+	return result, resp.StatusCode, nil
+}
+
+// firstResult returns the first item from a paginated list response.
+func firstResult(data map[string]interface{}) (map[string]interface{}, error) {
+	results, ok := data["results"].([]interface{})
+	if !ok || len(results) == 0 {
+		return nil, fmt.Errorf("no results returned")
+	}
+	item, ok := results[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected result type")
+	}
+	return item, nil
+}
+
+// CreateGroup creates an Authentik group and returns its UUID pk.
+// Returns the existing group pk if the name already exists.
+func (c *AuthentikClient) CreateGroup(name string) (string, error) {
+	data, _, err := c.do("POST", "/api/v3/core/groups/", map[string]interface{}{
+		"name":         name,
+		"is_superuser": false,
+	})
+	if err != nil {
+		// Already exists → look it up
+		if strings.Contains(err.Error(), "400") {
+			data, _, err2 := c.do("GET", "/api/v3/core/groups/?name="+name, nil)
+			if err2 != nil {
+				return "", err2
+			}
+			item, err2 := firstResult(data)
+			if err2 != nil {
+				return "", fmt.Errorf("group %q: %w", name, err)
+			}
+			return item["pk"].(string), nil
+		}
+		return "", err
+	}
+	return data["pk"].(string), nil
+}
+
+// CreateUser creates an Authentik user and sets their password. Idempotent.
+func (c *AuthentikClient) CreateUser(username, displayName, email, password string, groupPKs []string) error {
+	data, _, err := c.do("POST", "/api/v3/core/users/", map[string]interface{}{
+		"username":  username,
+		"name":      displayName,
+		"email":     email,
+		"type":      "internal",
+		"is_active": true,
+		"groups":    groupPKs,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "400") {
+			return nil // already exists — skip silently
+		}
+		return err
+	}
+
+	// Extract integer pk
+	pkFloat, ok := data["pk"].(float64)
+	if !ok {
+		return fmt.Errorf("unexpected user pk type")
+	}
+	pk := int(pkFloat)
+
+	// Set password
+	_, _, err = c.do("POST", fmt.Sprintf("/api/v3/core/users/%d/set_password/", pk), map[string]interface{}{
+		"password": password,
+	})
+	return err
+}
+
+// GetDefaultInvalidationFlowPK returns the PK of the default provider invalidation flow.
+// Required by CreateOAuth2Provider since Authentik 2024.x.
+func (c *AuthentikClient) GetDefaultInvalidationFlowPK() (string, error) {
+	data, _, err := c.do("GET", "/api/v3/flows/instances/?designation=invalidation&ordering=slug", nil)
+	if err != nil {
+		return "", err
+	}
+	// Prefer the provider-specific invalidation flow if present.
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if slug, _ := item["slug"].(string); strings.Contains(slug, "provider") {
+			return item["pk"].(string), nil
+		}
+	}
+	// Fall back to first available invalidation flow.
+	item, err := firstResult(data)
+	if err != nil {
+		return "", fmt.Errorf("invalidation flow: %w", err)
+	}
+	return item["pk"].(string), nil
+}
+
+// GetDefaultAuthorizationFlowPK returns the PK of the implicit-consent authorization flow.
+// Implicit consent auto-approves without showing a user-facing consent page, which
+// keeps the OIDC popup clean and prevents duplicate callback races that corrupt OAuth state.
+func (c *AuthentikClient) GetDefaultAuthorizationFlowPK() (string, error) {
+	data, _, err := c.do("GET", "/api/v3/flows/instances/?designation=authorization&ordering=slug", nil)
+	if err != nil {
+		return "", err
+	}
+	// Prefer the implicit-consent flow so the OIDC popup redirects directly back to the
+	// RP (Vault) without showing an intermediate consent page that the user might
+	// navigate away from (which would orphan the OAuth state on the next attempt).
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if slug, _ := item["slug"].(string); strings.Contains(slug, "implicit") {
+			return item["pk"].(string), nil
+		}
+	}
+	// Fall back to first available authorization flow.
+	item, err := firstResult(data)
+	if err != nil {
+		return "", fmt.Errorf("authorization flow: %w", err)
+	}
+	return item["pk"].(string), nil
+}
+
+// GetFirstSigningKeyPK returns the PK of the first available certificate key pair.
+func (c *AuthentikClient) GetFirstSigningKeyPK() (string, error) {
+	data, _, err := c.do("GET", "/api/v3/crypto/certificatekeypairs/?has_key=true&ordering=name", nil)
+	if err != nil {
+		return "", err
+	}
+	item, err := firstResult(data)
+	if err != nil {
+		return "", fmt.Errorf("signing key: %w", err)
+	}
+	return item["pk"].(string), nil
+}
+
+// GetGroupsScopeMappingPK returns the PK of the OIDC groups scope property mapping,
+// creating it if it doesn't exist. The built-in groups mapping was removed from
+// Authentik defaults in 2024.x — this ensures it's always present.
+// Path changed in Authentik 2024.4: /propertymappings/scope/ → /propertymappings/provider/scope/
+func (c *AuthentikClient) GetGroupsScopeMappingPK() (string, error) {
+	data, _, err := c.do("GET", "/api/v3/propertymappings/provider/scope/?search=groups", nil)
+	if err != nil {
+		return "", err
+	}
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		scopeName, _ := item["scope_name"].(string)
+		managed, _ := item["managed"].(string)
+		if strings.Contains(scopeName, "group") || strings.Contains(managed, "group") {
+			return item["pk"].(string), nil
+		}
+	}
+
+	// Not found — create a custom groups scope mapping.
+	// The expression returns the list of group names for the authenticated user.
+	created, _, err := c.do("POST", "/api/v3/propertymappings/provider/scope/", map[string]interface{}{
+		"name":        "hal: OIDC groups scope",
+		"scope_name":  "groups",
+		"description": "Adds a 'groups' claim containing the user's group names. Created by hal.",
+		"expression":  `return list(request.user.ak_groups.values_list("name", flat=True))`,
+	})
+	if err != nil {
+		// Already exists with same name — look it up by scope_name
+		if strings.Contains(err.Error(), "400") {
+			data2, _, err2 := c.do("GET", "/api/v3/propertymappings/provider/scope/?scope_name=groups", nil)
+			if err2 != nil {
+				return "", fmt.Errorf("groups scope mapping: %w", err2)
+			}
+			item, err2 := firstResult(data2)
+			if err2 != nil {
+				return "", fmt.Errorf("groups scope mapping not found and could not be created")
+			}
+			return item["pk"].(string), nil
+		}
+		return "", fmt.Errorf("create groups scope mapping: %w", err)
+	}
+	return created["pk"].(string), nil
+}
+
+// AuthentikRedirectURI pairs a matching mode with a URL for OAuth2 redirect_uris.
+type AuthentikRedirectURI struct {
+	MatchingMode string `json:"matching_mode"`
+	URL          string `json:"url"`
+}
+
+// CreateOAuth2Provider creates a confidential OAuth2/OIDC provider.
+// Returns (providerPK, clientID, clientSecret, error).
+func (c *AuthentikClient) CreateOAuth2Provider(
+	name, flowPK, invalidationFlowPK, signingKeyPK, groupsScopePK string,
+	redirectURIs []AuthentikRedirectURI,
+) (int, string, string, error) {
+	// Collect the standard scope PKs (openid, profile, email) so the JWT contains
+	// preferred_username, name, email, etc. alongside our custom groups claim.
+	standardPKs, err := c.GetScopeMappingPKsByName([]string{"openid", "profile", "email"})
+	if err != nil {
+		return 0, "", "", fmt.Errorf("get standard scope mappings: %w", err)
+	}
+	if len(standardPKs) < 3 {
+		return 0, "", "", fmt.Errorf("expected 3 standard scope mappings (openid/profile/email), got %d — JWT will be missing claims", len(standardPKs))
+	}
+	mappings := append(standardPKs, groupsScopePK)
+
+	body := map[string]interface{}{
+		"name":                       name,
+		"authorization_flow":         flowPK,
+		"invalidation_flow":          invalidationFlowPK,
+		"client_type":                "confidential",
+		"sub_mode":                   "user_username",
+		"include_claims_in_id_token": true,
+		"signing_key":                signingKeyPK,
+		"property_mappings":          mappings,
+		"redirect_uris":              redirectURIs,
+	}
+
+	data, _, err := c.do("POST", "/api/v3/providers/oauth2/", body)
+	if err != nil {
+		if !strings.Contains(err.Error(), "400") {
+			return 0, "", "", err
+		}
+		// Provider already exists — look it up by name and PATCH it so redirect URIs
+		// and mappings stay current, then return its credentials.
+		existing, _, err2 := c.do("GET", "/api/v3/providers/oauth2/?search="+name, nil)
+		if err2 != nil {
+			return 0, "", "", fmt.Errorf("provider %q already exists and lookup failed: %w", name, err2)
+		}
+		results, _ := existing["results"].([]interface{})
+		for _, r := range results {
+			item, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if item["name"] != name {
+				continue
+			}
+			pkFloat, _ := item["pk"].(float64)
+			pk := int(pkFloat)
+			// PATCH to refresh redirect_uris and property_mappings.
+			updated, _, _ := c.do("PATCH", fmt.Sprintf("/api/v3/providers/oauth2/%d/", pk), map[string]interface{}{
+				"redirect_uris":     redirectURIs,
+				"property_mappings": mappings,
+			})
+			if updated != nil {
+				item = updated
+			}
+			clientID, _ := item["client_id"].(string)
+			clientSecret, _ := item["client_secret"].(string)
+			return pk, clientID, clientSecret, nil
+		}
+		return 0, "", "", fmt.Errorf("provider %q already exists but could not be found in search results", name)
+	}
+
+	pkFloat, _ := data["pk"].(float64)
+	clientID, _ := data["client_id"].(string)
+	clientSecret, _ := data["client_secret"].(string)
+	return int(pkFloat), clientID, clientSecret, nil
+}
+
+// GetScopeMappingPKsByName returns the PKs of the scope property mappings with the given scope_names.
+// Missing scopes are silently skipped (best-effort).
+func (c *AuthentikClient) GetScopeMappingPKsByName(scopeNames []string) ([]string, error) {
+	// page_size=100 to avoid pagination silently dropping standard built-in mappings.
+	data, _, err := c.do("GET", "/api/v3/propertymappings/provider/scope/?page_size=100", nil)
+	if err != nil {
+		return nil, err
+	}
+	wanted := make(map[string]bool, len(scopeNames))
+	for _, s := range scopeNames {
+		wanted[s] = true
+	}
+	var pks []string
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		scopeName, _ := item["scope_name"].(string)
+		if wanted[scopeName] {
+			pks = append(pks, item["pk"].(string))
+		}
+	}
+	return pks, nil
+}
+
+// CreateApplication creates an Authentik application linked to a provider. Idempotent.
+// launchURL is set as meta_launch_url so the application tile in the Authentik portal
+// points to the SP's login page (e.g. the Vault UI OIDC page) rather than the
+// auto-computed URL which may use an internal container hostname.
+func (c *AuthentikClient) CreateApplication(name, slug string, providerPK int, launchURL string) error {
+	body := map[string]interface{}{
+		"name":            name,
+		"slug":            slug,
+		"provider":        providerPK,
+		"meta_launch_url": launchURL,
+	}
+	_, _, err := c.do("POST", "/api/v3/core/applications/", body)
+	if err != nil && strings.Contains(err.Error(), "400") {
+		// Already exists — update provider binding and launch URL.
+		_, _, err = c.do("PATCH", "/api/v3/core/applications/"+slug+"/", map[string]interface{}{
+			"provider":        providerPK,
+			"meta_launch_url": launchURL,
+		})
+	}
+	return err
+}
+
+// DeleteApplicationBySlug deletes an Authentik application by its slug. No-op if not found.
+func (c *AuthentikClient) DeleteApplicationBySlug(slug string) error {
+	_, _, err := c.do("DELETE", "/api/v3/core/applications/"+slug+"/", nil)
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return nil
+	}
+	return err
+}
+
+// DeleteOAuth2ProviderByName deletes an OAuth2 provider by name. No-op if not found.
+func (c *AuthentikClient) DeleteOAuth2ProviderByName(name string) error {
+	data, _, err := c.do("GET", "/api/v3/providers/oauth2/?search="+name, nil)
+	if err != nil {
+		return err
+	}
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if item["name"] == name {
+			pkFloat, _ := item["pk"].(float64)
+			pk := int(pkFloat)
+			_, _, err = c.do("DELETE", fmt.Sprintf("/api/v3/providers/oauth2/%d/", pk), nil)
+			if err != nil && strings.Contains(err.Error(), "404") {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil // not found — nothing to delete
+}
+
+// ─── SCIM provider management ─────────────────────────────────────────────────
+
+// GetDefaultSCIMPropertyMappings returns Authentik's built-in SCIM property mapping PKs
+// partitioned into user mappings and group mappings.
+// Authentik ships defaults with managed fields under goauthentik.io/providers/scim/user*
+// and goauthentik.io/providers/scim/group*.
+func (c *AuthentikClient) GetDefaultSCIMPropertyMappings() (userPKs, groupPKs []string, err error) {
+	data, _, err := c.do("GET", "/api/v3/propertymappings/provider/scim/", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pk, _ := item["pk"].(string)
+		managed, _ := item["managed"].(string)
+		name, _ := item["name"].(string)
+
+		isGroup := strings.Contains(managed, "/group") || strings.Contains(strings.ToLower(name), "group")
+		if isGroup {
+			groupPKs = append(groupPKs, pk)
+		} else {
+			userPKs = append(userPKs, pk)
+		}
+	}
+	return userPKs, groupPKs, nil
+}
+
+// CreateSCIMProvider creates an Authentik outbound SCIM provider pointing at url.
+// Returns the provider integer PK.
+func (c *AuthentikClient) CreateSCIMProvider(name, baseURL, token string, userMappingPKs, groupMappingPKs []string) (int, error) {
+	body := map[string]interface{}{
+		"name":                    name,
+		"url":                     baseURL,
+		"token":                   token,
+		"property_mappings":       userMappingPKs,
+		"property_mappings_group": groupMappingPKs,
+		// AWS compatibility mode avoids including "schemas" inside PATCH Operation
+		// objects. Vault SCIM rejects that attribute with invalidValue/400, which
+		// prevents group membership from ever being pushed (members list stays empty).
+		"compatibility_mode": "aws",
+	}
+	data, _, err := c.do("POST", "/api/v3/providers/scim/", body)
+	if err != nil {
+		if strings.Contains(err.Error(), "400") {
+			// Already exists — fetch existing pk
+			existing, _, err2 := c.do("GET", "/api/v3/providers/scim/?search="+name, nil)
+			if err2 != nil {
+				return 0, err2
+			}
+			item, err2 := firstResult(existing)
+			if err2 != nil {
+				return 0, fmt.Errorf("scim provider %q: %w", name, err)
+			}
+			pkFloat, _ := item["pk"].(float64)
+			return int(pkFloat), nil
+		}
+		return 0, err
+	}
+	pkFloat, _ := data["pk"].(float64)
+	return int(pkFloat), nil
+}
+
+// GetSCIMSyncStatus returns the sync status of an Authentik SCIM provider.
+// Authentik 2026.x does not expose a full-sync trigger endpoint — sync is event-driven.
+func (c *AuthentikClient) GetSCIMSyncStatus(providerPK int) (map[string]interface{}, error) {
+	data, _, err := c.do("GET", fmt.Sprintf("/api/v3/providers/scim/%d/sync/status/", providerPK), nil)
+	return data, err
+}
+
+// SetApplicationBackchannelProviders adds providerPKs to the backchannel_providers list
+// of an existing application. This is required for Authentik outbound SCIM to function —
+// without a backchannel assignment, the SCIM provider never syncs.
+func (c *AuthentikClient) SetApplicationBackchannelProviders(appSlug string, providerPKs []int) error {
+	// Fetch current backchannel list so we don't overwrite existing entries.
+	existing, _, err := c.do("GET", "/api/v3/core/applications/"+appSlug+"/", nil)
+	if err != nil {
+		return fmt.Errorf("get application %q: %w", appSlug, err)
+	}
+	// Merge existing backchannel_providers with new ones.
+	pkSet := map[int]bool{}
+	if current, ok := existing["backchannel_providers"].([]interface{}); ok {
+		for _, v := range current {
+			if f, ok := v.(float64); ok {
+				pkSet[int(f)] = true
+			}
+		}
+	}
+	for _, pk := range providerPKs {
+		pkSet[pk] = true
+	}
+	merged := make([]int, 0, len(pkSet))
+	for pk := range pkSet {
+		merged = append(merged, pk)
+	}
+	// Need provider PK for the PATCH — fetch it.
+	providerPK, _ := existing["provider"].(float64)
+	_, _, err = c.do("PATCH", "/api/v3/core/applications/"+appSlug+"/", map[string]interface{}{
+		"name":                  existing["name"],
+		"slug":                  appSlug,
+		"provider":              int(providerPK),
+		"backchannel_providers": merged,
+	})
+	return err
+}
+
+// DeleteSCIMProviderByName deletes an Authentik SCIM provider by name. No-op if not found.
+func (c *AuthentikClient) DeleteSCIMProviderByName(name string) error {
+	data, _, err := c.do("GET", "/api/v3/providers/scim/?search="+name, nil)
+	if err != nil {
+		return err
+	}
+	results, _ := data["results"].([]interface{})
+	for _, r := range results {
+		item, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if item["name"] == name {
+			pkFloat, _ := item["pk"].(float64)
+			pk := int(pkFloat)
+			_, _, err = c.do("DELETE", fmt.Sprintf("/api/v3/providers/scim/%d/", pk), nil)
+			if err != nil && strings.Contains(err.Error(), "404") {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/skills/data/vault/SKILL.md
+++ b/internal/skills/data/vault/SKILL.md
@@ -24,7 +24,7 @@ If obs comes after Vault, prefer `hal vault obs create` to backfill metrics/dash
 - Use audit when the user asks about audit devices, logging, Loki, Grafana, or log shipping.
 - Use audit-analysis when the user asks who did what, request tracing, incident review, or audit investigations.
 - Use jwt when the user asks about CI or machine auth with JWT, GitLab pipelines, or bound claims.
-- Use oidc when the user asks about human SSO, browser login, callback URL issues, or Keycloak.
+- Use oidc when the user asks about human SSO, browser login, callback URL issues, or Authentik.
 - Use k8s when the user asks about Kubernetes auth, KinD, VSO, secret refresh demos, or CSI projection.
 - Use mariadb when the user asks about database secrets, dynamic DB credentials, or root rotation.
 - Use ldap when the user asks about LDAP auth, LDAP secrets engine, dynamic users, static creds, or credential libraries.

--- a/internal/skills/data/vault/oidc/EXAMPLES.md
+++ b/internal/skills/data/vault/oidc/EXAMPLES.md
@@ -13,7 +13,7 @@ Assistant: I verify OIDC config and default role:
     vault read auth/oidc/config
     vault read auth/oidc/role/default
 
-Assistant: I confirm Keycloak realm `hal` users (`alice`, `bob`) map to external groups `admin` and `user-ro`.
+Assistant: I confirm Authentik users `alice` (group `admin`) and `bob` (group `user-ro`) map to Vault external groups with matching policies.
 
 ## Example 2: Callback Error
 
@@ -28,3 +28,11 @@ User: Rebuild OIDC integration completely.
 Assistant:
 
     hal vault oidc update
+
+A: This cleans Vault OIDC mounts and policies, removes the Authentik application and OAuth2 provider, then re-provisions everything with fresh clientID/clientSecret — without restarting the Authentik stack.
+
+## Example 4: Authentik admin credentials
+
+User: What is the Authentik admin password?
+
+A: The admin username is `akadmin`. The password was printed on first `hal vault oidc enable` and is stored in `~/.hal/authentik/env` under `AUTHENTIK_BOOTSTRAP_PASSWORD`. Access the UI at `http://authentik.localhost:9100/if/admin/`.

--- a/internal/skills/data/vault/oidc/SKILL.md
+++ b/internal/skills/data/vault/oidc/SKILL.md
@@ -1,28 +1,49 @@
 ---
 name: oidc
-description: Deploy, verify, and troubleshoot the Vault OIDC lab in hal. Use this skill when the user asks to enable OIDC, set up human SSO, debug browser login redirects, inspect Keycloak-backed roles, or reset the OIDC demo. Triggers include "enable oidc", "Vault SSO", "Keycloak", "OIDC callback", "configure oidc", and "hal vault oidc".
+description: Deploy, verify, and troubleshoot the Vault OIDC lab in hal. Use this skill when the user asks to enable OIDC, set up human SSO, debug browser login redirects, inspect Authentik-backed roles, reset the OIDC demo, or configure SCIM provisioning. Triggers include "enable oidc", "Vault SSO", "Authentik", "OIDC callback", "configure oidc", "hal vault oidc", "enable scim", and "vault scim".
 ---
 
 # Hal Vault OIDC Configurator
 
-This skill covers the Keycloak-backed OIDC demo implemented by `hal vault oidc`.
+This skill covers the Authentik-backed OIDC demo implemented by `hal vault oidc`.
 
 ## Lab Assumptions
 
 - Vault runs locally at `http://vault.localhost:8200`
 - Root token defaults to `root`
-- Keycloak is exposed locally on port `8081`
+- Authentik is exposed locally on port `9100` at `http://authentik.localhost:9100`
 - Prefer `hal` for lifecycle actions and `vault read/write` for post-deploy tuning
 
 ## What The Command Actually Sets Up
 
-- Keycloak container: `hal-keycloak`
+**Authentik containers** (all on `hal-net`):
+- `hal-authentik-pg` — PostgreSQL database
+- `hal-authentik-server` — Authentik API + UI (HTTP `9100`, HTTPS `9143`)
+- `hal-authentik-worker` — Celery background tasks
+
+**Authentik objects provisioned via REST API**:
+- Groups: `admin`, `user-ro`
+- Users: `alice / password` (admin), `bob / password` (user-ro)
+- Scope mapping: `hal: OIDC groups scope` (created automatically if absent in 2024.x+)
+- OAuth2 provider: `vault-oidc-provider` (confidential, implicit-consent flow, `sub_mode: user_username`)
+- Application slug: `hashicorp-vault` (tile launch URL: `http://vault.localhost:8200/ui/vault/auth/oidc`)
+
+**Vault objects (OIDC only)**:
 - OIDC auth mount: `oidc/`
-- KV mount: `kv-oidc/`
-- Policies: `admin`, `user-ro`
-- External identity groups mapped from Keycloak groups `admin` and `user-ro`
-- Demo users: `alice` and `bob`
-- Keycloak realm: `hal`
+- KV-V2 mount: `kv-oidc/`
+- Policies: `admin` (all paths), `user-ro` (kv-oidc/team1 read)
+- External identity groups `admin` and `user-ro` with aliases bound to OIDC accessor
+- OIDC issuer: `http://authentik.localhost:9100/application/o/hashicorp-vault/`
+
+**Additional Vault objects with `--scim` (Enterprise)**:
+- SCIM activation flag (one-way)
+- Policy `scim-client` (identity/scim/v2/* — create/read/update/patch/delete/list)
+- Entity `scim-client-authentik` with alias on token mount
+- Token role `authentik-scim` (32-day renewable, orphan)
+- SCIM client `authentik-scim` with `alias_mount_accessor = oidc/`
+- Authentik outbound SCIM provider `vault-scim-provider` (AWS compatibility mode)
+- Authentik: SCIM provider assigned as backchannel on `hashicorp-vault` app
+- External groups (`admin`, `user-ro`) owned by Authentik SCIM — **not** pre-created in Vault
 
 ## Workflow
 
@@ -34,9 +55,14 @@ Use smart status mode if needed:
 
 Then use the correct lifecycle command:
 
-    hal vault oidc enable --keycloak-version 24.0.4
+    hal vault oidc enable
     hal vault oidc update
     hal vault oidc disable
+
+Flags:
+- `--authentik-image` — override image (default: `ghcr.io/goauthentik/server`)
+- `--authentik-tag` — override tag (default: `2026.2.3`)
+- `--scim` — [Vault Enterprise] configure Authentik outbound SCIM provisioning to Vault
 
 ### Step 2: Enrich with Vault MCP Context
 
@@ -59,10 +85,11 @@ Provide a brief confirmation that the OIDC auth method is enabled.
 | Component | Value | Description |
 |-----------|-------|-------------|
 | Auth Path | `auth/oidc/` | The mount point for the OIDC auth method |
-| Client ID | `vault` | The OIDC client registered in Keycloak |
+| Client ID | dynamic (printed at enable time) | OAuth2 client registered in Authentik |
 | Default Role | `default` | The configured default Vault OIDC role |
-| Discovery URL | `http://keycloak.localhost:8081/realms/hal` | The OIDC discovery endpoint |
-| External Groups | `admin`, `user-ro` | Keycloak groups mapped to Vault identity groups and policies |
+| Discovery URL | `http://authentik.localhost:9100/application/o/hashicorp-vault/` | OIDC discovery endpoint |
+| External Groups | `admin`, `user-ro` | Authentik groups mapped to Vault identity groups and policies |
+| Authentik Admin UI | `http://authentik.localhost:9100/if/admin/` | Manage users, groups, applications |
 
 **Tier 3 — Actionable Testing Commands**
 
@@ -75,7 +102,19 @@ Provide a brief confirmation that the OIDC auth method is enabled.
 
 ## Handling Edge Cases
 
-1. **Callback URL mismatch:** Ensure the allowed callback URL matches `http://localhost:8250/oidc/callback`.
+1. **Callback URL mismatch:** Authentik must have `http://localhost:8250/oidc/callback`, `http://127.0.0.1:8250/oidc/callback`, and `http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback` as allowed redirect URIs on the `vault-oidc-provider`.
 2. **Vault is offline:** Instruct the user to run `hal vault create` first.
-3. **Group claim mismatch:** Verify Keycloak group membership and `groups_claim` on `auth/oidc/role/default`.
-4. **User asks about groups or policies after deployment:** Provide exact `vault read/write` commands for `identity/group`, `identity/group-alias`, or `auth/oidc/role/default`.
+3. **Group claim missing:** The `hal: OIDC groups scope` mapping must be assigned to the `vault-oidc-provider`. It uses `ak_groups` to return group names. Verify with `vault read auth/oidc/role/default` — `groups_claim` should be `groups`.
+4. **403 on first enable after fresh stack:** Bootstrap token race — the Authentik worker creates the token asynchronously. `hal vault oidc update` retries safely.
+5. **User asks about Authentik admin password:** It is printed once at first enable and stored in `~/.hal/authentik/env` (field `AUTHENTIK_BOOTSTRAP_PASSWORD`). Username is `akadmin`.
+6. **"Expired or missing OAuth state" on second OIDC attempt:** Caused by the explicit-consent authorization flow orphaning the state. Fixed by using the implicit-consent flow. The `GetDefaultAuthorizationFlowPK` function now prefers slugs containing `implicit`.
+7. **SCIM group membership empty after adding a user:** Authentik 2026.x does not emit an outbound SCIM event when a user is added to a group (ManyToMany change). Must trigger a per-object sync manually:
+   ```bash
+   curl -s -X POST -H 'Authorization: Bearer <bootstrap-token>' \
+     -H 'Content-Type: application/json' \
+     -d '{"sync_object_model":"authentik.core.models.Group","sync_object_id":"<group-pk>"}' \
+     'http://authentik.localhost:9100/api/v3/providers/scim/<scim-provider-pk>/sync/object/'
+   ```
+   The bootstrap token and SCIM provider PK are printed by `hal vault oidc enable --scim`.
+8. **SCIM returns 400/invalidValue for group PATCH:** Authentik without `compatibility_mode: aws` includes `"schemas"` inside PatchOp Operations array items, which Vault SCIM rejects. This is already set by `hal`. If syncing manually, ensure provider has compatibility mode enabled.
+9. **SCIM returns permission denied on group PATCH:** The `scim-client` Vault policy must include the `patch` capability. Vault 1.14+ treats HTTP PATCH as a separate capability from `update`.


### PR DESCRIPTION
**feat(vault/oidc): implement OIDC fixes + SCIM provisioning (Vault Enterprise)**

Partial progress on #1 — Vault side done, TFE side is a separate branch.

**What's in here:**
- Fix OIDC flow: implicit-consent auth, correct Authentik tile URL, 127.0.0.1 redirect URI
- Implement `hal vault oidc enable --scim` (Vault Enterprise only): activates SCIM flag, provisions SCIM client/entity/token, wires Authentik outbound SCIM provider with `compatibility_mode=aws`, handles pre-existing group conflicts
- Add `hal creds status` command — shows active credentials for all running lab services
- Fix: `scim-client` policy now includes `patch` capability (Vault 1.14+ requires it for group membership PATCH)
- Docs/skills updated in the same cycle

**Known limitation:** Group membership changes in Authentik are not auto-propagated via SCIM — manual per-object sync required (curl commands printed at enable time).