### PR TITLE
bugfix(tfe): named volumes, hal delete cleanup, HalNetStaticIP Podman…

### DIFF
--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -15,9 +15,12 @@ import (
 // leaves no leftover state that would cause stale-data problems on the next
 // "hal vault create / hal vault oidc enable --scim" cycle.
 var halNamedVolumes = []string{
-	"hal-authentik-db",  // Authentik PostgreSQL data (cmd/vault/oidc + integrations/authentik.go)
-	"hal-vault-logs",    // Vault audit logs shared with Promtail (cmd/vault/create.go)
-	"hal-vault-plugins", // Vault external plugins, e.g. OS secrets engine (cmd/vault/create.go)
+	"hal-authentik-db",   // Authentik PostgreSQL data (cmd/vault/oidc + integrations/authentik.go)
+	"hal-vault-logs",     // Vault audit logs shared with Promtail (cmd/vault/create.go)
+	"hal-vault-plugins",  // Vault external plugins, e.g. OS secrets engine (cmd/vault/create.go)
+	"hal-tfe-db-data",    // TFE PostgreSQL data (cmd/terraform/create.go)
+	"hal-tfe-redis-data", // TFE Redis cache (cmd/terraform/create.go)
+	"hal-tfe-minio-data", // TFE MinIO object storage (cmd/terraform/create.go)
 }
 
 const tfeCLIHelperImage = "hal-tfe-cli:latest"

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -134,18 +134,21 @@ var deployCmd = &cobra.Command{
 		// 5. Deploy PostgreSQL
 		fmt.Printf("⚙️  Provisioning TFE PostgreSQL Database...\n")
 		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-db", "--network", "hal-net",
+			"-v", "hal-tfe-db-data:/var/lib/postgresql/data",
 			"-e", "POSTGRES_USER=tfe", "-e", "POSTGRES_PASSWORD=tfe_password", "-e", "POSTGRES_DB=tfe",
 			fmt.Sprintf("%s:%s", pgImage, pgVersion)).Run()
 
 		// 6. Deploy Redis
 		fmt.Printf("⚙️  Provisioning TFE Redis Cache...\n")
 		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-redis", "--network", "hal-net",
+			"-v", "hal-tfe-redis-data:/data",
 			fmt.Sprintf("%s:%s", redisImage, redisVersion)).Run()
 
 		// 7. Deploy MinIO (S3 Mock)
 		fmt.Println("⚙️  Provisioning TFE Object Storage (MinIO)...")
 		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-minio", "--network", "hal-net",
 			"-p", fmt.Sprintf("%d:9000", minioAPIPort), "-p", fmt.Sprintf("%d:9001", minioConsolePort),
+			"-v", "hal-tfe-minio-data:/data",
 			"-e", "MINIO_ROOT_USER=minioadmin", "-e", "MINIO_ROOT_PASSWORD=minioadmin",
 			fmt.Sprintf("%s:%s", minioImage, minioVersion), "server", "/data", "--console-address", ":9001").Run()
 

--- a/cmd/terraform/delete.go
+++ b/cmd/terraform/delete.go
@@ -28,6 +28,14 @@ var tfeSharedBackendContainers = []string{
 	"hal-tfe-minio",
 }
 
+// Named volumes created by the shared backend containers. Must be removed
+// explicitly — docker rm -f does not remove named volumes.
+var tfeSharedBackendVolumes = []string{
+	"hal-tfe-db-data",
+	"hal-tfe-redis-data",
+	"hal-tfe-minio-data",
+}
+
 var destroyCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Tear down the TFE stack and wipe all local state for a fresh restart",
@@ -127,7 +135,18 @@ var destroyCmd = &cobra.Command{
 			}
 		}
 
