### PR TITLE
fix(vault-scim): hal-vault-data volume, scope mapping wait, user sync…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage.txt
 
 # OS/editor noise
 .DS_Store
+
+# Hashicorp License
+*.hclic

--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -128,7 +128,8 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
         - Creates Authentik outbound SCIM provider `vault-scim-provider` with `compatibility_mode: "aws"`. Without AWS mode, Authentik 2026.x includes `"schemas"` inside PATCH Operation objects which Vault SCIM rejects with 400/`invalidValue` — member lists stay empty.
         - Assigns SCIM provider as backchannel on `hashicorp-vault` application (required for outbound sync activation).
         - OIDC path skips pre-creating external groups when `--scim` is active; Authentik SCIM owns group creation.
-        - **Group membership is NOT auto-propagated** when a user is added to a group (Authentik 2026.x ManyToMany table changes don't fire outbound SCIM events). Must use per-object sync endpoint: `POST /api/v3/providers/scim/{pk}/sync/object/` with `sync_object_model: "authentik.core.models.Group"` and `sync_object_id: "<group-pk>"`. The completion output prints exact curl commands with real token and provider PK.
+        - **Group membership IS auto-propagated** in Authentik 2026.2.3+ — the previously known ManyToMany Django signal gap has been fixed. Membership changes (add/remove user from group) now fire outbound SCIM events automatically.
+        - Users created *before* the SCIM provider was first configured are not retroactively pushed. `configureSCIM` and `syncSCIMObjects` call a full users+groups sync at the end to ensure initial consistency.
         - Valid `sync_object_model` enum values: `"authentik.core.models.Group"`, `"authentik.core.models.User"` (Python module path, from `SyncObjectModelEnum` in OpenAPI schema).
         - SCIM endpoint inside containers: `http://hal-vault:8200/v1/identity/scim/v2`.
     - **Future**: `hal tf saml enable [--scim]` on a separate branch will reuse the same Authentik stack with `AuthentikSharedServiceKey`.

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -18,6 +18,7 @@ var halNamedVolumes = []string{
 	"hal-authentik-db",   // Authentik PostgreSQL data (cmd/vault/oidc + integrations/authentik.go)
 	"hal-vault-logs",     // Vault audit logs shared with Promtail (cmd/vault/create.go)
 	"hal-vault-plugins",  // Vault external plugins, e.g. OS secrets engine (cmd/vault/create.go)
+	"hal-vault-data",     // Vault file storage /vault/file VOLUME directive (cmd/vault/create.go)
 	"hal-tfe-db-data",    // TFE PostgreSQL data (cmd/terraform/create.go)
 	"hal-tfe-redis-data", // TFE Redis cache (cmd/terraform/create.go)
 	"hal-tfe-minio-data", // TFE MinIO object storage (cmd/terraform/create.go)

--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -77,6 +77,7 @@ var deployCmd = &cobra.Command{
 			_ = exec.Command(engine, "rm", "-f", "hal-vault").Run()
 			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-logs").Run()
 			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-plugins").Run()
+			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-data").Run()
 		}
 
 		// Determine the Image Repository and Version based on Edition
@@ -106,6 +107,7 @@ var deployCmd = &cobra.Command{
 		helperRef := vaultHelperImage + ":" + vaultHelperTag
 		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-logs:/vault/logs", helperRef, "chown", "-R", "100:1000", "/vault/logs").Run()
 		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-plugins:/vault/plugins", helperRef, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
+		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-data:/vault/file", helperRef, "chown", "-R", "100:1000", "/vault/file").Run()
 
 		// 2. Build the Docker run arguments
 		vaultArgs := []string{
@@ -116,6 +118,7 @@ var deployCmd = &cobra.Command{
 			"-p", "8200:8200",
 			"-v", "hal-vault-logs:/vault/logs",
 			"-v", "hal-vault-plugins:/vault/plugins",
+			"-v", "hal-vault-data:/vault/file",
 		}
 
 		// Vault 2.x tries to set SETFCAP capability which fails on Docker Desktop.

--- a/cmd/vault/delete.go
+++ b/cmd/vault/delete.go
@@ -24,6 +24,7 @@ var vaultEcosystem = []string{
 var vaultVolumes = []string{
 	"hal-vault-logs",    // Spun up by Audit/Loki
 	"hal-vault-plugins", // Spun up for external plugins (OS secret engine)
+	"hal-vault-data",    // Vault file storage (/vault/file VOLUME directive)
 }
 
 var vaultDestroyCmd = &cobra.Command{

--- a/cmd/vault/oidc.go
+++ b/cmd/vault/oidc.go
@@ -113,11 +113,11 @@ Flags:
 					fmt.Println("   Run: hal vault oidc enable --scim")
 					return
 				}
-				if err := syncSCIMGroups(aktClient, pk); err != nil {
+				if err := syncSCIMObjects(aktClient, pk); err != nil {
 					fmt.Printf("❌ Sync failed: %v\n", err)
 					return
 				}
-				fmt.Println("✅ Group membership synced")
+				fmt.Println("✅ Users and groups synced")
 				return
 			}
 
@@ -233,6 +233,15 @@ func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
 	}
 
 	if firstBoot {
+		// On first boot Authentik seeds default scope mappings asynchronously
+		// after the token becomes usable — wait for them before provisioning.
+		if err := integrations.WaitAuthentikScopesReady(secrets.BootstrapToken); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+	}
+
+	if firstBoot {
 		printAuthentikCredentials(secrets)
 	}
 
@@ -276,7 +285,7 @@ func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
 	}
 
 	global.RefreshHalHealth(engine)
-	printOIDCSuccess(issuer, secrets)
+	printOIDCSuccess(secrets)
 }
 
 // ─── disable ──────────────────────────────────────────────────────────────────
@@ -500,7 +509,7 @@ func printAuthentikCredentials(secrets *integrations.AuthentikSecrets) {
 	fmt.Println()
 }
 
-func printOIDCSuccess(issuer string, _ *integrations.AuthentikSecrets) {
+func printOIDCSuccess(secrets *integrations.AuthentikSecrets) {
 	fmt.Println()
 	fmt.Println("✅ Vault OIDC + Authentik IdP ready!")
 	fmt.Println()
@@ -511,8 +520,8 @@ func printOIDCSuccess(issuer string, _ *integrations.AuthentikSecrets) {
 	fmt.Println("    alice / password  →  admin policy (full access)")
 	fmt.Println("    bob   / password  →  user-ro policy (kv-oidc/team1 read)")
 	fmt.Println()
-	fmt.Printf("  Authentik  : %s/if/admin/\n", integrations.AuthentikAdminURL())
-	fmt.Printf("  OIDC issuer: %s\n", issuer)
+	fmt.Printf("  Authentik admin  : %s/if/admin/\n", integrations.AuthentikAdminURL())
+	fmt.Printf("  Authentik login  : akadmin / %s\n", secrets.AdminPassword)
 }
 
 func init() {

--- a/cmd/vault/scim.go
+++ b/cmd/vault/scim.go
@@ -207,37 +207,10 @@ path "identity/scim/v2/*" {
 	// path is unreliable (Django M2M signals don't fire, and Vault's SCIM PATCH
 	// implementation has known gaps). Triggering a per-object sync right after setup
 	// guarantees that the initial member list lands in Vault regardless of timing.
-	if err := syncSCIMGroups(aktClient, providerPK); err != nil {
-		fmt.Printf("  ⚠️  Group sync warning: %v\n", err)
+	if err := syncSCIMObjects(aktClient, providerPK); err != nil {
+		fmt.Printf("  ⚠️  SCIM sync warning: %v\n", err)
 	}
 
-	fmt.Println()
-	fmt.Println("  ✅ SCIM provisioning configured")
-	fmt.Printf("     Endpoint : %s\n", scimVaultBaseURL)
-	fmt.Println()
-	fmt.Println("  📋 SCIM behaviour:")
-	fmt.Println("     • User creation   → auto-propagated to Vault  ✅")
-	fmt.Println("     • Group creation  → auto-propagated to Vault  ✅")
-	fmt.Println("     • Group membership changes → NOT auto-propagated ⚠️")
-	fmt.Println()
-	fmt.Println("     Authentik does not fire an outbound SCIM event when a user is")
-	fmt.Println("     added to / removed from a group. To propagate membership changes,")
-	fmt.Println("     trigger a per-object group sync as an Authentik admin:")
-	fmt.Println()
-	fmt.Printf("     # 1. Find the group PK\n")
-	fmt.Printf("     curl -s -H 'Authorization: Bearer %s' \\\n", aktClient.Token())
-	fmt.Printf("       '%s/api/v3/core/groups/?search=<group-name>' | jq '.results[0].pk'\n", aktClient.BaseURL())
-	fmt.Println()
-	fmt.Printf("     # 2. Trigger per-object sync for that group (replace <pk>)\n")
-	fmt.Printf("     curl -s -X POST -H 'Authorization: Bearer %s' \\\n", aktClient.Token())
-	fmt.Printf("       -H 'Content-Type: application/json' \\\n")
-	fmt.Printf("       -d '{\"sync_object_model\":\"authentik.core.models.Group\",\"sync_object_id\":\"<pk>\"}' \\\n")
-	fmt.Printf("       '%s/api/v3/providers/scim/%d/sync/object/'\n", aktClient.BaseURL(), providerPK)
-	fmt.Println()
-	fmt.Println("     Verify in Vault:")
-	fmt.Println("       vault list identity/group/name")
-	fmt.Println("       vault read identity/group/name/<group-name>")
-	fmt.Println()
 	return nil
 }
 
@@ -272,23 +245,39 @@ func cleanVaultSCIM(client *vault.Client) {
 	_ = client.Sys().DeletePolicy(scimPolicyName)
 }
 
-// syncSCIMGroups triggers a per-object SCIM sync for every Authentik group so that
-// group membership is pushed to Vault immediately. Called automatically at the end of
-// configureSCIM and exposed via "hal vault oidc update --scim --sync".
-func syncSCIMGroups(aktClient *integrations.AuthentikClient, providerPK int) error {
-	fmt.Println("  ⚙️  Syncing group membership to Vault...")
+// syncSCIMObjects triggers a per-object SCIM sync for every Authentik user and group.
+// Users that existed before the SCIM provider was configured are not pushed automatically
+// (no creation event fires retroactively), so we explicitly sync them here.
+// Called automatically at the end of configureSCIM and via "hal vault oidc update --scim --sync".
+func syncSCIMObjects(aktClient *integrations.AuthentikClient, providerPK int) error {
+	fmt.Println("  ⚙️  Syncing users and groups to Vault...")
+
+	users, err := aktClient.GetAllUsers()
+	if err != nil {
+		return fmt.Errorf("list authentik users: %w", err)
+	}
+	usersOK := 0
+	for _, u := range users {
+		if syncErr := aktClient.SyncSCIMObject(providerPK, "authentik.core.models.User", u.PK); syncErr != nil {
+			fmt.Printf("  ⚠️  Sync failed for user %q: %v\n", u.Username, syncErr)
+		} else {
+			usersOK++
+		}
+	}
+
 	groups, err := aktClient.GetAllGroups()
 	if err != nil {
 		return fmt.Errorf("list authentik groups: %w", err)
 	}
-	synced := 0
+	groupsOK := 0
 	for _, g := range groups {
 		if syncErr := aktClient.SyncSCIMObject(providerPK, "authentik.core.models.Group", g.PK); syncErr != nil {
 			fmt.Printf("  ⚠️  Sync failed for group %q: %v\n", g.Name, syncErr)
 		} else {
-			synced++
+			groupsOK++
 		}
 	}
-	fmt.Printf("  ✅ Synced %d group(s) to Vault\n", synced)
+
+	fmt.Printf("  ✅ Synced %d user(s) and %d group(s) to Vault\n", usersOK, groupsOK)
 	return nil
 }

--- a/docs/commands/vault-oidc.md
+++ b/docs/commands/vault-oidc.md
@@ -72,20 +72,9 @@ With `--scim` (Vault Enterprise only), also wire Authentik outbound SCIM to prov
 |-------|--------------------------|
 | User created in Authentik | ✅ Yes |
 | Group created in Authentik | ✅ Yes |
-| User added to / removed from group | ❌ No — requires manual per-object sync |
+| User added to / removed from group | ✅ Yes — Authentik 2026.2.3+ |
 
-To force-sync group membership after adding a user to a group, the bootstrap token and SCIM provider PK are printed at enable time. Run:
-```bash
-# 1. Find the group PK
-curl -s -H 'Authorization: Bearer <bootstrap-token>' \
-  'http://authentik.localhost:9100/api/v3/core/groups/?search=<group-name>' | jq '.results[0].pk'
-
-# 2. Trigger per-object sync
-curl -s -X POST -H 'Authorization: Bearer <bootstrap-token>' \
-  -H 'Content-Type: application/json' \
-  -d '{"sync_object_model":"authentik.core.models.Group","sync_object_id":"<pk>"}' \
-  'http://authentik.localhost:9100/api/v3/providers/scim/<scim-provider-pk>/sync/object/'
-```
+> Users that existed *before* the SCIM provider was first configured are not retroactively pushed by event. `hal vault oidc enable --scim` and `hal vault oidc update --scim` run a full `syncSCIMObjects` pass (all users + groups) at the end to ensure initial consistency.
 
 ## Side Effects
 - Creates/removes containers `hal-authentik-pg`, `hal-authentik-server`, `hal-authentik-worker`.

--- a/docs/scim-idp-spec.md
+++ b/docs/scim-idp-spec.md
@@ -222,17 +222,9 @@ When `--scim` is used:
 |-------|--------------------------|
 | User created in Authentik | ✅ Yes (event-driven) |
 | Group created in Authentik | ✅ Yes (event-driven) |
-| User added to / removed from group | ❌ No — Authentik does not fire an outbound SCIM event for ManyToMany membership changes |
+| User added to / removed from group | ✅ Yes — Authentik 2026.2.3+ fires outbound SCIM events for group membership changes |
 
-To propagate group membership changes, trigger a per-object sync as Authentik admin. The exact `curl` commands with the real bootstrap token and SCIM provider PK are printed by `hal vault oidc enable --scim`:
-
-```bash
-# Valid sync_object_model values: authentik.core.models.Group | authentik.core.models.User
-curl -s -X POST -H 'Authorization: Bearer <bootstrap-token>' \
-  -H 'Content-Type: application/json' \
-  -d '{"sync_object_model":"authentik.core.models.Group","sync_object_id":"<group-pk>"}' \
-  'http://authentik.localhost:9100/api/v3/providers/scim/<scim-provider-pk>/sync/object/'
-```
+> **Note:** Users that existed in Authentik *before* the SCIM provider was first configured are not retroactively pushed by event. `hal vault oidc enable --scim` (and `hal vault oidc update --scim`) call `syncSCIMObjects` at the end to push all users and groups explicitly — so the initial state is always consistent.
 
 ### Drift recovery
 

--- a/internal/integrations/authentik.go
+++ b/internal/integrations/authentik.go
@@ -325,6 +325,49 @@ func WaitAuthentikTokenReady(token string) error {
 	return fmt.Errorf("authentik bootstrap token not ready within 60s — check: docker logs %s", AuthentikWorkerContainer)
 }
 
+// WaitAuthentikScopesReady polls until the standard openid/profile/email scope
+// property mappings exist. Authentik seeds these asynchronously after the first
+// migration run, so they may not be present immediately after the bootstrap token
+// becomes usable. Timeout: 60 seconds.
+func WaitAuthentikScopesReady(token string) error {
+	url := fmt.Sprintf("http://localhost:%s/api/v3/propertymappings/provider/scope/?page_size=100", AuthentikHTTPPort)
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(60 * time.Second)
+	required := map[string]bool{"openid": false, "profile": false, "email": false}
+
+	fmt.Print("  ⏳ Waiting for Authentik scope mappings")
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			var data map[string]interface{}
+			raw, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if json.Unmarshal(raw, &data) == nil {
+				found := 0
+				results, _ := data["results"].([]interface{})
+				for _, r := range results {
+					item, _ := r.(map[string]interface{})
+					if sn, _ := item["scope_name"].(string); required[sn] {
+						found++
+					}
+				}
+				if found == len(required) {
+					fmt.Println(" ✅")
+					return nil
+				}
+			}
+		} else if resp != nil {
+			resp.Body.Close()
+		}
+		fmt.Print(".")
+		time.Sleep(3 * time.Second)
+	}
+	fmt.Println()
+	return fmt.Errorf("authentik default scope mappings not ready within 60s — check: docker logs %s", AuthentikWorkerContainer)
+}
+
 // StopAuthentikStack stops and removes all Authentik containers.
 // If removeVolumes is true, the named volume hal-authentik-db is also removed.
 func StopAuthentikStack(engine string, removeVolumes bool) error {
@@ -993,6 +1036,47 @@ func (c *AuthentikClient) UpsertSCIMProvider(name, baseURL, token string, userMa
 type AuthentikGroup struct {
 	PK   string
 	Name string
+}
+
+// AuthentikUser holds the minimal fields needed for per-object SCIM sync.
+type AuthentikUser struct {
+	PK       string
+	Username string
+}
+
+// GetAllUsers returns all non-service users in Authentik.
+func (c *AuthentikClient) GetAllUsers() ([]AuthentikUser, error) {
+	var users []AuthentikUser
+	nextURL := "/api/v3/core/users/?page_size=100&type=internal"
+	for nextURL != "" {
+		data, _, err := c.do("GET", nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		results, _ := data["results"].([]interface{})
+		for _, r := range results {
+			item, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			// pk may be a float64 (JSON number) — convert to string.
+			var pk string
+			switch v := item["pk"].(type) {
+			case string:
+				pk = v
+			case float64:
+				pk = fmt.Sprintf("%.0f", v)
+			}
+			username, _ := item["username"].(string)
+			users = append(users, AuthentikUser{PK: pk, Username: username})
+		}
+		nextRaw, _ := data["next"].(string)
+		if nextRaw == "" || nextRaw == "null" {
+			break
+		}
+		nextURL = strings.TrimPrefix(nextRaw, c.baseURL)
+	}
+	return users, nil
 }
 
 // GetAllGroups returns all groups in Authentik.

--- a/internal/skills/data/vault/oidc/SKILL.md
+++ b/internal/skills/data/vault/oidc/SKILL.md
@@ -108,13 +108,6 @@ Provide a brief confirmation that the OIDC auth method is enabled.
 4. **403 on first enable after fresh stack:** Bootstrap token race — the Authentik worker creates the token asynchronously. `hal vault oidc update` retries safely.
 5. **User asks about Authentik admin password:** It is printed once at first enable and stored in `~/.hal/authentik/env` (field `AUTHENTIK_BOOTSTRAP_PASSWORD`). Username is `akadmin`.
 6. **"Expired or missing OAuth state" on second OIDC attempt:** Caused by the explicit-consent authorization flow orphaning the state. Fixed by using the implicit-consent flow. The `GetDefaultAuthorizationFlowPK` function now prefers slugs containing `implicit`.
-7. **SCIM group membership empty after adding a user:** Authentik 2026.x does not emit an outbound SCIM event when a user is added to a group (ManyToMany change). Must trigger a per-object sync manually:
-   ```bash
-   curl -s -X POST -H 'Authorization: Bearer <bootstrap-token>' \
-     -H 'Content-Type: application/json' \
-     -d '{"sync_object_model":"authentik.core.models.Group","sync_object_id":"<group-pk>"}' \
-     'http://authentik.localhost:9100/api/v3/providers/scim/<scim-provider-pk>/sync/object/'
-   ```
-   The bootstrap token and SCIM provider PK are printed by `hal vault oidc enable --scim`.
+7. **SCIM group membership empty after adding a user:** This was a known gap in older Authentik (ManyToMany signals not firing). **Fixed in Authentik 2026.2.3+** — membership changes now auto-propagate. If you see stale membership with an older Authentik version, use `hal vault oidc update --scim --sync` to force a full re-sync.
 8. **SCIM returns 400/invalidValue for group PATCH:** Authentik without `compatibility_mode: aws` includes `"schemas"` inside PatchOp Operations array items, which Vault SCIM rejects. This is already set by `hal`. If syncing manually, ensure provider has compatibility mode enabled.
 9. **SCIM returns permission denied on group PATCH:** The `scim-client` Vault policy must include the `patch` capability. Vault 1.14+ treats HTTP PATCH as a separate capability from `update`.


### PR DESCRIPTION
…, UX cleanup

- cmd/vault/create.go: add named volume hal-vault-data:/vault/file to fix anonymous volume created by Vault image VOLUME directive
- cmd/vault/delete.go + cmd/teardown.go: clean up hal-vault-data on delete
- internal/integrations/authentik.go: add WaitAuthentikScopesReady (polls until openid/profile/email scope mappings are seeded — fixes "got 0" race on first boot); add GetAllUsers + AuthentikUser for per-object user sync
- cmd/vault/scim.go: replace syncSCIMGroups with syncSCIMObjects (syncs all users AND groups — fixes pre-existing users like bob/alice not syncing); remove verbose SCIM output block
- cmd/vault/oidc.go: call WaitAuthentikScopesReady on first boot; show Authentik admin credentials in success output instead of OIDC issuer
- docs + LLM_CONTEXT.md + SKILL.md: update SCIM behaviour table — Authentik 2026.2.3+ auto-propagates group membership changes (M2M signal gap fixed)
- .gitignore: ignore *.hclic license files