-		// 2. Wipe the local Cert cache
+		// 2. Remove named volumes for shared backend (only when not preserving for twin).
+		if !preserveSharedBackend {
+			for _, vol := range tfeSharedBackendVolumes {
+				if global.DryRun {
+					fmt.Printf("[DRY RUN] Would execute: %s volume rm -f %s\n", engine, vol)
+					continue
+				}
+				_ = exec.Command(engine, "volume", "rm", "-f", vol).Run()
+			}
+		}
+
+		// 3. Wipe the local Cert cache
 		homeDir, _ := os.UserHomeDir()
 		certDir := filepath.Join(homeDir, ".hal", "tfe-certs")
 		if _, err := os.Stat(certDir); err == nil {

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -1,6 +1,7 @@
 package global
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -81,22 +82,68 @@ func EnsureNetwork(engine string) {
 // HalNetStaticIP returns an IP in the hal-net subnet with the given last octet.
 // It inspects the live network so it works regardless of which subnet the engine
 // assigned (e.g. 172.18.0.250, 10.89.3.250, ...).
-// Falls back to 172.18.0.<hostNum> when inspection fails.
+// Parses raw JSON to handle both Docker (IPAM.Config[].Subnet) and Podman
+// (subnets[].subnet) inspect formats. Falls back to 172.18.0.<hostNum>.
 func HalNetStaticIP(engine string, hostNum int) string {
-	out, err := exec.Command(engine, "network", "inspect", HalNetName,
-		"--format", "{{range .IPAM.Config}}{{.Subnet}}{{end}}").Output()
+	out, err := exec.Command(engine, "network", "inspect", HalNetName).Output()
 	if err == nil {
-		subnet := strings.TrimSpace(string(out))
-		// subnet looks like "172.18.0.0/16" or "10.89.3.0/24"
-		// Take everything up to the last dot of the network address.
-		if slash := strings.Index(subnet, "/"); slash > 0 {
-			host := subnet[:slash] // "172.18.0.0"
-			if dot := strings.LastIndex(host, "."); dot > 0 {
-				return fmt.Sprintf("%s.%d", host[:dot], hostNum)
+		subnet := extractSubnetFromInspect(out)
+		if subnet != "" {
+			// subnet looks like "172.18.0.0/16" or "10.89.3.0/24"
+			// Strip the mask and replace the last octet.
+			if slash := strings.Index(subnet, "/"); slash > 0 {
+				host := subnet[:slash]
+				if dot := strings.LastIndex(host, "."); dot > 0 {
+					return fmt.Sprintf("%s.%d", host[:dot], hostNum)
+				}
 			}
 		}
 	}
 	return fmt.Sprintf("172.18.0.%d", hostNum)
+}
+
+// extractSubnetFromInspect parses the raw JSON output of "docker/podman network inspect"
+// and returns the first subnet CIDR string. Handles both:
+//   - Docker: [{"IPAM":{"Config":[{"Subnet":"172.18.0.0/16"}]}}]
+//   - Podman: [{"subnets":[{"subnet":"10.89.3.0/24"}]}]
+func extractSubnetFromInspect(data []byte) string {
+	var raw []map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil || len(raw) == 0 {
+		return ""
+	}
+	net := raw[0]
+
+	// Docker format: IPAM.Config[].Subnet
+	if ipamRaw, ok := net["IPAM"]; ok {
+		var ipam struct {
+			Config []struct {
+				Subnet string `json:"Subnet"`
+			} `json:"Config"`
+		}
+		if err := json.Unmarshal(ipamRaw, &ipam); err == nil {
+			for _, c := range ipam.Config {
+				if c.Subnet != "" {
+					return c.Subnet
+				}
+			}
+		}
+	}
+
+	// Podman format: subnets[].subnet
+	if subnetsRaw, ok := net["subnets"]; ok {
+		var subnets []struct {
+			Subnet string `json:"subnet"`
+		}
+		if err := json.Unmarshal(subnetsRaw, &subnets); err == nil {
+			for _, s := range subnets {
+				if s.Subnet != "" {
+					return s.Subnet
+				}
+			}
+		}
+	}
+
+	return ""
 }
 
 // CleanNetworkIfEmpty acts as a garbage collector.


### PR DESCRIPTION
… fix

- cmd/terraform/create.go: add named -v mounts for hal-tfe-db-data, hal-tfe-redis-data, hal-tfe-minio-data to avoid anonymous volumes
- cmd/terraform/delete.go: remove those named volumes on tf teardown (skipped when twin is still running / preserveSharedBackend=true)
- cmd/teardown.go: remove all hal named volumes + reset shared services file on full hal delete
- internal/global/global.go: rewrite HalNetStaticIP to parse raw JSON instead of Docker-only Go template; handles both Docker (IPAM.Config) and Podman (subnets[].subnet) network inspect formats