### PR TITLE
Bugfix/hal minor fixes

### DIFF
--- a/cmd/boundary/create.go
+++ b/cmd/boundary/create.go
@@ -40,7 +40,7 @@ var deployCmd = &cobra.Command{
 
 		if boundaryUpdate {
 			fmt.Println("♻️  Update requested. Reconciling existing Boundary Control Plane...")
-			_ = exec.Command(engine, "rm", "-f", "hal-boundary", "hal-boundary-backend").Run()
+			_ = exec.Command(engine, "rm", "-f", boundaryContainer, boundaryBackendContainer).Run()
 		}
 
 		fmt.Printf("🚀 Deploying Boundary %s (with Postgres %s) via %s...\n", boundaryVersion, pgVersion, engine)
@@ -50,11 +50,11 @@ var deployCmd = &cobra.Command{
 		fmt.Printf("⚙️  Provisioning Boundary Control Plane Database (%s:%s)...\n", pgImage, pgVersion)
 		backendArgs := []string{
 			"run", "-d",
-			"--name", "hal-boundary-backend",
-			"--network", "hal-net",
-			"-e", "POSTGRES_USER=boundary",
-			"-e", "POSTGRES_PASSWORD=boundary",
-			"-e", "POSTGRES_DB=boundary",
+			"--name", boundaryBackendContainer,
+			"--network", global.HalNetName,
+			"-e", "POSTGRES_USER=" + boundaryDBUser,
+			"-e", "POSTGRES_PASSWORD=" + boundaryDBPassword,
+			"-e", "POSTGRES_DB=" + boundaryDBName,
 			fmt.Sprintf("%s:%s", pgImage, pgVersion),
 		}
 
@@ -69,11 +69,11 @@ var deployCmd = &cobra.Command{
 		fmt.Println("⚙️  Booting Boundary Controller & Worker...")
 		boundaryArgs := []string{
 			"run", "-d",
-			"--name", "hal-boundary",
-			"--network", "hal-net",
-			"-p", "9200:9200",
-			"-p", "9201:9201",
-			"-p", "9202:9202",
+			"--name", boundaryContainer,
+			"--network", global.HalNetName,
+			"-p", fmt.Sprintf("%d:%d", boundaryAPIPort, boundaryAPIPort),
+			"-p", fmt.Sprintf("%d:%d", boundaryClusterPort, boundaryClusterPort),
+			"-p", fmt.Sprintf("%d:%d", boundaryProxyPort, boundaryProxyPort),
 		}
 
 		if boundaryJoinConsul {
@@ -84,9 +84,9 @@ var deployCmd = &cobra.Command{
 		boundaryArgs = append(boundaryArgs,
 			fmt.Sprintf("%s:%s", boundaryImage, boundaryVersion),
 			"boundary", "dev",
-			"-api-listen-address=0.0.0.0:9200",
-			"-proxy-listen-address=0.0.0.0:9202",
-			"-database-url=postgresql://boundary:boundary@hal-boundary-backend:5432/boundary?sslmode=disable",
+			fmt.Sprintf("-api-listen-address=0.0.0.0:%d", boundaryAPIPort),
+			fmt.Sprintf("-proxy-listen-address=0.0.0.0:%d", boundaryProxyPort),
+			fmt.Sprintf("-database-url=postgresql://%s:%s@%s:5432/%s?sslmode=disable", boundaryDBUser, boundaryDBPassword, boundaryBackendContainer, boundaryDBName),
 		)
 
 		out, err := exec.Command(engine, boundaryArgs...).CombinedOutput()
@@ -101,8 +101,8 @@ var deployCmd = &cobra.Command{
 
 		fmt.Println("⏳ Waiting for Boundary to initialize (this can take 10-15 seconds)...")
 
-		if err := waitForService("Boundary", "http://127.0.0.1:9200", 30); err != nil {
-			handleDockerFailure("hal-boundary", engine)
+		if err := waitForService("Boundary", boundaryLocalAPIURL, 30); err != nil {
+			handleDockerFailure(boundaryContainer, engine)
 			return
 		}
 
@@ -110,8 +110,8 @@ var deployCmd = &cobra.Command{
 		fmt.Println("✅ Boundary Controller & Worker are up!")
 		global.RefreshHalHealth(engine)
 		fmt.Println("---------------------------------------------------------")
-		fmt.Println("   🔗 UI Address: http://boundary.localhost:9200")
-		fmt.Println("   👤 Login:      admin / password")
+		fmt.Printf("   🔗 UI Address: %s\n", boundaryUIURL)
+		fmt.Printf("   👤 Login:      %s / %s\n", boundaryAdminUsername, boundaryAdminPassword)
 		if boundaryJoinConsul {
 			fmt.Println("   🟢 Tethered:   Global Consul Control Plane")
 		}
@@ -164,10 +164,10 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&boundaryVersion, "boundary-tag", "v", "0.15.2", "Boundary container image tag")
-	cmd.Flags().StringVar(&boundaryImage, "boundary-image", "hashicorp/boundary", "Boundary container image name")
-	cmd.Flags().StringVar(&pgVersion, "boundary-pg-tag", "16-alpine", "PostgreSQL image tag for Boundary backend")
-	cmd.Flags().StringVar(&pgImage, "boundary-pg-image", "postgres", "PostgreSQL image name for Boundary backend")
+	cmd.Flags().StringVarP(&boundaryVersion, "boundary-tag", "v", defaultBoundaryTag, "Boundary container image tag")
+	cmd.Flags().StringVar(&boundaryImage, "boundary-image", defaultBoundaryImage, "Boundary container image name")
+	cmd.Flags().StringVar(&pgVersion, "boundary-pg-tag", defaultBoundaryPGTag, "PostgreSQL image tag for Boundary backend")
+	cmd.Flags().StringVar(&pgImage, "boundary-pg-image", defaultBoundaryPGImage, "PostgreSQL image name for Boundary backend")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&boundaryUpdate, "update", "u", false, "Reconcile an existing Boundary deployment in place")
 	}

--- a/cmd/boundary/defaults.go
+++ b/cmd/boundary/defaults.go
@@ -1,0 +1,47 @@
+package boundary
+
+// defaults.go is the single source of truth for values shared across the Boundary
+// command package. Container names, ports, endpoint URLs, the dev login and every
+// image/tag flag default are declared once here so create, status, delete, obs,
+// mariadb and ssh can never drift apart. Cross-product values (the Docker network
+// name) live in internal/global and are referenced, never redeclared.
+
+const (
+	// --- Containers / instances ---
+	boundaryContainer        = "hal-boundary"
+	boundaryBackendContainer = "hal-boundary-backend"
+	boundaryMariaDBContainer = "hal-boundary-target-mariadb"
+	boundarySSHInstance      = "hal-boundary-ssh" // Multipass VM
+	// vaultMariaDBContainer mirrors the Vault package's MariaDB container name; it
+	// is referenced (not owned) here when --with-vault attaches to that database.
+	vaultMariaDBContainer = "hal-vault-mariadb"
+
+	// --- Ports ---
+	boundaryAPIPort     = 9200
+	boundaryClusterPort = 9201
+	boundaryProxyPort   = 9202
+	boundaryMariaDBPort = 3306
+
+	// --- Endpoints / dev login (shared by create, ssh, obs) ---
+	boundaryUIURL         = "http://boundary.localhost:9200"
+	boundaryLocalAPIURL   = "http://127.0.0.1:9200"
+	boundaryAdminUsername = "admin"
+	boundaryAdminPassword = "password"
+	boundaryObsTarget     = boundaryContainer + ":9200"
+
+	// --- Backend Postgres credentials ---
+	boundaryDBUser     = "boundary"
+	boundaryDBPassword = "boundary"
+	boundaryDBName     = "boundary"
+
+	// --- Image / tag flag defaults ---
+	defaultBoundaryImage          = "hashicorp/boundary"
+	defaultBoundaryTag            = "0.15.2"
+	defaultBoundaryPGImage        = "postgres"
+	defaultBoundaryPGTag          = "16-alpine"
+	defaultBoundaryMariaDBImage   = "mariadb"
+	defaultBoundaryMariaDBTag     = "11.4"
+	defaultBoundarySSHUbuntuImage = "22.04"
+	defaultBoundarySSHCPUs        = "1"
+	defaultBoundarySSHMem         = "512M"
+)

--- a/cmd/boundary/delete.go
+++ b/cmd/boundary/delete.go
@@ -11,9 +11,9 @@ import (
 )
 
 var boundaryEcosystem = []string{
-	"hal-boundary",
-	"hal-boundary-backend",
-	"hal-boundary-target-mariadb",
+	boundaryContainer,
+	boundaryBackendContainer,
+	boundaryMariaDBContainer,
 }
 
 var destroyCmd = &cobra.Command{
@@ -43,7 +43,7 @@ var destroyCmd = &cobra.Command{
 		}
 
 		// Handle Multipass target cleanup gracefully
-		_ = exec.Command("multipass", "delete", "hal-boundary-ssh").Run()
+		_ = exec.Command("multipass", "delete", boundarySSHInstance).Run()
 		_ = exec.Command("multipass", "purge").Run()
 		fmt.Println("  ✅ Destroyed SSH VM (if it existed)")
 

--- a/cmd/boundary/mariadb.go
+++ b/cmd/boundary/mariadb.go
@@ -36,7 +36,7 @@ var mariadbCmd = &cobra.Command{
 
 		// 1. STATUS CHECK
 		if !mariadbEnable && !mariadbDisable && !mariadbUpdate {
-			out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-boundary-target-mariadb").Output()
+			out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", boundaryMariaDBContainer).Output()
 			status := strings.TrimSpace(string(out))
 			if err != nil {
 				fmt.Println("❌ MariaDB Target: Not deployed. Run: hal boundary mariadb enable")
@@ -56,7 +56,7 @@ var mariadbCmd = &cobra.Command{
 				if err := cleanupBoundaryMariaDB(); err != nil {
 					fmt.Printf("⚠️  Boundary cleanup warning: %v\n", err)
 				}
-				if err := exec.Command(engine, "rm", "-f", "hal-boundary-target-mariadb").Run(); err != nil {
+				if err := exec.Command(engine, "rm", "-f", boundaryMariaDBContainer).Run(); err != nil {
 					fmt.Printf("⚠️  Container cleanup warning: %v\n", err)
 				}
 			}
@@ -67,10 +67,10 @@ var mariadbCmd = &cobra.Command{
 
 		// 3. DEPLOY
 		if mariadbEnable || mariadbUpdate {
-			dbContainerName := "hal-boundary-target-mariadb"
+			dbContainerName := boundaryMariaDBContainer
 			if global.DryRun {
 				if mariadbWithVault {
-					dbContainerName = "hal-vault-mariadb"
+					dbContainerName = vaultMariaDBContainer
 					fmt.Println("[DRY RUN] Would attach Boundary target to existing hal-vault-mariadb")
 				} else {
 					fmt.Printf("[DRY RUN] Would create/start MariaDB container hal-boundary-target-mariadb (mariadb:%s) on hal-net\n", targetMariadbVer)
@@ -83,7 +83,7 @@ var mariadbCmd = &cobra.Command{
 			}
 
 			// Boundary Guardrail
-			out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-boundary").Output()
+			out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", boundaryContainer).Output()
 			if err != nil || strings.TrimSpace(string(out)) != "running" {
 				fmt.Println("❌ Error: Boundary controller is not running! Run: hal boundary create")
 				return
@@ -96,12 +96,12 @@ var mariadbCmd = &cobra.Command{
 					fmt.Println("❌ Error: Vault is not running! Run: hal vault create && hal vault database enable")
 					return
 				}
-				dbContainerName = "hal-vault-mariadb"
+				dbContainerName = vaultMariaDBContainer
 				fmt.Printf("🔗 Attaching Boundary to existing %s...\n", dbContainerName)
 			} else {
 				fmt.Println("🚀 Deploying standalone MariaDB...")
 				global.EnsureNetwork(engine)
-				out, err = exec.Command(engine, "run", "-d", "--name", dbContainerName, "--network", "hal-net", "-p", "3306:3306", "-e", "MARIADB_ROOT_PASSWORD=password", "-e", "MARIADB_DATABASE=targetdb", "-e", "MARIADB_USER=admin", "-e", "MARIADB_PASSWORD=password", fmt.Sprintf("%s:%s", targetMariadbImage, targetMariadbVer)).CombinedOutput()
+				out, err = exec.Command(engine, "run", "-d", "--name", dbContainerName, "--network", global.HalNetName, "-p", fmt.Sprintf("%d:%d", boundaryMariaDBPort, boundaryMariaDBPort), "-e", "MARIADB_ROOT_PASSWORD=password", "-e", "MARIADB_DATABASE=targetdb", "-e", "MARIADB_USER=admin", "-e", "MARIADB_PASSWORD=password", fmt.Sprintf("%s:%s", targetMariadbImage, targetMariadbVer)).CombinedOutput()
 				if err != nil {
 					fmt.Printf("❌ Failed to start MariaDB container: %v\n%s\n", err, strings.TrimSpace(string(out)))
 					return
@@ -133,8 +133,8 @@ func init() {
 	_ = mariadbCmd.Flags().MarkHidden("disable")
 	_ = mariadbCmd.Flags().MarkHidden("update")
 	mariadbCmd.Flags().BoolVar(&mariadbWithVault, "with-vault", false, "Link with Vault Dynamic Creds")
-	mariadbCmd.Flags().StringVar(&targetMariadbVer, "boundary-mariadb-tag", "11.4", "MariaDB container image tag")
-	mariadbCmd.Flags().StringVar(&targetMariadbImage, "boundary-mariadb-image", "mariadb", "MariaDB container image name")
+	mariadbCmd.Flags().StringVar(&targetMariadbVer, "boundary-mariadb-tag", defaultBoundaryMariaDBTag, "MariaDB container image tag")
+	mariadbCmd.Flags().StringVar(&targetMariadbImage, "boundary-mariadb-image", defaultBoundaryMariaDBImage, "MariaDB container image name")
 	Cmd.AddCommand(mariadbCmd)
 }
 
@@ -173,7 +173,7 @@ func bootstrapBoundaryMariaDB(targetHost string) error {
 		return fmt.Errorf("failed to add host to host set: %v", err)
 	}
 
-	targetID, err := client.CreateOrGetResource("targets", map[string]interface{}{"name": "mariadb-secure-access", "type": "tcp", "default_port": 3306, "scope_id": projID}, "name", map[string]string{"scope_id": projID})
+	targetID, err := client.CreateOrGetResource("targets", map[string]interface{}{"name": "mariadb-secure-access", "type": "tcp", "default_port": boundaryMariaDBPort, "scope_id": projID}, "name", map[string]string{"scope_id": projID})
 	if err != nil {
 		return fmt.Errorf("failed to create target: %v", err)
 	}

--- a/cmd/boundary/obs.go
+++ b/cmd/boundary/obs.go
@@ -13,7 +13,6 @@ import (
 )
 
 const boundaryObsProduct = "boundary"
-const boundaryObsTarget = "hal-boundary:9200"
 
 var boundaryObsCmd = &cobra.Command{
 	Use:   "obs",
@@ -34,7 +33,7 @@ var boundaryObsCreateCmd = &cobra.Command{
 			fmt.Printf("❌ Error: %v\n", err)
 			return
 		}
-		if !global.IsContainerRunning(engine, "hal-boundary") {
+		if !global.IsContainerRunning(engine, boundaryContainer) {
 			fmt.Println("❌ Boundary is not running.")
 			fmt.Println("   💡 Run 'hal boundary create' first.")
 			return

--- a/cmd/boundary/ssh.go
+++ b/cmd/boundary/ssh.go
@@ -100,14 +100,14 @@ var sshCmd = &cobra.Command{
 				fmt.Println("[DRY RUN] Would configure Boundary API resources for SSH target")
 				return
 			}
-			_ = exec.Command("multipass", "delete", "hal-boundary-ssh").Run()
+			_ = exec.Command("multipass", "delete", boundarySSHInstance).Run()
 			_ = exec.Command("multipass", "purge").Run()
 
-			vmArgs := []string{"launch", sshUbuntuImage, "--name", "hal-boundary-ssh", "--cpus", sshVMCPUs, "--mem", sshVMMem}
+			vmArgs := []string{"launch", sshUbuntuImage, "--name", boundarySSHInstance, "--cpus", sshVMCPUs, "--mem", sshVMMem}
 			_, vmErr := exec.Command("multipass", vmArgs...).CombinedOutput()
 
 			if vmErr == nil {
-				ipOut, _ := exec.Command("multipass", "info", "hal-boundary-ssh", "--format", "csv").Output()
+				ipOut, _ := exec.Command("multipass", "info", boundarySSHInstance, "--format", "csv").Output()
 				ip := extractMultipassIP(string(ipOut))
 				fmt.Println("✅ SSH Target ready!")
 				fmt.Printf("   Host: %s (Port 22)\n", ip)
@@ -132,16 +132,16 @@ func init() {
 	_ = sshCmd.Flags().MarkHidden("enable")
 	_ = sshCmd.Flags().MarkHidden("disable")
 	_ = sshCmd.Flags().MarkHidden("update")
-	sshCmd.Flags().StringVar(&sshUbuntuImage, "ubuntu-image", "22.04", "Multipass image/channel used for the SSH target VM")
-	sshCmd.Flags().StringVar(&sshVMCPUs, "cpus", "1", "Number of CPUs for the SSH target VM")
-	sshCmd.Flags().StringVar(&sshVMMem, "mem", "512M", "Amount of RAM for the SSH target VM")
+	sshCmd.Flags().StringVar(&sshUbuntuImage, "ubuntu-image", defaultBoundarySSHUbuntuImage, "Multipass image/channel used for the SSH target VM")
+	sshCmd.Flags().StringVar(&sshVMCPUs, "cpus", defaultBoundarySSHCPUs, "Number of CPUs for the SSH target VM")
+	sshCmd.Flags().StringVar(&sshVMMem, "mem", defaultBoundarySSHMem, "Amount of RAM for the SSH target VM")
 
 	Cmd.AddCommand(sshCmd)
 }
 
 func newBoundaryAdminClient() (*BoundaryClient, error) {
 	client := &BoundaryClient{
-		Address: "http://127.0.0.1:9200",
+		Address: boundaryLocalAPIURL,
 		Client:  &http.Client{},
 	}
 
@@ -150,7 +150,7 @@ func newBoundaryAdminClient() (*BoundaryClient, error) {
 		return nil, fmt.Errorf("failed to get auth method: %v", err)
 	}
 
-	if err := client.Authenticate(authID, "admin", "password"); err != nil {
+	if err := client.Authenticate(authID, boundaryAdminUsername, boundaryAdminPassword); err != nil {
 		return nil, err
 	}
 
@@ -378,7 +378,7 @@ func bootstrapBoundarySSH(targetIP string) error {
 		global.RefreshHalHealth(eng)
 	}
 	fmt.Println("\n💡 Test your access:")
-	fmt.Println("   1. Log in to UI (http://boundary.localhost:9200)")
+	fmt.Println("   1. Log in to UI (" + boundaryUIURL + ")")
 	fmt.Println("   2. Change Scope to 'hal-academy-ssh'")
 	fmt.Println("   3. Auth Method: ssh-lab-auth")
 	fmt.Println("   4. Login as 'ssh-operator' or 'ssh-auditor' (Password: password)")

--- a/cmd/boundary/status.go
+++ b/cmd/boundary/status.go
@@ -30,8 +30,8 @@ var statusCmd = &cobra.Command{
 			Name      string
 			Container string
 		}{
-			{"Backend DB", "hal-boundary-backend"},
-			{"Controller/Worker", "hal-boundary"},
+			{"Backend DB", boundaryBackendContainer},
+			{"Controller/Worker", boundaryContainer},
 		}
 
 		allCoresRunning := true
@@ -54,14 +54,14 @@ var statusCmd = &cobra.Command{
 		fmt.Println("\n  [ Target Ecosystem ]")
 
 		// DB Target
-		dbOut, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-boundary-target-mariadb").Output()
+		dbOut, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", boundaryMariaDBContainer).Output()
 		if err == nil && strings.TrimSpace(string(dbOut)) == "running" {
 			fmt.Println("  🟢 MariaDB Target   : Up (hal boundary mariadb disable)")
 		} else {
 			fmt.Println("  ⚪ MariaDB Target   : Down (hal boundary mariadb enable)")
 		}
 
-		vmOut, vmErr := exec.Command("multipass", "info", "hal-boundary-ssh", "--format", "csv").Output()
+		vmOut, vmErr := exec.Command("multipass", "info", boundarySSHInstance, "--format", "csv").Output()
 		if vmErr == nil && strings.Contains(string(vmOut), "Running") {
 			ip := extractMultipassIP(string(vmOut))
 			fmt.Printf("  🟢 Ubuntu SSH Target: Up (IP: %s) (hal boundary ssh disable)\n", ip)

--- a/cmd/consul/create.go
+++ b/cmd/consul/create.go
@@ -35,7 +35,7 @@ var deployCmd = &cobra.Command{
 			if global.Debug {
 				fmt.Println("[DEBUG] --update detected. Reconciling existing standalone Consul...")
 			}
-			_ = exec.Command(engine, "rm", "-f", "hal-consul").Run()
+			_ = exec.Command(engine, "rm", "-f", consulContainer).Run()
 		}
 
 		fmt.Printf(" Deploying standalone Consul %s via %s...\n", consulVersion, engine)
@@ -43,9 +43,9 @@ var deployCmd = &cobra.Command{
 		// Command: <engine> run -d --name hal-consul --network hal-net -p 8500:8500 hashicorp/consul:1.15.0 agent -server -ui -node=server-1 -bootstrap-expect=1 -client=0.0.0.0
 		consulArgs := []string{
 			"run", "-d",
-			"--name", "hal-consul",
-			"--network", "hal-net",
-			"-p", "8500:8500", // The magic UI/API port
+			"--name", consulContainer,
+			"--network", global.HalNetName,
+			"-p", fmt.Sprintf("%d:%d", consulHTTPPort, consulHTTPPort), // The magic UI/API port
 			fmt.Sprintf("%s:%s", consulImage, consulVersion),
 			"agent", "-server", "-ui", "-node=hal-server", "-bootstrap-expect=1", "-client=0.0.0.0",
 		}
@@ -67,7 +67,7 @@ var deployCmd = &cobra.Command{
 
 		fmt.Println("✅ Standalone Consul Server is up!")
 		global.RefreshHalHealth(engine)
-		fmt.Println("   🔗 UI Address: http://consul.localhost:8500")
+		fmt.Printf("   🔗 UI Address: %s\n", consulBaseURL)
 		fmt.Println("\n💡 Tip: Use this to test the KV store or learn the API.")
 		fmt.Println("   (For real workloads, use 'hal nomad create --with-consul' instead!)")
 	},
@@ -84,8 +84,8 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&consulVersion, "consul-tag", "v", "1.15.0", "Consul container image tag")
-	cmd.Flags().StringVar(&consulImage, "consul-image", "hashicorp/consul", "Consul container image name")
+	cmd.Flags().StringVarP(&consulVersion, "consul-tag", "v", defaultConsulTag, "Consul container image tag")
+	cmd.Flags().StringVar(&consulImage, "consul-image", defaultConsulImage, "Consul container image name")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&consulUpdate, "update", "u", false, "Reconcile an existing Consul deployment in place")
 	}

--- a/cmd/consul/defaults.go
+++ b/cmd/consul/defaults.go
@@ -1,0 +1,22 @@
+package consul
+
+// defaults.go is the single source of truth for values shared across the Consul
+// command package. Any value used by more than one file in this package, plus
+// every identity / endpoint / URL / image flag default, MUST be defined here so
+// the commands can never drift apart. Cross-product values (the Docker network
+// name) live in internal/global and are referenced, never redeclared.
+
+const (
+	// --- Container ---
+	consulContainer = "hal-consul"
+
+	// --- Host / ports / URL ---
+	consulHostname  = "consul.localhost"
+	consulHTTPPort  = 8500
+	consulBaseURL   = "http://consul.localhost:8500"
+	consulObsTarget = consulContainer + ":8500"
+
+	// --- Image / tag flag defaults ---
+	defaultConsulImage = "hashicorp/consul"
+	defaultConsulTag   = "1.15.0"
+)

--- a/cmd/consul/delete.go
+++ b/cmd/consul/delete.go
@@ -27,7 +27,7 @@ var destroyCmd = &cobra.Command{
 			return
 		}
 
-		out, err := exec.Command(engine, "rm", "-f", "hal-consul").Output()
+		out, err := exec.Command(engine, "rm", "-f", consulContainer).Output()
 		if err == nil && string(out) != "" {
 			fmt.Println("  ✅ Destroyed container: hal-consul")
 		}

--- a/cmd/consul/obs.go
+++ b/cmd/consul/obs.go
@@ -13,7 +13,6 @@ import (
 )
 
 const consulObsProduct = "consul"
-const consulObsTarget = "hal-consul:8500"
 
 var consulObsCmd = &cobra.Command{
 	Use:   "obs",
@@ -34,7 +33,7 @@ var consulObsCreateCmd = &cobra.Command{
 			fmt.Printf("❌ Error: %v\n", err)
 			return
 		}
-		if !global.IsContainerRunning(engine, "hal-consul") {
+		if !global.IsContainerRunning(engine, consulContainer) {
 			fmt.Println("❌ Consul is not running.")
 			fmt.Println("   💡 Run 'hal consul create' first.")
 			return

--- a/cmd/consul/status.go
+++ b/cmd/consul/status.go
@@ -25,13 +25,13 @@ var consulStatusCmd = &cobra.Command{
 		fmt.Println()
 		fmt.Println("  [ Control Plane ]")
 
-		out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-consul").Output()
+		out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", consulContainer).Output()
 		status := strings.TrimSpace(string(out))
 
 		if err != nil {
 			fmt.Println("  ⚪ hal-consul : Down (hal consul create to start)")
 		} else if status == "running" {
-			fmt.Println("  🟢 hal-consul : Up   (http://consul.localhost:8500)")
+			fmt.Printf("  🟢 hal-consul : Up   (%s)\n", consulBaseURL)
 		} else {
 			fmt.Printf("  🟡 hal-consul : %s\n", strings.ToUpper(status))
 		}

--- a/cmd/creds/creds.go
+++ b/cmd/creds/creds.go
@@ -112,13 +112,13 @@ var statusCmd = &cobra.Command{
 			fmt.Println("   Username : admin")
 			fmt.Println("   Password : password")
 			fmt.Println()
-			if global.CheckContainer(engine, "hal-ssh-target") {
+			if global.MultipassInstanceExists("hal-boundary-ssh") {
 				fmt.Println("   SSH lab users (Boundary auth method: ssh-lab-auth)")
 				fmt.Println("     ssh-operator / password")
 				fmt.Println("     ssh-auditor  / password")
 				fmt.Println()
 			}
-			if global.CheckContainer(engine, "hal-mariadb-target") {
+			if global.CheckContainer(engine, "hal-boundary-target-mariadb") {
 				fmt.Println("   MariaDB target")
 				fmt.Println("     host: localhost:3306  user: admin  password: password")
 				fmt.Println()
@@ -275,13 +275,13 @@ func CollectActiveCredentials() (ActiveCredentials, error) {
 			URL:     "http://boundary.localhost:9200",
 			Entries: []CredentialEntry{{Name: "Admin", Username: "admin", Secret: "password"}},
 		}
-		if global.CheckContainer(engine, "hal-ssh-target") {
+		if global.MultipassInstanceExists("hal-boundary-ssh") {
 			boundary.Entries = append(boundary.Entries,
 				CredentialEntry{Name: "ssh-operator", Username: "ssh-operator", Secret: "password", Note: "Boundary auth method: ssh-lab-auth"},
 				CredentialEntry{Name: "ssh-auditor", Username: "ssh-auditor", Secret: "password", Note: "Boundary auth method: ssh-lab-auth"},
 			)
 		}
-		if global.CheckContainer(engine, "hal-mariadb-target") {
+		if global.CheckContainer(engine, "hal-boundary-target-mariadb") {
 			boundary.Entries = append(boundary.Entries,
 				CredentialEntry{Name: "MariaDB target", Username: "admin", Secret: "password", Note: "host: localhost:3306"},
 			)

--- a/cmd/creds/creds.go
+++ b/cmd/creds/creds.go
@@ -132,6 +132,7 @@ var statusCmd = &cobra.Command{
 			fmt.Println("🏗️  Terraform Enterprise")
 			fmt.Println("   URL      : https://tfe.localhost")
 			fmt.Println("   Username : haladmin")
+			fmt.Println("   Password : hal9000FTW")
 			if token != "" {
 				fmt.Printf("   API token: %s\n", token)
 			} else {

--- a/cmd/nomad/create.go
+++ b/cmd/nomad/create.go
@@ -48,7 +48,7 @@ var deployCmd = &cobra.Command{
 				fmt.Println("[DEBUG] --update detected. Purging existing VM 'hal-nomad' for reconciliation...")
 			}
 			if !global.DryRun {
-				_ = exec.Command("multipass", "delete", "hal-nomad").Run()
+				_ = exec.Command("multipass", "delete", nomadInstance).Run()
 				_ = exec.Command("multipass", "purge").Run()
 			}
 		}
@@ -67,7 +67,7 @@ var deployCmd = &cobra.Command{
 
 		// 1. Launch the VM
 		fmt.Println("📦 Provisioning Ubuntu VM (This takes a few seconds)...")
-		launchArgs := []string{"launch", nomadUbuntuImage, "--name", "hal-nomad", "--cpus", nomadCPUs, "--mem", nomadMem}
+		launchArgs := []string{"launch", nomadUbuntuImage, "--name", nomadInstance, "--cpus", nomadCPUs, "--mem", nomadMem}
 		out, err := exec.Command("multipass", launchArgs...).CombinedOutput()
 		if err != nil {
 			if strings.Contains(string(out), "already exists") {
@@ -119,25 +119,25 @@ var deployCmd = &cobra.Command{
 			sudo systemctl enable --now nomad;
 		`, nomadVersion, nomadVersion, joinConsulStr)
 
-		execArgs := []string{"exec", "hal-nomad", "--", "bash", "-c", installScript}
+		execArgs := []string{"exec", nomadInstance, "--", "bash", "-c", installScript}
 		if out, err := exec.Command("multipass", execArgs...).CombinedOutput(); err != nil {
 			fmt.Printf("❌ Failed to configure VM: %v\nOutput: %s\n", err, string(out))
 			return
 		}
 
 		// 3. Fetch the VM's IP Address
-		ipOut, _ := exec.Command("multipass", "info", "hal-nomad", "--format", "csv").Output()
+		ipOut, _ := exec.Command("multipass", "info", nomadInstance, "--format", "csv").Output()
 		ip := extractMultipassIP(string(ipOut))
 
 		// 4. THE HEALTH CHECK PHASE
 		fmt.Println("⏳ Waiting for Nomad to become healthy...")
-		if err := waitForService("Nomad", fmt.Sprintf("http://%s:4646/v1/status/leader", ip), 45); err != nil {
+		if err := waitForService("Nomad", fmt.Sprintf("http://%s:%d/v1/status/leader", ip, nomadHTTPPort), 45); err != nil {
 			handleServiceFailure("nomad")
 			return
 		}
 
 		fmt.Println("\n✅ Environment is fully verified and ready!")
-		fmt.Printf("   🔗 Nomad UI:  http://%s:4646\n", ip)
+		fmt.Printf("   🔗 Nomad UI:  http://%s:%d\n", ip, nomadHTTPPort)
 
 		if nomadJoinConsul {
 			fmt.Println("   🟢 Nomad is successfully tethered to the global Consul Control Plane!")
@@ -167,7 +167,7 @@ func handleServiceFailure(service string) {
 	fmt.Printf("❌ %s service failed to start or become healthy.\n", strings.Title(service))
 	fmt.Println("📜 Fetching recent systemd logs from the VM...")
 
-	out, _ := exec.Command("multipass", "exec", "hal-nomad", "--", "journalctl", "-u", service, "-n", "15", "--no-pager").CombinedOutput()
+	out, _ := exec.Command("multipass", "exec", nomadInstance, "--", "journalctl", "-u", service, "-n", "15", "--no-pager").CombinedOutput()
 	logStr := strings.TrimSpace(string(out))
 
 	if logStr != "" {
@@ -202,10 +202,10 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&nomadVersion, "version", "v", "1.11.3", "Nomad version to install")
-	cmd.Flags().StringVar(&nomadUbuntuImage, "ubuntu-image", "22.04", "Multipass image/channel used for the Nomad VM")
-	cmd.Flags().StringVar(&nomadCPUs, "cpus", "2", "Number of CPUs for the VM")
-	cmd.Flags().StringVar(&nomadMem, "mem", "2G", "Amount of RAM for the VM")
+	cmd.Flags().StringVarP(&nomadVersion, "version", "v", defaultNomadVersion, "Nomad version to install")
+	cmd.Flags().StringVar(&nomadUbuntuImage, "ubuntu-image", defaultNomadUbuntuImage, "Multipass image/channel used for the Nomad VM")
+	cmd.Flags().StringVar(&nomadCPUs, "cpus", defaultNomadCPUs, "Number of CPUs for the VM")
+	cmd.Flags().StringVar(&nomadMem, "mem", defaultNomadMem, "Amount of RAM for the VM")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&nomadUpdate, "update", "u", false, "Reconcile an existing Nomad deployment in place")
 	}

--- a/cmd/nomad/defaults.go
+++ b/cmd/nomad/defaults.go
@@ -1,0 +1,19 @@
+package nomad
+
+// defaults.go is the single source of truth for values shared across the Nomad
+// command package. Any value used by more than one file in this package, plus
+// every identity / endpoint / URL / image flag default, MUST be defined here so
+// the commands can never drift apart.
+
+const (
+	// --- Multipass instance / host / port ---
+	nomadInstance = "hal-nomad"
+	nomadHostname = "nomad.localhost"
+	nomadHTTPPort = 4646
+
+	// --- Flag defaults ---
+	defaultNomadVersion     = "1.11.3"
+	defaultNomadUbuntuImage = "22.04"
+	defaultNomadCPUs        = "2"
+	defaultNomadMem         = "2G"
+)

--- a/cmd/nomad/delete.go
+++ b/cmd/nomad/delete.go
@@ -21,7 +21,7 @@ var destroyCmd = &cobra.Command{
 			return
 		}
 
-		_ = exec.Command("multipass", "delete", "hal-nomad").Run()
+		_ = exec.Command("multipass", "delete", nomadInstance).Run()
 		_ = exec.Command("multipass", "purge").Run()
 		if err := global.RemoveObsPromTargetFile("nomad"); err != nil {
 			fmt.Printf("⚠️  Could not remove Nomad observability target file: %v\n", err)

--- a/cmd/nomad/job.go
+++ b/cmd/nomad/job.go
@@ -12,7 +12,7 @@ var nomadJobCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("⚙️ Submitting sample job to Nomad...")
 		// TODO: Use the Nomad Go API or CLI via multipass exec to submit a basic web server job
-		fmt.Println("✅ Job deployed! Check the UI at http://nomad.localhost:4646")
+		fmt.Printf("✅ Job deployed! Check the UI at http://%s:%d\n", nomadHostname, nomadHTTPPort)
 	},
 }
 

--- a/cmd/nomad/obs.go
+++ b/cmd/nomad/obs.go
@@ -29,7 +29,7 @@ var nomadObsCreateCmd = &cobra.Command{
 	Short: "Create Nomad observability artifacts",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		if !global.MultipassInstanceExists("hal-nomad") {
+		if !global.MultipassInstanceExists(nomadInstance) {
 			fmt.Println("❌ Nomad VM is not present.")
 			fmt.Println("   💡 Run 'hal nomad create' first.")
 			return
@@ -117,7 +117,7 @@ var nomadObsStatusCmd = &cobra.Command{
 }
 
 func resolveNomadObsTarget() (string, error) {
-	ipOut, err := exec.Command("multipass", "info", "hal-nomad", "--format", "csv").Output()
+	ipOut, err := exec.Command("multipass", "info", nomadInstance, "--format", "csv").Output()
 	if err != nil {
 		return "", err
 	}
@@ -125,7 +125,7 @@ func resolveNomadObsTarget() (string, error) {
 	if strings.TrimSpace(ip) == "" || ip == "127.0.0.1" {
 		return "", fmt.Errorf("hal-nomad IP not available")
 	}
-	return fmt.Sprintf("%s:4646", ip), nil
+	return fmt.Sprintf("%s:%d", ip, nomadHTTPPort), nil
 }
 
 func nomadObsTargetFileContains(path, wanted string) bool {

--- a/cmd/nomad/status.go
+++ b/cmd/nomad/status.go
@@ -18,7 +18,7 @@ var nomadStatusCmd = &cobra.Command{
 		fmt.Println()
 		fmt.Println("  [ Multipass Infrastructure ]")
 
-		out, err := exec.Command("multipass", "info", "hal-nomad", "--format", "csv").Output()
+		out, err := exec.Command("multipass", "info", nomadInstance, "--format", "csv").Output()
 		if err != nil {
 			fmt.Println("  ⚪ Nomad VM : Down (hal nomad create to start)")
 			return
@@ -41,14 +41,14 @@ var nomadStatusCmd = &cobra.Command{
 		fmt.Println("\n  [ Nomad API Health ]")
 
 		client := http.Client{Timeout: 2 * time.Second}
-		resp, err := client.Get(fmt.Sprintf("http://%s:4646/v1/status/leader", ip))
+		resp, err := client.Get(fmt.Sprintf("http://%s:%d/v1/status/leader", ip, nomadHTTPPort))
 
 		if err != nil {
 			fmt.Println("  🟡 Nomad API: Unreachable (Agent crashed or booting)")
 		} else {
 			defer resp.Body.Close()
 			if resp.StatusCode == 200 {
-				fmt.Printf("  🟢 Nomad API: Ready (http://%s:4646)\n", ip)
+				fmt.Printf("  🟢 Nomad API: Ready (http://%s:%d)\n", ip, nomadHTTPPort)
 			} else {
 				fmt.Printf("  🟡 Nomad API: Error (HTTP %d)\n", resp.StatusCode)
 			}

--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -44,7 +44,7 @@ var deployCmd = &cobra.Command{
 
 		if obsUpdate {
 			fmt.Println("♻️  Update requested. Reconciling observability stack...")
-			_ = exec.Command(engine, "rm", "-f", "hal-grafana", "hal-promtail", "hal-loki", "hal-prometheus").Run()
+			_ = exec.Command(engine, "rm", "-f", obsGrafanaContainer, obsPromtailContainer, obsLokiContainer, obsPrometheusContainer).Run()
 			homeDir, _ := os.UserHomeDir()
 			_ = os.RemoveAll(filepath.Join(homeDir, ".hal", "obs"))
 		}
@@ -226,10 +226,10 @@ providers:
 			}
 		}
 
-		bootContainer("Prometheus", "run", "-d", "--name", "hal-prometheus", "--network", "hal-net", "-p", "9090:9090", "-v", filepath.Join(configDir, "prometheus.yml")+":/etc/prometheus/prometheus.yml", "-v", targetsDir+":/etc/prometheus/targets", promImage+":"+promVer)
-		bootContainer("Loki", "run", "-d", "--name", "hal-loki", "--network", "hal-net", "-p", "3100:3100", "-v", filepath.Join(configDir, "loki-config.yaml")+":/etc/loki/local-config.yaml", lokiImage+":"+lokiVer, "-config.file=/etc/loki/local-config.yaml")
-		bootContainer("Promtail", "run", "-d", "--name", "hal-promtail", "--network", "hal-net", "-v", "hal-vault-logs:/vault/logs:ro", "-v", filepath.Join(configDir, "promtail-config.yaml")+":/etc/promtail/config.yml", promtailImage+":"+promtailVer, "-config.file=/etc/promtail/config.yml")
-		bootContainer("Grafana", "run", "-d", "--name", "hal-grafana", "--network", "hal-net", "-p", "3000:3000", "-v", filepath.Join(configDir, "datasources.yml")+":/etc/grafana/provisioning/datasources/datasources.yml", "-v", filepath.Join(configDir, "dashboards.yml")+":/etc/grafana/provisioning/dashboards/dashboards.yml", "-v", dashboardsDir+":/var/lib/grafana/dashboards", "-e", "GF_AUTH_ANONYMOUS_ENABLED=true", "-e", "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin", grafanaImage+":"+grafanaVer)
+		bootContainer("Prometheus", "run", "-d", "--name", obsPrometheusContainer, "--network", global.HalNetName, "-p", "9090:9090", "-v", filepath.Join(configDir, "prometheus.yml")+":/etc/prometheus/prometheus.yml", "-v", targetsDir+":/etc/prometheus/targets", promImage+":"+promVer)
+		bootContainer("Loki", "run", "-d", "--name", obsLokiContainer, "--network", global.HalNetName, "-p", "3100:3100", "-v", filepath.Join(configDir, "loki-config.yaml")+":/etc/loki/local-config.yaml", lokiImage+":"+lokiVer, "-config.file=/etc/loki/local-config.yaml")
+		bootContainer("Promtail", "run", "-d", "--name", obsPromtailContainer, "--network", global.HalNetName, "-v", "hal-vault-logs:/vault/logs:ro", "-v", filepath.Join(configDir, "promtail-config.yaml")+":/etc/promtail/config.yml", promtailImage+":"+promtailVer, "-config.file=/etc/promtail/config.yml")
+		bootContainer("Grafana", "run", "-d", "--name", obsGrafanaContainer, "--network", global.HalNetName, "-p", "3000:3000", "-v", filepath.Join(configDir, "datasources.yml")+":/etc/grafana/provisioning/datasources/datasources.yml", "-v", filepath.Join(configDir, "dashboards.yml")+":/etc/grafana/provisioning/dashboards/dashboards.yml", "-v", dashboardsDir+":/var/lib/grafana/dashboards", "-e", "GF_AUTH_ANONYMOUS_ENABLED=true", "-e", "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin", grafanaImage+":"+grafanaVer)
 
 		fmt.Println("⏳ Waiting for Prometheus, Loki, and Grafana health checks...")
 		if err := waitForObsHealth(engine); err != nil {
@@ -242,9 +242,9 @@ providers:
 		fmt.Println("✅ Observability Stack Deployed Successfully!")
 		global.RefreshHalHealth(engine)
 		fmt.Println("---------------------------------------------------------")
-		fmt.Println("🔗 Grafana:    http://grafana.localhost:3000 (Auto-logged in as Admin)")
-		fmt.Println("🔗 Prometheus: http://prometheus.localhost:9090")
-		fmt.Println("🔗 Loki API:   http://loki.localhost:3100/ready")
+		fmt.Printf("🔗 Grafana:    %s (Auto-logged in as Admin)\n", obsGrafanaURL)
+		fmt.Printf("🔗 Prometheus: %s\n", obsPrometheusURL)
+		fmt.Printf("🔗 Loki API:   %s\n", obsLokiReadyURL)
 		fmt.Println("---------------------------------------------------------")
 
 		if obsJobName != "" {
@@ -319,7 +319,7 @@ func readinessLabel(ok bool) string {
 }
 
 func firstNonRunningObsContainer(engine string) (string, error) {
-	containers := []string{"hal-prometheus", "hal-loki", "hal-promtail", "hal-grafana"}
+	containers := []string{obsPrometheusContainer, obsLokiContainer, obsPromtailContainer, obsGrafanaContainer}
 	for _, c := range containers {
 		out, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", c).CombinedOutput()
 		if err != nil {
@@ -398,14 +398,14 @@ func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&obsUpdate, "update", "u", false, "Reconcile an existing observability stack in place")
 	}
-	cmd.Flags().StringVar(&lokiVer, "loki-tag", "3.7", "Tag for the Loki image")
-	cmd.Flags().StringVar(&lokiImage, "loki-image", "grafana/loki", "Loki container image name")
-	cmd.Flags().StringVar(&grafanaVer, "grafana-tag", "main", "Tag for the Grafana image")
-	cmd.Flags().StringVar(&grafanaImage, "grafana-image", "grafana/grafana", "Grafana container image name")
-	cmd.Flags().StringVar(&promVer, "prometheus-tag", "main", "Tag for the Prometheus image")
-	cmd.Flags().StringVar(&promImage, "prometheus-image", "prom/prometheus", "Prometheus container image name")
-	cmd.Flags().StringVar(&promtailVer, "promtail-tag", "3.6", "Tag for the Promtail image")
-	cmd.Flags().StringVar(&promtailImage, "promtail-image", "grafana/promtail", "Promtail container image name")
+	cmd.Flags().StringVar(&lokiVer, "loki-tag", defaultLokiTag, "Tag for the Loki image")
+	cmd.Flags().StringVar(&lokiImage, "loki-image", defaultLokiImage, "Loki container image name")
+	cmd.Flags().StringVar(&grafanaVer, "grafana-tag", defaultGrafanaTag, "Tag for the Grafana image")
+	cmd.Flags().StringVar(&grafanaImage, "grafana-image", defaultGrafanaImage, "Grafana container image name")
+	cmd.Flags().StringVar(&promVer, "prometheus-tag", defaultPromTag, "Tag for the Prometheus image")
+	cmd.Flags().StringVar(&promImage, "prometheus-image", defaultPromImage, "Prometheus container image name")
+	cmd.Flags().StringVar(&promtailVer, "promtail-tag", defaultPromtailTag, "Tag for the Promtail image")
+	cmd.Flags().StringVar(&promtailImage, "promtail-image", defaultPromtailImage, "Promtail container image name")
 	cmd.Flags().StringVar(&promConfigPath, "prom-config-path", "", "Path to a custom prometheus.yml; skips the generated config when set")
 	cmd.Flags().StringVar(&obsJobName, "job-name", "", "Register a custom Prometheus scrape job with this name (no local TFE required)")
 	cmd.Flags().StringVar(&obsMetricsPath, "metrics-path", "/metrics", "Metrics path for the custom job (only used when --job-name is set)")

--- a/cmd/observability/defaults.go
+++ b/cmd/observability/defaults.go
@@ -1,0 +1,30 @@
+package observability
+
+// defaults.go is the single source of truth for values shared across the
+// observability (PLG stack) command package. Container names, public UI URLs and
+// image/tag flag defaults are declared once here so create, status and delete can
+// never drift apart. Cross-product values (the Docker network name) live in
+// internal/global and are referenced, never redeclared.
+
+const (
+	// --- Container names (shared by create, status, delete) ---
+	obsPrometheusContainer = "hal-prometheus"
+	obsLokiContainer       = "hal-loki"
+	obsPromtailContainer   = "hal-promtail"
+	obsGrafanaContainer    = "hal-grafana"
+
+	// --- Public UI URLs (shared by create + status output) ---
+	obsGrafanaURL    = "http://grafana.localhost:3000"
+	obsPrometheusURL = "http://prometheus.localhost:9090"
+	obsLokiReadyURL  = "http://loki.localhost:3100/ready"
+
+	// --- Image / tag flag defaults ---
+	defaultLokiImage     = "grafana/loki"
+	defaultLokiTag       = "3.7"
+	defaultGrafanaImage  = "grafana/grafana"
+	defaultGrafanaTag    = "main"
+	defaultPromImage     = "prom/prometheus"
+	defaultPromTag       = "main"
+	defaultPromtailImage = "grafana/promtail"
+	defaultPromtailTag   = "3.6"
+)

--- a/cmd/observability/delete.go
+++ b/cmd/observability/delete.go
@@ -11,10 +11,10 @@ import (
 )
 
 var obsEcosystem = []string{
-	"hal-grafana",
-	"hal-promtail",
-	"hal-loki",
-	"hal-prometheus",
+	obsGrafanaContainer,
+	obsPromtailContainer,
+	obsLokiContainer,
+	obsPrometheusContainer,
 }
 
 var destroyCmd = &cobra.Command{

--- a/cmd/observability/status.go
+++ b/cmd/observability/status.go
@@ -28,10 +28,10 @@ var statusCmd = &cobra.Command{
 			Name      string
 			Container string
 		}{
-			{"Prometheus", "hal-prometheus"},
-			{"Loki", "hal-loki"},
-			{"Promtail", "hal-promtail"},
-			{"Grafana", "hal-grafana"},
+			{"Prometheus", obsPrometheusContainer},
+			{"Loki", obsLokiContainer},
+			{"Promtail", obsPromtailContainer},
+			{"Grafana", obsGrafanaContainer},
 		}
 
 		allRunning := true
@@ -60,9 +60,9 @@ var statusCmd = &cobra.Command{
 			fmt.Println("   hal obs create")
 		} else if allRunning {
 			fmt.Println("   All systems green. Stack is capturing telemetry.")
-			fmt.Println("   🔗 Grafana UI: http://grafana.localhost:3000")
-			fmt.Println("   🔗 Prometheus: http://prometheus.localhost:9090")
-			fmt.Println("   🔗 Loki API:   http://loki.localhost:3100/ready")
+			fmt.Printf("   🔗 Grafana UI: %s\n", obsGrafanaURL)
+			fmt.Printf("   🔗 Prometheus: %s\n", obsPrometheusURL)
+			fmt.Printf("   🔗 Loki API:   %s\n", obsLokiReadyURL)
 		} else {
 			fmt.Println("   Environment is partially degraded. To safely reset, run:")
 			fmt.Println("   hal obs create --update")

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -60,10 +60,10 @@ var createCmd = &cobra.Command{
 				fmt.Printf("[DRY RUN] Would set OLLAMA_CONTEXT_WINDOW=%d\n", runtimeConfig.ContextWindow)
 			}
 			fmt.Printf("[DRY RUN] Would set OLLAMA_KEEP_ALIVE=%s\n", runtimeConfig.KeepAlive)
-			fmt.Println("[DRY RUN] Would set HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp")
+			fmt.Printf("[DRY RUN] Would set HAL_MCP_HTTP_URL=%s\n", plusMCPEnvURL)
 			if qdrantEnabled {
 				fmt.Println("[DRY RUN] Would set HAL_RAG_BACKEND=qdrant")
-				fmt.Println("[DRY RUN] Would set HAL_QDRANT_URL=http://hal-qdrant:6333")
+				fmt.Printf("[DRY RUN] Would set HAL_QDRANT_URL=%s\n", plusQdrantEnvURL)
 				fmt.Printf("[DRY RUN] Would set HAL_DOC_SEARCH_EMBED_MODEL=%s\n", embedModel)
 			}
 			return
@@ -119,7 +119,7 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		if err := ensureRunningContainer(engine, halMCPContainerName, []string{"--network", "hal-net", mcpImage}); err != nil {
+		if err := ensureRunningContainer(engine, halMCPContainerName, []string{"--network", global.HalNetName, mcpImage}); err != nil {
 			fmt.Printf("❌ %v\n", err)
 			return
 		}
@@ -137,22 +137,22 @@ var createCmd = &cobra.Command{
 					return
 				}
 			}
-			if err := ensureRunningContainer(engine, halQdrantContainerName, []string{"--network", "hal-net", qdrantImage}); err != nil {
+			if err := ensureRunningContainer(engine, halQdrantContainerName, []string{"--network", global.HalNetName, qdrantImage}); err != nil {
 				fmt.Printf("❌ %v\n", err)
 				return
 			}
 		}
 
 		plusArgs := []string{
-			"--network", "hal-net",
-			"-p", fmt.Sprintf("%d:9000", plusPort),
+			"--network", global.HalNetName,
+			"-p", fmt.Sprintf("%d:%d", plusPort, plusAPIPort),
 			"-e", "API_HOST=0.0.0.0",
-			"-e", "API_PORT=9000",
+			"-e", fmt.Sprintf("API_PORT=%d", plusAPIPort),
 			"-e", fmt.Sprintf("OLLAMA_BASE_URL=%s", containerOllamaURL),
 			"-e", fmt.Sprintf("OLLAMA_MODEL=%s", runtimeConfig.RuntimeModel),
 			"-e", fmt.Sprintf("OLLAMA_MODEL_LABEL=%s", runtimeConfig.RequestedModel),
 			"-e", fmt.Sprintf("OLLAMA_KEEP_ALIVE=%s", runtimeConfig.KeepAlive),
-			"-e", "HAL_MCP_HTTP_URL=http://hal-mcp:8080/mcp",
+			"-e", fmt.Sprintf("HAL_MCP_HTTP_URL=%s", plusMCPEnvURL),
 			"-e", "HAL_PLUS_CONTAINER_MODE=true",
 			plusImage,
 		}
@@ -162,7 +162,7 @@ var createCmd = &cobra.Command{
 		if qdrantEnabled {
 			qdrantEnv := []string{
 				"-e", "HAL_RAG_BACKEND=qdrant",
-				"-e", "HAL_QDRANT_URL=http://hal-qdrant:6333",
+				"-e", fmt.Sprintf("HAL_QDRANT_URL=%s", plusQdrantEnvURL),
 				"-e", fmt.Sprintf("HAL_DOC_SEARCH_EMBED_MODEL=%s", embedModel),
 			}
 			plusArgs = append(plusArgs[:len(plusArgs)-1], append(qdrantEnv, plusArgs[len(plusArgs)-1])...)
@@ -188,7 +188,7 @@ var createCmd = &cobra.Command{
 			fmt.Printf("🧩 Model preset: %s\n", runtimeConfig.RequestedModel)
 		}
 		fmt.Printf("🧠 Ollama host:  %s\n", ollamaHostURL)
-		fmt.Printf("🌐 UI URL:       http://hal.localhost:%d\n", plusPort)
+		fmt.Printf("🌐 UI URL:       http://%s:%d\n", plusUIHostname, plusPort)
 		fmt.Println("💡 Run 'hal plus status' to verify container and endpoint health.")
 	},
 }

--- a/cmd/plus/defaults.go
+++ b/cmd/plus/defaults.go
@@ -1,0 +1,16 @@
+package plus
+
+// defaults.go complements the single source of truth for the HAL Plus package.
+// Container names and image name/tag defaults are declared once in plus.go (every
+// flag default references the same variable, so they cannot drift). This file
+// holds the network endpoints and host values shared across more than one file.
+
+const (
+	// --- Public UI host (shared by create + status output) ---
+	plusUIHostname = "hal.localhost"
+
+	// --- Container-internal endpoints / ports ---
+	plusAPIPort      = 9000
+	plusMCPEnvURL    = "http://hal-mcp:8080/mcp"
+	plusQdrantEnvURL = "http://hal-qdrant:6333"
+)

--- a/cmd/plus/status.go
+++ b/cmd/plus/status.go
@@ -42,7 +42,7 @@ var statusCmd = &cobra.Command{
 		fmt.Printf("HAL Plus health:     %s\n", boolLabel(uiReady))
 		fmt.Printf("HAL MCP health:      %s\n", boolLabel(mcpReady))
 		fmt.Printf("HAL Qdrant health:   %s\n", boolLabel(qdrantReady))
-		fmt.Printf("UI endpoint:         http://hal.localhost:%d\n", plusPort)
+		fmt.Printf("UI endpoint:         http://%s:%d\n", plusUIHostname, plusPort)
 
 		if plusState != "running" || mcpState != "running" {
 			fmt.Println("💡 Tip: Run 'hal plus create' to start or reconcile HAL Plus and HAL MCP containers.")

--- a/cmd/terraform/agent.go
+++ b/cmd/terraform/agent.go
@@ -23,7 +23,6 @@ const (
 	defaultTFETwinAgentPool    = "hal-agent-pool-bis"
 	defaultTFEAgentDisplayName = "hal-tfc-agent"
 	defaultTFETwinAgentName    = "hal-tfc-agent-bis"
-	tfeProxyInternalIP         = "10.89.3.54"
 )
 
 type tfeAgentState struct {
@@ -266,17 +265,22 @@ func enableTFEAgent(engine, target string) error {
 
 	addHostArg := ""
 	if parsed, parseErr := url.Parse(baseURL); parseErr == nil {
-		if strings.EqualFold(parsed.Hostname(), "tfe.localhost") {
-			addHostArg = "tfe.localhost:" + tfeProxyInternalIP
-		} else if strings.EqualFold(parsed.Hostname(), "tfe-bis.localhost") {
-			addHostArg = "tfe-bis.localhost:" + tfeTwinProxyInternalIP
+		if strings.EqualFold(parsed.Hostname(), tfePrimaryHostname) {
+			// Derive the proxy IP from the live hal-net subnet so it works on any host/engine.
+			addHostArg = tfePrimaryHostname + ":" + global.HalNetStaticIP(engine, tfePrimaryProxyHostNum)
+		} else if strings.EqualFold(parsed.Hostname(), defaultTFETwinHostname) {
+			twinIP := tfeTwinProxyInternalIP
+			if twinIP == "" {
+				twinIP = global.HalNetStaticIP(engine, tfeTwinProxyHostNum)
+			}
+			addHostArg = defaultTFETwinHostname + ":" + twinIP
 		}
 	}
 
 	runArgs := []string{
 		"run", "-d",
 		"--name", containerName,
-		"--network", "hal-net",
+		"--network", global.HalNetName,
 	}
 	if addHostArg != "" {
 		runArgs = append(runArgs, "--add-host", addHostArg)
@@ -529,19 +533,19 @@ func configureTFEAgentTargetDefaults(cmd *cobra.Command, target string) error {
 	}
 
 	if !cmd.Flags().Changed("tfe-url") {
-		tfeAgentBaseURL = "https://tfe.localhost:8443"
+		tfeAgentBaseURL = tfePrimaryBaseURL
 	}
 	if !cmd.Flags().Changed("tfe-org") {
-		tfeAgentOrg = "hal"
+		tfeAgentOrg = defaultTFEOrg
 	}
 	if !cmd.Flags().Changed("tfe-admin-username") {
-		tfeAgentAdminUsername = "haladmin"
+		tfeAgentAdminUsername = defaultTFEAdminUsername
 	}
 	if !cmd.Flags().Changed("tfe-admin-email") {
-		tfeAgentAdminEmail = "haladmin@localhost"
+		tfeAgentAdminEmail = defaultTFEAdminEmail
 	}
 	if !cmd.Flags().Changed("tfe-admin-password") {
-		tfeAgentAdminPassword = "hal9000FTW"
+		tfeAgentAdminPassword = defaultTFEAdminPassword
 	}
 	if !cmd.Flags().Changed("pool-name") {
 		tfeAgentPoolName = defaultTFEAgentPoolName
@@ -625,12 +629,12 @@ func init() {
 	agentCmd.Flags().StringVar(&tfeAgentImage, "image", defaultTFEAgentImage, "Docker image used for the custom TFE agent")
 	agentCmd.Flags().StringVar(&tfeAgentPoolName, "pool-name", defaultTFEAgentPoolName, "TFE agent pool name to create or reuse")
 	agentCmd.Flags().StringVar(&tfeAgentName, "agent-name", defaultTFEAgentDisplayName, "Display name advertised by the running agent")
-	agentCmd.Flags().StringVar(&tfeAgentOrg, "tfe-org", "hal", "Terraform Enterprise organization name")
-	agentCmd.Flags().StringVar(&tfeAgentBaseURL, "tfe-url", "https://tfe.localhost:8443", "Terraform Enterprise base URL")
+	agentCmd.Flags().StringVar(&tfeAgentOrg, "tfe-org", defaultTFEOrg, "Terraform Enterprise organization name")
+	agentCmd.Flags().StringVar(&tfeAgentBaseURL, "tfe-url", tfePrimaryBaseURL, "Terraform Enterprise base URL")
 	agentCmd.Flags().StringVar(&tfeAgentAPIToken, "tfe-api-token", "", "Terraform Enterprise app API token (or set TFE_API_TOKEN)")
-	agentCmd.Flags().StringVar(&tfeAgentAdminUsername, "tfe-admin-username", "haladmin", "Initial TFE admin username used when bootstrapping via IACT")
-	agentCmd.Flags().StringVar(&tfeAgentAdminEmail, "tfe-admin-email", "haladmin@localhost", "Initial TFE admin email used when bootstrapping via IACT")
-	agentCmd.Flags().StringVar(&tfeAgentAdminPassword, "tfe-admin-password", "hal9000FTW", "Initial TFE admin password used when bootstrapping via IACT")
+	agentCmd.Flags().StringVar(&tfeAgentAdminUsername, "tfe-admin-username", defaultTFEAdminUsername, "Initial TFE admin username used when bootstrapping via IACT")
+	agentCmd.Flags().StringVar(&tfeAgentAdminEmail, "tfe-admin-email", defaultTFEAdminEmail, "Initial TFE admin email used when bootstrapping via IACT")
+	agentCmd.Flags().StringVar(&tfeAgentAdminPassword, "tfe-admin-password", defaultTFEAdminPassword, "Initial TFE admin password used when bootstrapping via IACT")
 	bindTFETargetFlag(agentCmd)
 	bindTwinFlags(agentCmd)
 

--- a/cmd/terraform/api-workflow.go
+++ b/cmd/terraform/api-workflow.go
@@ -454,7 +454,7 @@ func ensureTFECLIContainer(engine, certPath, localDir string) error {
 	runArgs := []string{
 		"run", "-d",
 		"--name", tfeAPIContainerName,
-		"--network", "hal-net",
+		"--network", global.HalNetName,
 		"--entrypoint", "sh",
 		"-v", fmt.Sprintf("%s:/hal/certs/tfe-localhost.crt:ro", certPath),
 	}
@@ -675,7 +675,7 @@ func disableTFECLI(engine string, nonInteractiveConfirm bool) error {
 		managedWorkspaces, _ := readTFECLIManagedList(engine, tfeCLIManagedWSFile)
 
 		if len(managedWorkspaces) > 0 {
-			if !global.IsContainerRunning(engine, "hal-tfe") {
+			if !global.IsContainerRunning(engine, tfeCoreContainer) {
 				fmt.Println("⚠️  Skipping TFE workspace cleanup because hal-tfe is not running.")
 			} else if authErr != nil {
 				fmt.Printf("⚠️  Skipping TFE workspace cleanup because helper auth could not be read: %v\n", authErr)
@@ -790,8 +790,8 @@ func deleteTFECLIManagedWorkspace(auth tfeCLIAuthConfig, workspaceName string) e
 	if baseURL == "" {
 		baseURL = "https://" + normalizeTFXHostname(auth.Hostname)
 	}
-	if strings.Contains(baseURL, "hal-tfe:") {
-		baseURL = "https://tfe.localhost:8443"
+	if strings.Contains(baseURL, tfeCoreContainer+":") {
+		baseURL = tfePrimaryBaseURL
 	}
 
 	deleteURL := fmt.Sprintf("%s/api/v2/organizations/%s/workspaces/%s", baseURL, auth.Organization, workspaceName)
@@ -1058,7 +1058,7 @@ func ensureDefaultScenarioWorkspaces(token string) error {
 		_ = removeLegacyTFEProject(baseURL, org, token, "HAL-CLI")
 	}
 
-	daveProjectID, err := ensureTFEOrgAndProject(baseURL, token, org, "Dave")
+	daveProjectID, err := ensureTFEOrgAndProject(baseURL, token, org, defaultTFEProject)
 	if err != nil {
 		return fmt.Errorf("failed to ensure TFE project Dave: %w", err)
 	}
@@ -1286,7 +1286,7 @@ func tfeCoreContainerForTarget(target string) (string, error) {
 		}
 		return layout.CoreContainer, nil
 	}
-	return "hal-tfe", nil
+	return tfeCoreContainer, nil
 }
 
 func configureTFEAPITargetDefaults(cmd *cobra.Command, target string) error {
@@ -1317,19 +1317,19 @@ func configureTFEAPITargetDefaults(cmd *cobra.Command, target string) error {
 	}
 
 	if !cmd.Flags().Changed("tfe-url") {
-		tfeCLIURL = "https://tfe.localhost:8443"
+		tfeCLIURL = tfePrimaryBaseURL
 	}
 	if !cmd.Flags().Changed("tfe-org") {
-		tfeCLIDefaultOrg = "hal"
+		tfeCLIDefaultOrg = defaultTFEOrg
 	}
 	if !cmd.Flags().Changed("tfe-admin-username") {
-		tfeCLIAdminUsername = "haladmin"
+		tfeCLIAdminUsername = defaultTFEAdminUsername
 	}
 	if !cmd.Flags().Changed("tfe-admin-email") {
-		tfeCLIAdminEmail = "haladmin@localhost"
+		tfeCLIAdminEmail = defaultTFEAdminEmail
 	}
 	if !cmd.Flags().Changed("tfe-admin-password") {
-		tfeCLIAdminPassword = "hal9000FTW"
+		tfeCLIAdminPassword = defaultTFEAdminPassword
 	}
 	return nil
 }
@@ -1398,11 +1398,11 @@ func init() {
 	apiCmd.Flags().BoolVar(&tfeCLIShowBannerOnly, "banner", false, "Print API helper welcome banner without opening a shell")
 	apiCmd.Flags().StringVar(&tfeCLILocalDirectory, "local-directory", "", "Optional host directory to mount into the helper at /workspaces")
 	apiCmd.Flags().StringVar(&tfeCLIBaseImage, "base-image", defaultTFECLIBase, "Base image used to build the helper image")
-	apiCmd.Flags().StringVar(&tfeCLIURL, "tfe-url", "https://tfe.localhost:8443", "Terraform Enterprise URL used for helper auth bootstrap")
+	apiCmd.Flags().StringVar(&tfeCLIURL, "tfe-url", tfePrimaryBaseURL, "Terraform Enterprise URL used for helper auth bootstrap")
 	apiCmd.Flags().StringVar(&tfeCLIDefaultOrg, "tfe-org", "hal", "Default Terraform Enterprise organization written to ~/.tfx.hcl")
-	apiCmd.Flags().StringVar(&tfeCLIAdminUsername, "tfe-admin-username", "haladmin", "Terraform Enterprise admin username used for helper token bootstrap")
-	apiCmd.Flags().StringVar(&tfeCLIAdminEmail, "tfe-admin-email", "haladmin@localhost", "Terraform Enterprise admin email used for helper token bootstrap")
-	apiCmd.Flags().StringVar(&tfeCLIAdminPassword, "tfe-admin-password", "hal9000FTW", "Terraform Enterprise admin password used for helper token bootstrap")
+	apiCmd.Flags().StringVar(&tfeCLIAdminUsername, "tfe-admin-username", defaultTFEAdminUsername, "Terraform Enterprise admin username used for helper token bootstrap")
+	apiCmd.Flags().StringVar(&tfeCLIAdminEmail, "tfe-admin-email", defaultTFEAdminEmail, "Terraform Enterprise admin email used for helper token bootstrap")
+	apiCmd.Flags().StringVar(&tfeCLIAdminPassword, "tfe-admin-password", defaultTFEAdminPassword, "Terraform Enterprise admin password used for helper token bootstrap")
 	apiCmd.Flags().StringVar(&tfeCLIProjectSeed, "tfe-project", "", "Optional Terraform Enterprise project to ensure during helper token bootstrap")
 	apiCmd.Flags().BoolVar(&tfeCLIAutoApprove, "auto-approve", false, "Skip interactive confirmation for destructive disable operations")
 	apiCmd.Flags().BoolVar(&tfeCLIVerbose, "verbose", false, "Show raw Docker build logs instead of HAL build animation")

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -86,7 +86,7 @@ var deployCmd = &cobra.Command{
 		os.Setenv("TFE_LICENSE", license)
 
 		os.Setenv("TFE_ENCRYPTION_PASSWORD", tfePassword)
-		os.Setenv("TFE_DATABASE_PASSWORD", "tfe_password")
+		os.Setenv("TFE_DATABASE_PASSWORD", tfeDBPassword)
 
 		global.WarnIfEngineResourcesTight(engine, "terraform-deploy")
 		if !global.DryRun {
@@ -103,19 +103,19 @@ var deployCmd = &cobra.Command{
 		isPodman := strings.Contains(engine, "podman")
 
 		// Keep an unprivileged HTTPS listener for rootless Podman.
-		tfeHostname := "tfe.localhost"
-		healthURL := "https://tfe.localhost:8443/api/v1/health/readiness"
-		uiURL := "https://tfe.localhost:8443"
+		tfeHostname := tfePrimaryHostname
+		healthURL := tfePrimaryBaseURL + "/api/v1/health/readiness"
+		uiURL := tfePrimaryBaseURL
 
 		// 2. FORGE THE TLS CERTIFICATES
 		fmt.Println("🔐 Forging local TLS certificates for TFE...")
 		homeDir, _ := os.UserHomeDir()
-		certDir := filepath.Join(homeDir, ".hal", "tfe-certs")
+		certDir := filepath.Join(homeDir, halStateDirName, tfeCertsDirName)
 
 		if tfeUpdate {
 			fmt.Println("♻️  Update requested. Reconciling existing TFE resources...")
 			// 🎯 Included the proxy in the teardown list
-			_ = exec.Command(engine, "rm", "-f", "hal-tfe", "hal-tfe-proxy", "hal-tfe-db", "hal-tfe-redis", "hal-tfe-minio").Run()
+			_ = exec.Command(engine, "rm", "-f", tfeCoreContainer, tfeProxyContainer, tfeDBContainer, tfeRedisContainer, tfeMinioContainer).Run()
 			_ = os.Remove(filepath.Join(certDir, "cert.pem"))
 			_ = os.Remove(filepath.Join(certDir, "key.pem"))
 		}
@@ -140,41 +140,41 @@ var deployCmd = &cobra.Command{
 		// 4. Ensure the global HAL network exists
 		global.EnsureNetwork(engine)
 		// Derive the proxy IP from the actual hal-net subnet so it works on any engine.
-		proxyInternalIP := global.HalNetStaticIP(engine, 250)
+		proxyInternalIP := global.HalNetStaticIP(engine, tfePrimaryProxyHostNum)
 
 		// 5. Deploy PostgreSQL
 		fmt.Printf("⚙️  Provisioning TFE PostgreSQL Database...\n")
-		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-db", "--network", "hal-net",
-			"-v", "hal-tfe-db-data:/var/lib/postgresql/data",
-			"-e", "POSTGRES_USER=tfe", "-e", "POSTGRES_PASSWORD=tfe_password", "-e", "POSTGRES_DB=tfe",
+		_ = exec.Command(engine, "run", "-d", "--name", tfeDBContainer, "--network", global.HalNetName,
+			"-v", tfeDBVolume+":/var/lib/postgresql/data",
+			"-e", "POSTGRES_USER="+tfeDBUser, "-e", "POSTGRES_PASSWORD="+tfeDBPassword, "-e", "POSTGRES_DB="+tfeDBName,
 			fmt.Sprintf("%s:%s", pgImage, pgVersion)).Run()
 
 		// 6. Deploy Redis
 		fmt.Printf("⚙️  Provisioning TFE Redis Cache...\n")
-		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-redis", "--network", "hal-net",
-			"-v", "hal-tfe-redis-data:/data",
+		_ = exec.Command(engine, "run", "-d", "--name", tfeRedisContainer, "--network", global.HalNetName,
+			"-v", tfeRedisVolume+":/data",
 			fmt.Sprintf("%s:%s", redisImage, redisVersion)).Run()
 
 		// 7. Deploy MinIO (S3 Mock)
 		fmt.Println("⚙️  Provisioning TFE Object Storage (MinIO)...")
-		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-minio", "--network", "hal-net",
+		_ = exec.Command(engine, "run", "-d", "--name", tfeMinioContainer, "--network", global.HalNetName,
 			"-p", fmt.Sprintf("%d:9000", minioAPIPort), "-p", fmt.Sprintf("%d:9001", minioConsolePort),
-			"-v", "hal-tfe-minio-data:/data",
-			"-e", "MINIO_ROOT_USER=minioadmin", "-e", "MINIO_ROOT_PASSWORD=minioadmin",
+			"-v", tfeMinioVolume+":/data",
+			"-e", "MINIO_ROOT_USER="+tfeMinioRootUser, "-e", "MINIO_ROOT_PASSWORD="+tfeMinioRootPass,
 			fmt.Sprintf("%s:%s", minioImage, minioVersion), "server", "/data", "--console-address", ":9001").Run()
 
 		time.Sleep(3 * time.Second)
-		_ = exec.Command(engine, "exec", "hal-tfe-minio", "sh", "-c", "mkdir -p /data/tfe-data").Run()
+		_ = exec.Command(engine, "exec", tfeMinioContainer, "sh", "-c", "mkdir -p /data/"+tfeS3Bucket).Run()
 
 		// 8. Deploy TFE Core (NO EXPOSED HOST PORTS!)
 		fmt.Println("⚙️  Booting TFE Core Application (This requires heavy compute)...")
 		tfeArgs := []string{
 			"run", "-d",
-			"--name", "hal-tfe",
-			"--network", "hal-net",
+			"--name", tfeCoreContainer,
+			"--network", global.HalNetName,
 			"--privileged",
-			"--add-host", "hal-tfe:127.0.0.1",
-			"--add-host", fmt.Sprintf("tfe.localhost:%s", proxyInternalIP),
+			"--add-host", tfeCoreContainer + ":127.0.0.1",
+			"--add-host", fmt.Sprintf("%s:%s", tfePrimaryHostname, proxyInternalIP),
 			"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		}
 
@@ -188,39 +188,39 @@ var deployCmd = &cobra.Command{
 		tfeArgs = append(tfeArgs,
 			"-e", "TFE_OPERATIONAL_MODE=external",
 			"-e", fmt.Sprintf("TFE_HOSTNAME=%s", tfeHostname),
-			"-e", "TFE_VCS_HOSTNAME=tfe.localhost:8443",
+			"-e", fmt.Sprintf("TFE_VCS_HOSTNAME=%s:%d", tfePrimaryHostname, tfeHTTPSPort),
 			"-e", "VAULT_ADDR=http://127.0.0.1:8200",
 			"-e", "TFE_METRICS_ENABLE=true",
-			"-e", "TFE_METRICS_HTTP_PORT=9090",
-			"-e", "TFE_METRICS_HTTPS_PORT=9091",
-			"-e", "TFE_IA_HOSTNAME=hal-tfe",
+			"-e", fmt.Sprintf("TFE_METRICS_HTTP_PORT=%d", tfeMetricsHTTPPort),
+			"-e", fmt.Sprintf("TFE_METRICS_HTTPS_PORT=%d", tfeMetricsHTTPSPort),
+			"-e", fmt.Sprintf("TFE_IA_HOSTNAME=%s", tfeCoreContainer),
 			"-e", "TFE_VAULT_DISABLE_MLOCK=true",
 			"-e", "TFE_VAULT_ADDR=http://127.0.0.1:8200", // 🎯 Sorry Copilot!
 			"-e", "TFE_IA_INTERNAL_VAULT_ADDR=http://127.0.0.1:8200", // 🎯 Sorry Copilot!
-			"-e", "TFE_RUN_PIPELINE_DOCKER_NETWORK=hal-net",
-			"-e", "TFE_HTTP_PORT=8080",
-			"-e", "TFE_HTTPS_PORT=8443",
-			"-e", "TFE_ADMIN_HTTPS_PORT=8444",
+			"-e", "TFE_RUN_PIPELINE_DOCKER_NETWORK="+global.HalNetName,
+			"-e", fmt.Sprintf("TFE_HTTP_PORT=%d", tfeHTTPPort),
+			"-e", fmt.Sprintf("TFE_HTTPS_PORT=%d", tfeHTTPSPort),
+			"-e", fmt.Sprintf("TFE_ADMIN_HTTPS_PORT=%d", tfeAdminHTTPSPort),
 			"-e", "TFE_TLS_CERT_FILE=/etc/ssl/tfe/cert.pem",
 			"-e", "TFE_TLS_KEY_FILE=/etc/ssl/tfe/key.pem",
-			"-e", "TFE_DISK_CACHE_VOLUME_NAME=hal-tfe-cache",
+			"-e", "TFE_DISK_CACHE_VOLUME_NAME="+tfeCacheVolume,
 			"-e", "TFE_LICENSE",
 			"-e", "TFE_ENCRYPTION_PASSWORD",
-			"-e", "TFE_DATABASE_USER=tfe",
+			"-e", "TFE_DATABASE_USER="+tfeDBUser,
 			"-e", "TFE_DATABASE_PASSWORD",
-			"-e", "TFE_DATABASE_HOST=hal-tfe-db",
-			"-e", "TFE_DATABASE_NAME=tfe",
+			"-e", "TFE_DATABASE_HOST="+tfeDBContainer,
+			"-e", "TFE_DATABASE_NAME="+tfeDBName,
 			"-e", "TFE_DATABASE_PARAMETERS=sslmode=disable",
-			"-e", "TFE_REDIS_HOST=hal-tfe-redis",
+			"-e", "TFE_REDIS_HOST="+tfeRedisContainer,
 			"-e", "TFE_REDIS_USE_TLS=false",
 			"-e", "TFE_REDIS_USE_AUTH=false",
 			"-e", "TFE_OBJECT_STORAGE_TYPE=s3",
 			"-e", "TFE_OBJECT_STORAGE_S3_USE_INSTANCE_PROFILE=false",
-			"-e", "TFE_OBJECT_STORAGE_S3_ENDPOINT=http://hal-tfe-minio:9000",
-			"-e", "TFE_OBJECT_STORAGE_S3_BUCKET=tfe-data",
-			"-e", "TFE_OBJECT_STORAGE_S3_REGION=us-east-1",
-			"-e", "TFE_OBJECT_STORAGE_S3_ACCESS_KEY_ID=minioadmin",
-			"-e", "TFE_OBJECT_STORAGE_S3_SECRET_ACCESS_KEY=minioadmin",
+			"-e", fmt.Sprintf("TFE_OBJECT_STORAGE_S3_ENDPOINT=http://%s:9000", tfeMinioContainer),
+			"-e", "TFE_OBJECT_STORAGE_S3_BUCKET="+tfeS3Bucket,
+			"-e", "TFE_OBJECT_STORAGE_S3_REGION="+tfeS3Region,
+			"-e", "TFE_OBJECT_STORAGE_S3_ACCESS_KEY_ID="+tfeMinioRootUser,
+			"-e", "TFE_OBJECT_STORAGE_S3_SECRET_ACCESS_KEY="+tfeMinioRootPass,
 			"-e", "TFE_OBJECT_STORAGE_S3_FORCE_PATH_STYLE=true",
 			"-e", "TFE_CAPACITY_CONCURRENCY=5",
 			fmt.Sprintf("%s:%s", tfeImage, tfeVersion),
@@ -240,7 +240,7 @@ var deployCmd = &cobra.Command{
 			"exec",
 			"--user",
 			"0",
-			"hal-tfe",
+			tfeCoreContainer,
 			"sh",
 			"-lc",
 			"cp /etc/ssl/tfe/cert.pem /usr/local/share/ca-certificates/tfe-localhost.crt && update-ca-certificates 2>&1",
@@ -256,7 +256,7 @@ var deployCmd = &cobra.Command{
 			"exec",
 			"--user",
 			"0",
-			"hal-tfe",
+			tfeCoreContainer,
 			"sh",
 			"-lc",
 			"test -f /run/terraform-enterprise/task-worker/config.hcl && sed -i 's/readonly = \"true\"/readonly = \"false\"/' /run/terraform-enterprise/task-worker/config.hcl 2>&1 || true",
@@ -325,13 +325,13 @@ http {
 		}
 	}
 }`
-		proxyConfPath := filepath.Join(homeDir, ".hal", "tfe-proxy.conf")
+		proxyConfPath := filepath.Join(homeDir, halStateDirName, tfeProxyConfName)
 		_ = os.WriteFile(proxyConfPath, []byte(nginxConfig), 0644)
 
-		_ = exec.Command(engine, "run", "-d", "--name", "hal-tfe-proxy", "--network", "hal-net", "--ip", proxyInternalIP,
-			"--network-alias", "tfe.localhost",
-			"-p", "8443:8443", // 🎯 Only the proxy exposes port 8443 to the host OS
-			"-p", "8444:8444", // 🎯 Expose the TFE admin HTTPS port through the proxy
+		_ = exec.Command(engine, "run", "-d", "--name", tfeProxyContainer, "--network", global.HalNetName, "--ip", proxyInternalIP,
+			"--network-alias", tfePrimaryHostname,
+			"-p", fmt.Sprintf("%d:%d", tfeHTTPSPort, tfeHTTPSPort), // 🎯 Only the proxy exposes port 8443 to the host OS
+			"-p", fmt.Sprintf("%d:%d", tfeAdminHTTPSPort, tfeAdminHTTPSPort), // 🎯 Expose the TFE admin HTTPS port through the proxy
 			"-v", fmt.Sprintf("%s:/etc/ssl/tfe:ro", certDir),
 			"-v", fmt.Sprintf("%s:/etc/nginx/nginx.conf:ro", proxyConfPath),
 			fmt.Sprintf("%s:%s", tfeProxyImage, tfeProxyNginxTag)).Run()
@@ -341,7 +341,7 @@ http {
 
 		// This will naturally hit the Proxy, which routes to TFE
 		if err := waitForService("TFE", healthURL, 60); err != nil {
-			handleDockerFailure("hal-tfe", engine)
+			handleDockerFailure(tfeCoreContainer, engine)
 			return
 		}
 
@@ -367,7 +367,7 @@ http {
 		} else {
 			fmt.Println("✅ TFE foundation ready: admin token + org/project are configured.")
 			if token != "" {
-				fmt.Println("   📄 Token cache: ~/.hal/tfe-app-api-token")
+				fmt.Printf("   📄 Token cache: ~/%s/%s\n", halStateDirName, tfeAPITokenFileName)
 			}
 		}
 		fmt.Println("⚠️  Note:        Accept the browser warning for the self-signed certificate.")
@@ -414,7 +414,7 @@ func ensureCerts(certDir string) error {
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			Organization: []string{"HAL Primary TFE Local Dev Environment"},
-			CommonName:   "tfe.localhost",
+			CommonName:   tfePrimaryHostname,
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
@@ -422,7 +422,7 @@ func ensureCerts(certDir string) error {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		DNSNames:              []string{"localhost", "hal-tfe", "tfe.localhost"},
+		DNSNames:              []string{"localhost", tfeCoreContainer, tfePrimaryHostname},
 		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
 	}
 
@@ -460,7 +460,7 @@ func shouldRotatePrimaryTFECert(certPath string) bool {
 
 	hasPrimaryDNS := false
 	for _, name := range cert.DNSNames {
-		if name == "tfe.localhost" {
+		if name == tfePrimaryHostname {
 			hasPrimaryDNS = true
 			break
 		}
@@ -516,24 +516,24 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&tfeVersion, "tfe-tag", "v", "2.0.2", "TFE container image tag")
-	cmd.Flags().StringVar(&tfeImage, "tfe-image", "images.releases.hashicorp.com/hashicorp/terraform-enterprise", "TFE container image name")
-	cmd.Flags().StringVar(&pgVersion, "tfe-pg-tag", "16-alpine", "PostgreSQL image tag for TFE backend")
-	cmd.Flags().StringVar(&pgImage, "tfe-pg-image", "postgres", "PostgreSQL image name for TFE backend")
-	cmd.Flags().StringVar(&redisVersion, "tfe-redis-tag", "7-alpine", "Redis image tag for TFE background jobs")
-	cmd.Flags().StringVar(&redisImage, "tfe-redis-image", "redis", "Redis image name for TFE background jobs")
-	cmd.Flags().StringVar(&minioVersion, "tfe-minio-tag", "latest", "MinIO image tag for TFE object storage")
-	cmd.Flags().StringVar(&minioImage, "tfe-minio-image", "minio/minio", "MinIO image name for TFE object storage")
-	cmd.Flags().IntVar(&minioAPIPort, "minio-api-port", 19000, "Host port mapped to MinIO S3 API container port 9000")
-	cmd.Flags().IntVar(&minioConsolePort, "minio-console-port", 19001, "Host port mapped to MinIO console container port 9001")
-	cmd.Flags().StringVar(&tfeProxyNginxTag, "tfe-proxy-tag", "alpine", "Nginx image tag for the TFE ingress proxy")
-	cmd.Flags().StringVar(&tfeProxyImage, "tfe-proxy-image", "nginx", "Nginx image name for the TFE ingress proxy")
-	cmd.Flags().StringVarP(&tfePassword, "password", "p", "hal-secret-encryption-password", "TFE Encryption Password")
-	cmd.Flags().StringVar(&deployTFEOrg, "tfe-org", "hal-org", "Terraform Enterprise organization name to auto-bootstrap during deploy")
-	cmd.Flags().StringVar(&deployTFEProject, "tfe-project", "Dave", "Terraform Enterprise project name to auto-bootstrap during deploy")
-	cmd.Flags().StringVar(&deployTFEAdminUser, "tfe-admin-username", "haladmin", "Initial TFE admin username used when bootstrapping via IACT")
-	cmd.Flags().StringVar(&deployTFEAdminEmail, "tfe-admin-email", "haladmin@localhost", "Initial TFE admin email used when bootstrapping via IACT")
-	cmd.Flags().StringVar(&deployTFEAdminPass, "tfe-admin-password", "hal9000FTW", "Initial TFE admin password used when bootstrapping via IACT")
+	cmd.Flags().StringVarP(&tfeVersion, "tfe-tag", "v", defaultTFETag, "TFE container image tag")
+	cmd.Flags().StringVar(&tfeImage, "tfe-image", defaultTFEImage, "TFE container image name")
+	cmd.Flags().StringVar(&pgVersion, "tfe-pg-tag", defaultTFEPGTag, "PostgreSQL image tag for TFE backend")
+	cmd.Flags().StringVar(&pgImage, "tfe-pg-image", defaultTFEPGImage, "PostgreSQL image name for TFE backend")
+	cmd.Flags().StringVar(&redisVersion, "tfe-redis-tag", defaultTFERedisTag, "Redis image tag for TFE background jobs")
+	cmd.Flags().StringVar(&redisImage, "tfe-redis-image", defaultTFERedisImage, "Redis image name for TFE background jobs")
+	cmd.Flags().StringVar(&minioVersion, "tfe-minio-tag", defaultTFEMinioTag, "MinIO image tag for TFE object storage")
+	cmd.Flags().StringVar(&minioImage, "tfe-minio-image", defaultTFEMinioImage, "MinIO image name for TFE object storage")
+	cmd.Flags().IntVar(&minioAPIPort, "minio-api-port", defaultMinioAPIHostPort, "Host port mapped to MinIO S3 API container port 9000")
+	cmd.Flags().IntVar(&minioConsolePort, "minio-console-port", defaultMinioConsoleHostPort, "Host port mapped to MinIO console container port 9001")
+	cmd.Flags().StringVar(&tfeProxyNginxTag, "tfe-proxy-tag", defaultTFEProxyTag, "Nginx image tag for the TFE ingress proxy")
+	cmd.Flags().StringVar(&tfeProxyImage, "tfe-proxy-image", defaultTFEProxyImage, "Nginx image name for the TFE ingress proxy")
+	cmd.Flags().StringVarP(&tfePassword, "password", "p", defaultTFEEncryptionPassword, "TFE Encryption Password")
+	cmd.Flags().StringVar(&deployTFEOrg, "tfe-org", defaultTFEOrg, "Terraform Enterprise organization name to auto-bootstrap during deploy")
+	cmd.Flags().StringVar(&deployTFEProject, "tfe-project", defaultTFEProject, "Terraform Enterprise project name to auto-bootstrap during deploy")
+	cmd.Flags().StringVar(&deployTFEAdminUser, "tfe-admin-username", defaultTFEAdminUsername, "Initial TFE admin username used when bootstrapping via IACT")
+	cmd.Flags().StringVar(&deployTFEAdminEmail, "tfe-admin-email", defaultTFEAdminEmail, "Initial TFE admin email used when bootstrapping via IACT")
+	cmd.Flags().StringVar(&deployTFEAdminPass, "tfe-admin-password", defaultTFEAdminPassword, "Initial TFE admin password used when bootstrapping via IACT")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&tfeUpdate, "update", "u", false, "Reconcile an existing Terraform Enterprise deployment in place")
 	}

--- a/cmd/terraform/defaults.go
+++ b/cmd/terraform/defaults.go
@@ -1,0 +1,93 @@
+package terraform
+
+// defaults.go is the single source of truth for shared Terraform Enterprise
+// deployment values.
+//
+// Rule: any value used by more than one file in this package — and every
+// identity/credential/URL default exposed through a CLI flag — MUST be defined
+// here and referenced by name. Never re-declare these as inline literals in a
+// command file. This prevents the kind of silent drift that let the bootstrap
+// org default ("hal") diverge from a downstream flag default.
+//
+// Values that are genuinely local to a single feature file (e.g. agent pool
+// names, SAML service keys, CLI seed-file paths) intentionally stay with that
+// feature; they are already defined in exactly one place.
+//
+// The shared Docker network name lives in internal/global (global.HalNetName);
+// reference that directly rather than copying it here.
+
+const (
+	// --- Primary TFE container + shared backend service names ---
+	// Used across create, delete, status, obs, saml, foundation, twin.
+	tfeCoreContainer  = "hal-tfe"
+	tfeProxyContainer = "hal-tfe-proxy"
+	tfeDBContainer    = "hal-tfe-db"
+	tfeRedisContainer = "hal-tfe-redis"
+	tfeMinioContainer = "hal-tfe-minio"
+
+	// --- Named volumes backing the shared services (create, delete) ---
+	tfeDBVolume    = "hal-tfe-db-data"
+	tfeRedisVolume = "hal-tfe-redis-data"
+	tfeMinioVolume = "hal-tfe-minio-data"
+	tfeCacheVolume = "hal-tfe-cache"
+
+	// --- Primary hostname, ports, and base URL (shared widely) ---
+	tfePrimaryHostname     = "tfe.localhost"
+	defaultTFETwinHostname = "tfe-bis.localhost"
+	tfeHTTPPort            = 8080
+	tfeHTTPSPort           = 8443
+	tfeAdminHTTPSPort      = 8444
+	tfeMetricsHTTPPort     = 9090
+	tfeMetricsHTTPSPort    = 9091
+	tfePrimaryBaseURL      = "https://tfe.localhost:8443"
+
+	// --- Ingress proxy static-IP host numbers on hal-net ---
+	// The proxy IP is derived dynamically from the live hal-net subnet via
+	// global.HalNetStaticIP(engine, hostNum) so it works on any host/engine.
+	// These host numbers are shared by create (primary), twin, and agent.
+	tfePrimaryProxyHostNum = 250
+	tfeTwinProxyHostNum    = 249
+
+	// --- Identity / credential defaults ---
+	// Flag defaults and !Changed() fallbacks across create, api-workflow,
+	// agent, vcs-workflow, saml.
+	defaultTFEOrg                = "hal"
+	defaultTFEProject            = "Dave"
+	defaultTFEAdminUsername      = "haladmin"
+	defaultTFEAdminEmail         = "haladmin@localhost"
+	defaultTFEAdminPassword      = "hal9000FTW"
+	defaultTFEEncryptionPassword = "hal-secret-encryption-password"
+
+	// --- Shared backend service credentials / object storage config ---
+	// Used by create and twin.
+	tfeDBUser        = "tfe"
+	tfeDBPassword    = "tfe_password"
+	tfeDBName        = "tfe"
+	tfeMinioRootUser = "minioadmin"
+	tfeMinioRootPass = "minioadmin"
+	tfeS3Bucket      = "tfe-data"
+	tfeS3Region      = "us-east-1"
+
+	// --- Default backend images + tags (create flag defaults) ---
+	// The TFE core image is also reused by the twin lifecycle.
+	defaultTFEImage      = "images.releases.hashicorp.com/hashicorp/terraform-enterprise"
+	defaultTFETag        = "2.0.2"
+	defaultTFEPGImage    = "postgres"
+	defaultTFEPGTag      = "16-alpine"
+	defaultTFERedisImage = "redis"
+	defaultTFERedisTag   = "7-alpine"
+	defaultTFEMinioImage = "minio/minio"
+	defaultTFEMinioTag   = "latest"
+	defaultTFEProxyImage = "nginx"
+	defaultTFEProxyTag   = "alpine"
+
+	// --- Host port mappings (create flag defaults) ---
+	defaultMinioAPIHostPort     = 19000
+	defaultMinioConsoleHostPort = 19001
+
+	// --- ~/.hal filesystem layout (create, delete, api-workflow, agent) ---
+	halStateDirName     = ".hal"
+	tfeCertsDirName     = "tfe-certs"
+	tfeProxyConfName    = "tfe-proxy.conf"
+	tfeAPITokenFileName = "tfe-app-api-token"
+)

--- a/cmd/terraform/delete.go
+++ b/cmd/terraform/delete.go
@@ -14,26 +14,26 @@ import (
 
 // Primary-only Terraform Enterprise containers and helpers.
 var tfePrimaryContainers = []string{
-	"hal-tfe",
-	"hal-tfe-proxy",
+	tfeCoreContainer,
+	tfeProxyContainer,
 	tfeAPIPrimaryContainer,
 	legacyTFECLIContainerName,
-	"hal-tfe-agent",
+	tfeAgentPrimaryContainer,
 }
 
 // Shared backend components used by primary and twin TFE instances.
 var tfeSharedBackendContainers = []string{
-	"hal-tfe-db",
-	"hal-tfe-redis",
-	"hal-tfe-minio",
+	tfeDBContainer,
+	tfeRedisContainer,
+	tfeMinioContainer,
 }
 
 // Named volumes created by the shared backend containers. Must be removed
 // explicitly — docker rm -f does not remove named volumes.
 var tfeSharedBackendVolumes = []string{
-	"hal-tfe-db-data",
-	"hal-tfe-redis-data",
-	"hal-tfe-minio-data",
+	tfeDBVolume,
+	tfeRedisVolume,
+	tfeMinioVolume,
 }
 
 var destroyCmd = &cobra.Command{
@@ -148,7 +148,7 @@ var destroyCmd = &cobra.Command{
 
 		// 3. Wipe the local Cert cache
 		homeDir, _ := os.UserHomeDir()
-		certDir := filepath.Join(homeDir, ".hal", "tfe-certs")
+		certDir := filepath.Join(homeDir, halStateDirName, tfeCertsDirName)
 		if _, err := os.Stat(certDir); err == nil {
 			if global.DryRun {
 				fmt.Printf("[DRY RUN] Would execute: rm -rf %s\n", certDir)

--- a/cmd/terraform/foundation.go
+++ b/cmd/terraform/foundation.go
@@ -185,10 +185,10 @@ func tfeCoreContainerForBaseURL(baseURL string) (string, error) {
 
 	hostname := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
 	if hostname == "" {
-		return "hal-tfe", nil
+		return tfeCoreContainer, nil
 	}
 
-	if hostname == "tfe-bis.localhost" {
+	if hostname == defaultTFETwinHostname {
 		layout, layoutErr := buildTFETwinLayout()
 		if layoutErr != nil {
 			return "", layoutErr
@@ -196,7 +196,7 @@ func tfeCoreContainerForBaseURL(baseURL string) (string, error) {
 		return layout.CoreContainer, nil
 	}
 
-	return "hal-tfe", nil
+	return tfeCoreContainer, nil
 }
 
 func extractAtlasUserToken(raw string) string {

--- a/cmd/terraform/obs.go
+++ b/cmd/terraform/obs.go
@@ -38,8 +38,8 @@ func syncTerraformObsTargets(engine string) error {
 func terraformObsTargets(engine string) []string {
 	targets := []string{}
 
-	if global.IsContainerRunning(engine, "hal-tfe") {
-		targets = append(targets, "hal-tfe:9090")
+	if global.IsContainerRunning(engine, tfeCoreContainer) {
+		targets = append(targets, fmt.Sprintf("%s:%d", tfeCoreContainer, tfeMetricsHTTPPort))
 	}
 
 	if layout, err := buildTFETwinLayout(); err == nil {
@@ -53,8 +53,8 @@ func terraformObsTargets(engine string) []string {
 
 func terraformObsTargetsForScope(engine, scope string) []string {
 	targets := []string{}
-	if (scope == tfeTargetPrimary || scope == tfeTargetBoth) && global.IsContainerRunning(engine, "hal-tfe") {
-		targets = append(targets, "hal-tfe:9090")
+	if (scope == tfeTargetPrimary || scope == tfeTargetBoth) && global.IsContainerRunning(engine, tfeCoreContainer) {
+		targets = append(targets, fmt.Sprintf("%s:%d", tfeCoreContainer, tfeMetricsHTTPPort))
 	}
 
 	if scope == tfeTargetTwin || scope == tfeTargetBoth {
@@ -69,7 +69,7 @@ func terraformObsTargetsForScope(engine, scope string) []string {
 }
 
 func ensureObsScopeRunning(engine, scope string) error {
-	primaryRunning := global.IsContainerRunning(engine, "hal-tfe")
+	primaryRunning := global.IsContainerRunning(engine, tfeCoreContainer)
 	twinRunning := false
 	if layout, err := buildTFETwinLayout(); err == nil {
 		twinRunning = global.IsContainerRunning(engine, strings.TrimSpace(layout.CoreContainer))

--- a/cmd/terraform/saml.go
+++ b/cmd/terraform/saml.go
@@ -57,7 +57,7 @@ func tfeSAMLBaseURLForTarget(target string) string {
 	if target == tfeTargetTwin {
 		return "https://tfe-bis.localhost:9443"
 	}
-	return "https://tfe.localhost:8443"
+	return tfePrimaryBaseURL
 }
 
 // tfeSAMLSPBaseURL returns the portless base URL that TFE uses in its own SAML
@@ -73,9 +73,9 @@ func tfeSAMLSPBaseURL(apiBaseURL, target string) string {
 		}
 	}
 	if target == tfeTargetTwin {
-		return "https://tfe-bis.localhost"
+		return "https://" + defaultTFETwinHostname
 	}
-	return "https://tfe.localhost"
+	return "https://" + tfePrimaryHostname
 }
 
 // tfeSAMLProxyContainerForTarget returns the proxy container name for SCIM
@@ -84,7 +84,7 @@ func tfeSAMLProxyContainerForTarget(target string) string {
 	if target == tfeTargetTwin {
 		return "hal-tfe-bis-proxy"
 	}
-	return "hal-tfe-proxy"
+	return tfeProxyContainer
 }
 
 // tfeSAMLProxyPortForTarget returns the HTTPS port that the proxy container
@@ -506,7 +506,7 @@ func runTFESAMLDisable(engine, target string) {
 
 // ─── Authentik provisioning ───────────────────────────────────────────────────
 
-const defaultSAMLOrgName = "hal-org"
+const defaultSAMLOrgName = defaultTFEOrg
 
 // provisionAuthentikForTFE creates demo users/groups and a SAML provider + application
 // in Authentik for the given TFE target. Returns the Authentik SAML provider PK.
@@ -694,7 +694,7 @@ func provisionTFESAMLTeams(baseURL, apiToken, orgName string) {
 // malformed (e.g. empty) cert that TFE later moved to old_idp_cert.
 // Best-effort: errors are silently ignored.
 func clearOldTFESAMLCert(engine string) {
-	_ = exec.Command(engine, "exec", "hal-tfe-db", "sh", "-c",
+	_ = exec.Command(engine, "exec", tfeDBContainer, "sh", "-c",
 		"psql -U tfe tfe -c 'UPDATE rails.admin_settings_saml SET old_idp_cert_encrypted = NULL WHERE old_idp_cert_encrypted IS NOT NULL;'").Run()
 }
 
@@ -722,7 +722,7 @@ func cleanTFESAML(baseURL, apiToken string) {
 func tfeCoreContainerForTargetNoErr(target string) string {
 	name, err := tfeCoreContainerForTarget(target)
 	if err != nil {
-		return "hal-tfe"
+		return tfeCoreContainer
 	}
 	return name
 }
@@ -735,15 +735,15 @@ func bootstrapTFETokenForSAML(engine, target string) (string, error) {
 	}
 	adminUser := tfeSAMLAdminUsername
 	if adminUser == "" {
-		adminUser = "haladmin"
+		adminUser = defaultTFEAdminUsername
 	}
 	adminEmail := tfeSAMLAdminEmail
 	if adminEmail == "" {
-		adminEmail = "haladmin@localhost"
+		adminEmail = defaultTFEAdminEmail
 	}
 	adminPass := tfeSAMLAdminPassword
 	if adminPass == "" {
-		adminPass = "hal9000FTW"
+		adminPass = defaultTFEAdminPassword
 	}
 	orgName := tfeSAMLOrgName
 	if orgName == "" {
@@ -819,9 +819,9 @@ func init() {
 	tfeSAMLCmd.Flags().StringVar(&tfeSAMLBaseURL, "tfe-url", "", "TFE base URL (default: https://tfe.localhost:8443 for primary)")
 	tfeSAMLCmd.Flags().StringVar(&tfeSAMLOrgName, "tfe-org", defaultSAMLOrgName, "TFE organization name")
 	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAPIToken, "tfe-token", "", "TFE admin API token (auto-bootstrapped if omitted)")
-	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAdminUsername, "tfe-admin-username", "haladmin", "TFE admin username")
-	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAdminEmail, "tfe-admin-email", "haladmin@localhost", "TFE admin email")
-	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAdminPassword, "tfe-admin-password", "hal9000FTW", "TFE admin password")
+	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAdminUsername, "tfe-admin-username", defaultTFEAdminUsername, "TFE admin username")
+	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAdminEmail, "tfe-admin-email", defaultTFEAdminEmail, "TFE admin email")
+	tfeSAMLCmd.Flags().StringVar(&tfeSAMLAdminPassword, "tfe-admin-password", defaultTFEAdminPassword, "TFE admin password")
 
 	bindTFETargetFlag(tfeSAMLCmd)
 	Cmd.AddCommand(tfeSAMLCmd)

--- a/cmd/terraform/status.go
+++ b/cmd/terraform/status.go
@@ -60,10 +60,10 @@ func printTFETargetDetailedStatus(engine, target string) {
 		Name      string
 		Container string
 	}{
-		{"Database (Postgres)", "hal-tfe-db"},
-		{"Cache (Redis)", "hal-tfe-redis"},
-		{"Object Storage (MinIO)", "hal-tfe-minio"},
-		{"TFE Core (Application)", "hal-tfe"},
+		{"Database (Postgres)", tfeDBContainer},
+		{"Cache (Redis)", tfeRedisContainer},
+		{"Object Storage (MinIO)", tfeMinioContainer},
+		{"TFE Core (Application)", tfeCoreContainer},
 	}
 
 	allRunning := true
@@ -97,7 +97,7 @@ func printTFETargetDetailedStatus(engine, target string) {
 		fmt.Println("   hal terraform create")
 	} else if allRunning {
 		fmt.Println("   All systems green. TFE is operational.")
-		fmt.Println("   🔗 UI Address: https://tfe.localhost:8443")
+		fmt.Printf("   🔗 UI Address: %s\n", tfePrimaryBaseURL)
 		if workspaceReady {
 			fmt.Println("   Workspace automation is enabled and ready for VCS-triggered runs.")
 		} else {
@@ -123,9 +123,9 @@ func printTFETwinDetailedStatus(engine string) {
 		Name      string
 		Container string
 	}{
-		{"Shared Database (Postgres)", "hal-tfe-db"},
-		{"Shared Cache (Redis)", "hal-tfe-redis"},
-		{"Shared Object Storage (MinIO)", "hal-tfe-minio"},
+		{"Shared Database (Postgres)", tfeDBContainer},
+		{"Shared Cache (Redis)", tfeRedisContainer},
+		{"Shared Object Storage (MinIO)", tfeMinioContainer},
 		{"Twin TFE Core", layout.CoreContainer},
 		{"Twin Ingress Proxy", layout.ProxyContainer},
 	}
@@ -183,7 +183,7 @@ func printTFETargetStatus(engine, target string) {
 		return
 	}
 
-	endpoint := "https://tfe.localhost:8443"
+	endpoint := tfePrimaryBaseURL
 	productName := "TFE"
 	if target == tfeTargetTwin {
 		layout, layoutErr := buildTFETwinLayout()

--- a/cmd/terraform/twin.go
+++ b/cmd/terraform/twin.go
@@ -97,7 +97,7 @@ var twinCmd = &cobra.Command{
 			return
 		}
 
-		if !global.IsContainerRunning(engine, "hal-tfe") {
+		if !global.IsContainerRunning(engine, tfeCoreContainer) {
 			fmt.Println("❌ Primary Terraform Enterprise instance is not running (hal-tfe).")
 			fmt.Println("   💡 Run 'hal tf create' first, then retry 'hal tf create --target twin'.")
 			return
@@ -170,7 +170,7 @@ var twinCmd = &cobra.Command{
 
 		global.EnsureNetwork(engine)
 		if tfeTwinProxyInternalIP == "" {
-			tfeTwinProxyInternalIP = global.HalNetStaticIP(engine, 249)
+			tfeTwinProxyInternalIP = global.HalNetStaticIP(engine, tfeTwinProxyHostNum)
 		}
 
 		fmt.Printf("⚙️  Ensuring shared PostgreSQL has twin database '%s'...\n", tfeTwinDatabaseName)
@@ -189,7 +189,7 @@ var twinCmd = &cobra.Command{
 		tfeArgs := []string{
 			"run", "-d",
 			"--name", layout.CoreContainer,
-			"--network", "hal-net",
+			"--network", global.HalNetName,
 			"--privileged",
 			"--add-host", fmt.Sprintf("%s:127.0.0.1", layout.CoreContainer),
 			"--add-host", fmt.Sprintf("%s:%s", tfeTwinHostname, tfeTwinProxyInternalIP),
@@ -315,7 +315,7 @@ http {
 			return
 		}
 
-		_ = exec.Command(engine, "run", "-d", "--name", layout.ProxyContainer, "--network", "hal-net", "--ip", tfeTwinProxyInternalIP,
+		_ = exec.Command(engine, "run", "-d", "--name", layout.ProxyContainer, "--network", global.HalNetName, "--ip", tfeTwinProxyInternalIP,
 			"--network-alias", tfeTwinHostname,
 			"-p", fmt.Sprintf("%d:%d", tfeTwinHTTPSPort, tfeTwinHTTPSPort),
 			"-v", fmt.Sprintf("%s:/etc/ssl/tfe:ro", layout.CertDir),
@@ -421,9 +421,9 @@ func showTFETwinStatus(engine string, layout tfeTwinLayout) {
 		Name      string
 		Container string
 	}{
-		{"Shared Database (Postgres)", "hal-tfe-db"},
-		{"Shared Cache (Redis)", "hal-tfe-redis"},
-		{"Shared Object Storage (MinIO)", "hal-tfe-minio"},
+		{"Shared Database (Postgres)", tfeDBContainer},
+		{"Shared Cache (Redis)", tfeRedisContainer},
+		{"Shared Object Storage (MinIO)", tfeMinioContainer},
 		{"Twin TFE Core", layout.CoreContainer},
 		{"Twin Ingress Proxy", layout.ProxyContainer},
 	}
@@ -496,7 +496,7 @@ func destroyTFETwin(engine string, layout tfeTwinLayout) {
 }
 
 func ensureSharedTFEEcosystemRunning(engine string) error {
-	required := []string{"hal-tfe-db", "hal-tfe-redis", "hal-tfe-minio"}
+	required := []string{tfeDBContainer, tfeRedisContainer, tfeMinioContainer}
 	for _, container := range required {
 		if !global.IsContainerRunning(engine, container) {
 			return fmt.Errorf("required shared component '%s' is not running; run 'hal tf create' first", container)
@@ -512,7 +512,7 @@ func ensureTwinDatabaseExists(engine, dbName string) error {
 	}
 
 	checkSQL := fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname='%s';", dbName)
-	out, err := exec.Command(engine, "exec", "hal-tfe-db", "psql", "-U", "tfe", "-d", "postgres", "-tAc", checkSQL).CombinedOutput()
+	out, err := exec.Command(engine, "exec", tfeDBContainer, "psql", "-U", tfeDBUser, "-d", "postgres", "-tAc", checkSQL).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("postgres check failed: %s", strings.TrimSpace(string(out)))
 	}
@@ -521,7 +521,7 @@ func ensureTwinDatabaseExists(engine, dbName string) error {
 	}
 
 	createSQL := fmt.Sprintf("CREATE DATABASE %s;", dbName)
-	createOut, createErr := exec.Command(engine, "exec", "hal-tfe-db", "psql", "-U", "tfe", "-d", "postgres", "-c", createSQL).CombinedOutput()
+	createOut, createErr := exec.Command(engine, "exec", tfeDBContainer, "psql", "-U", tfeDBUser, "-d", "postgres", "-c", createSQL).CombinedOutput()
 	if createErr != nil {
 		return fmt.Errorf("postgres database creation failed: %s", strings.TrimSpace(string(createOut)))
 	}
@@ -535,7 +535,7 @@ func ensureTwinBucketExists(engine, bucketName string) error {
 		return fmt.Errorf("invalid bucket name '%s'", bucketName)
 	}
 
-	out, err := exec.Command(engine, "exec", "hal-tfe-minio", "sh", "-c", fmt.Sprintf("mkdir -p /data/%s", trimmed)).CombinedOutput()
+	out, err := exec.Command(engine, "exec", tfeMinioContainer, "sh", "-c", fmt.Sprintf("mkdir -p /data/%s", trimmed)).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("minio bucket creation failed: %s", strings.TrimSpace(string(out)))
 	}
@@ -572,7 +572,7 @@ func ensureCertsForTwin(certDir string, dnsNames []string) error {
 		serialNumber = big.NewInt(time.Now().UnixNano())
 	}
 
-	commonName := "tfe-bis.localhost"
+	commonName := defaultTFETwinHostname
 	for _, name := range dnsNames {
 		if name != "" && name != "localhost" {
 			commonName = name
@@ -694,18 +694,18 @@ func runTFETwinLifecycle(enable, disable, update bool) {
 }
 
 func bindTwinFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&tfeTwinVersion, "twin-tag", "2.0.2", "TFE container image tag for the twin instance")
-	cmd.Flags().StringVar(&tfeTwinImage, "twin-image", "images.releases.hashicorp.com/hashicorp/terraform-enterprise", "TFE container image name for the twin instance")
-	cmd.Flags().StringVar(&tfeTwinPassword, "twin-password", "hal-secret-encryption-password", "Twin TFE encryption password")
+	cmd.Flags().StringVar(&tfeTwinVersion, "twin-tag", defaultTFETag, "TFE container image tag for the twin instance")
+	cmd.Flags().StringVar(&tfeTwinImage, "twin-image", defaultTFEImage, "TFE container image name for the twin instance")
+	cmd.Flags().StringVar(&tfeTwinPassword, "twin-password", defaultTFEEncryptionPassword, "Twin TFE encryption password")
 	cmd.Flags().StringVar(&tfeTwinOrg, "twin-tfe-org", "hal-bis", "Terraform Enterprise organization name to auto-bootstrap for the twin instance")
 	cmd.Flags().StringVar(&tfeTwinProject, "twin-tfe-project", "Dave-bis", "Terraform Enterprise project name to auto-bootstrap for the twin instance")
-	cmd.Flags().StringVar(&tfeTwinAdminUser, "twin-tfe-admin-username", "haladmin", "Initial twin TFE admin username used when bootstrapping via IACT")
-	cmd.Flags().StringVar(&tfeTwinAdminEmail, "twin-tfe-admin-email", "haladmin@localhost", "Initial twin TFE admin email used when bootstrapping via IACT")
-	cmd.Flags().StringVar(&tfeTwinAdminPass, "twin-tfe-admin-password", "hal9000FTW", "Initial twin TFE admin password used when bootstrapping via IACT")
-	cmd.Flags().StringVar(&tfeTwinProxyNginxTag, "twin-proxy-tag", "alpine", "Nginx image tag for the twin ingress proxy")
-	cmd.Flags().StringVar(&tfeTwinProxyImage, "twin-proxy-image", "nginx", "Nginx image name for the twin ingress proxy")
+	cmd.Flags().StringVar(&tfeTwinAdminUser, "twin-tfe-admin-username", defaultTFEAdminUsername, "Initial twin TFE admin username used when bootstrapping via IACT")
+	cmd.Flags().StringVar(&tfeTwinAdminEmail, "twin-tfe-admin-email", defaultTFEAdminEmail, "Initial twin TFE admin email used when bootstrapping via IACT")
+	cmd.Flags().StringVar(&tfeTwinAdminPass, "twin-tfe-admin-password", defaultTFEAdminPassword, "Initial twin TFE admin password used when bootstrapping via IACT")
+	cmd.Flags().StringVar(&tfeTwinProxyNginxTag, "twin-proxy-tag", defaultTFEProxyTag, "Nginx image tag for the twin ingress proxy")
+	cmd.Flags().StringVar(&tfeTwinProxyImage, "twin-proxy-image", defaultTFEProxyImage, "Nginx image name for the twin ingress proxy")
 	cmd.Flags().IntVar(&tfeTwinHTTPSPort, "twin-https-port", 9443, "Host HTTPS port exposed by the twin TFE ingress proxy")
-	cmd.Flags().StringVar(&tfeTwinHostname, "twin-hostname", "tfe-bis.localhost", "TLS hostname used by the twin TFE instance")
+	cmd.Flags().StringVar(&tfeTwinHostname, "twin-hostname", defaultTFETwinHostname, "TLS hostname used by the twin TFE instance")
 	cmd.Flags().StringVar(&tfeTwinContainerName, "twin-container-name", "hal-tfe-bis", "Container name used for the twin TFE core application")
 	cmd.Flags().StringVar(&tfeTwinProxyInternalIP, "twin-proxy-ip", "", "Static internal proxy IP on hal-net for twin hostname routing (default: auto-derived .249)")
 	cmd.Flags().StringVar(&tfeTwinDatabasePassword, "twin-db-password", "tfe_password", "PostgreSQL password used by the twin TFE backend")

--- a/cmd/terraform/vcs-workflow.go
+++ b/cmd/terraform/vcs-workflow.go
@@ -834,7 +834,7 @@ func workspaceSharedConsumerForTarget(target string) string {
 }
 
 func isAnyTFERuntimeRunning(engine string) bool {
-	if global.IsContainerRunning(engine, "hal-tfe") {
+	if global.IsContainerRunning(engine, tfeCoreContainer) {
 		return true
 	}
 	layout, err := buildTFETwinLayout()
@@ -881,22 +881,22 @@ func configureWorkspaceTargetDefaults(cmd *cobra.Command, target string) error {
 	}
 
 	if !cmd.Flags().Changed("tfe-url") {
-		tfeBaseURL = "https://tfe.localhost:8443"
+		tfeBaseURL = tfePrimaryBaseURL
 	}
 	if !cmd.Flags().Changed("tfe-org") {
-		tfeOrgName = "hal"
+		tfeOrgName = defaultTFEOrg
 	}
 	if !cmd.Flags().Changed("tfe-project") {
-		tfeProjectName = "Dave"
+		tfeProjectName = defaultTFEProject
 	}
 	if !cmd.Flags().Changed("tfe-admin-username") {
-		tfeAdminUsername = "haladmin"
+		tfeAdminUsername = defaultTFEAdminUsername
 	}
 	if !cmd.Flags().Changed("tfe-admin-email") {
-		tfeAdminEmail = "haladmin@localhost"
+		tfeAdminEmail = defaultTFEAdminEmail
 	}
 	if !cmd.Flags().Changed("tfe-admin-password") {
-		tfeAdminPassword = "hal9000FTW"
+		tfeAdminPassword = defaultTFEAdminPassword
 	}
 	if !cmd.Flags().Changed("tfe-workspace") {
 		tfeWorkspaceName = "tfe-agent-demo"
@@ -923,17 +923,17 @@ func init() {
 	workspaceCmd.Flags().StringVar(&workspaceGitLabPassword, "gitlab-root-password", "hal9000FTW", "Root password used to bootstrap GitLab when HAL starts it")
 	workspaceCmd.Flags().StringVar(&workspaceProjectName, "project-name", "tfe-agent-demo", "GitLab project name for the Terraform workspace demo")
 	workspaceCmd.Flags().StringVar(&workspaceProjectPath, "project-path", "tfe-agent-demo", "GitLab project path for the Terraform workspace demo")
-	workspaceCmd.Flags().StringVar(&tfeOrgName, "tfe-org", "hal", "Terraform Enterprise organization name to bootstrap")
-	workspaceCmd.Flags().StringVar(&tfeProjectName, "tfe-project", "Dave", "Terraform Enterprise project name to bootstrap")
+	workspaceCmd.Flags().StringVar(&tfeOrgName, "tfe-org", defaultTFEOrg, "Terraform Enterprise organization name to bootstrap")
+	workspaceCmd.Flags().StringVar(&tfeProjectName, "tfe-project", defaultTFEProject, "Terraform Enterprise project name to bootstrap")
 	workspaceCmd.Flags().StringVar(&tfeWorkspaceName, "tfe-workspace", "tfe-agent-demo", "Terraform Enterprise workspace name to bootstrap")
 	workspaceCmd.Flags().StringVar(&tfeAPIToken, "tfe-api-token", "", "Terraform Enterprise app API token (or set TFE_API_TOKEN)")
 	workspaceCmd.Flags().StringVar(&tfeVCSOAuthTokenID, "tfe-vcs-oauth-token-id", "", "Terraform Enterprise VCS OAuth token id for linking the workspace to GitLab (or set TFE_GITLAB_OAUTH_TOKEN_ID)")
 	workspaceCmd.Flags().StringVar(&tfeVCSOAuthTokenID, "gitlab-token-id", "", "Alias of --tfe-vcs-oauth-token-id")
-	workspaceCmd.Flags().StringVar(&tfeBaseURL, "tfe-url", "https://tfe.localhost:8443", "Terraform Enterprise base URL")
+	workspaceCmd.Flags().StringVar(&tfeBaseURL, "tfe-url", tfePrimaryBaseURL, "Terraform Enterprise base URL")
 	workspaceCmd.Flags().StringVar(&tfeVCSBranch, "tfe-vcs-branch", "main", "Git branch to trigger VCS runs from (set non-main for tag-focused workflows)")
-	workspaceCmd.Flags().StringVar(&tfeAdminUsername, "tfe-admin-username", "haladmin", "Initial TFE admin username used when bootstrapping via IACT")
-	workspaceCmd.Flags().StringVar(&tfeAdminEmail, "tfe-admin-email", "haladmin@localhost", "Initial TFE admin email used when bootstrapping via IACT")
-	workspaceCmd.Flags().StringVar(&tfeAdminPassword, "tfe-admin-password", "hal9000FTW", "Initial TFE admin password used when bootstrapping via IACT")
+	workspaceCmd.Flags().StringVar(&tfeAdminUsername, "tfe-admin-username", defaultTFEAdminUsername, "Initial TFE admin username used when bootstrapping via IACT")
+	workspaceCmd.Flags().StringVar(&tfeAdminEmail, "tfe-admin-email", defaultTFEAdminEmail, "Initial TFE admin email used when bootstrapping via IACT")
+	workspaceCmd.Flags().StringVar(&tfeAdminPassword, "tfe-admin-password", defaultTFEAdminPassword, "Initial TFE admin password used when bootstrapping via IACT")
 	workspaceCmd.Flags().StringVar(&tfeTagsRegex, "tfe-tags-regex", "", "Optional regex for VCS tag-triggered runs (leave empty to disable)")
 
 	bindTFETargetFlag(workspaceCmd)
@@ -980,11 +980,11 @@ func buildTFEVCSRepoConfig(repoIdentifier string) map[string]interface{} {
 }
 
 func ensureGitLabCanReachTFEWebhook(engine string) error {
-	if !global.IsContainerRunning(engine, "hal-gitlab") || !global.IsContainerRunning(engine, "hal-tfe-proxy") {
+	if !global.IsContainerRunning(engine, "hal-gitlab") || !global.IsContainerRunning(engine, tfeProxyContainer) {
 		return nil
 	}
 
-	proxyIPOut, err := exec.Command(engine, "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "hal-tfe-proxy").Output()
+	proxyIPOut, err := exec.Command(engine, "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", tfeProxyContainer).Output()
 	if err != nil {
 		return fmt.Errorf("failed to discover hal-tfe-proxy IP: %w", err)
 	}

--- a/cmd/vault/audit.go
+++ b/cmd/vault/audit.go
@@ -102,7 +102,7 @@ var vaultAuditCmd = &cobra.Command{
 				fmt.Println("🧹 Purging old audit logs from the shared volume...")
 				engine, _ := global.DetectEngine()
 				// We use 'exec' to reach inside the running container and delete the file
-				_ = exec.Command(engine, "exec", "hal-vault", "sh", "-c", "rm -f /vault/logs/audit.log").Run()
+				_ = exec.Command(engine, "exec", vaultContainer, "sh", "-c", "rm -f /vault/logs/audit.log").Run()
 			}
 
 			// If the user ONLY wanted to disable, exit here.
@@ -155,7 +155,7 @@ var vaultAuditCmd = &cobra.Command{
 
 			if lokiStack {
 				fmt.Println("\n💡 HAL Tip for Observability:")
-				fmt.Println("   Vault is now writing to the 'hal-vault-logs' Docker volume.")
+				fmt.Printf("   Vault is now writing to the '%s' Docker volume.\n", vaultLogsVolume)
 				fmt.Println("   Promtail reads this passively, meaning Vault will never block on network errors!")
 			} else if auditType == "file" {
 				fmt.Println("\n💡 HAL Tip: To view these logs live from the container, run:")

--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -74,22 +74,22 @@ var deployCmd = &cobra.Command{
 			if global.Debug {
 				fmt.Println("[DEBUG] --update detected. Reconciling Vault by replacing runtime artifacts...")
 			}
-			_ = exec.Command(engine, "rm", "-f", "hal-vault").Run()
-			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-logs").Run()
-			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-plugins").Run()
-			_ = exec.Command(engine, "volume", "rm", "-f", "hal-vault-data").Run()
+			_ = exec.Command(engine, "rm", "-f", vaultContainer).Run()
+			_ = exec.Command(engine, "volume", "rm", "-f", vaultLogsVolume).Run()
+			_ = exec.Command(engine, "volume", "rm", "-f", vaultPluginsVolume).Run()
+			_ = exec.Command(engine, "volume", "rm", "-f", vaultDataVolume).Run()
 		}
 
 		// Determine the Image Repository and Version based on Edition
-		imageRepo := "hashicorp/vault"
+		imageRepo := defaultVaultImageCE
 		actualVersion := vaultVersion
 
 		if vaultEdition == "ent" || vaultEdition == "enterprise" {
-			imageRepo = "hashicorp/vault-enterprise"
+			imageRepo = defaultVaultImageEnt
 
 			// If the user didn't explicitly specify a tag, give them the Enterprise default
 			if !cmd.Flags().Changed("vault-tag") {
-				actualVersion = "2.0.1-ent"
+				actualVersion = defaultVaultEntTag
 			}
 		}
 		// --vault-image overrides the per-edition image name entirely
@@ -105,20 +105,20 @@ var deployCmd = &cobra.Command{
 		// Correction des permissions du volume d'audit pour l'utilisateur Vault (UID 100)
 		fmt.Println("⚙️  Preparing shared volume permissions...")
 		helperRef := vaultHelperImage + ":" + vaultHelperTag
-		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-logs:/vault/logs", helperRef, "chown", "-R", "100:1000", "/vault/logs").Run()
-		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-plugins:/vault/plugins", helperRef, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
-		_ = exec.Command(engine, "run", "--rm", "-v", "hal-vault-data:/vault/file", helperRef, "chown", "-R", "100:1000", "/vault/file").Run()
+		_ = exec.Command(engine, "run", "--rm", "-v", vaultLogsVolume+":/vault/logs", helperRef, "chown", "-R", "100:1000", "/vault/logs").Run()
+		_ = exec.Command(engine, "run", "--rm", "-v", vaultPluginsVolume+":/vault/plugins", helperRef, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
+		_ = exec.Command(engine, "run", "--rm", "-v", vaultDataVolume+":/vault/file", helperRef, "chown", "-R", "100:1000", "/vault/file").Run()
 
 		// 2. Build the Docker run arguments
 		vaultArgs := []string{
 			"run", "-d",
-			"--name", "hal-vault",
-			"--network", "hal-net",
+			"--name", vaultContainer,
+			"--network", global.HalNetName,
 			"--cap-add", "IPC_LOCK",
-			"-p", "8200:8200",
-			"-v", "hal-vault-logs:/vault/logs",
-			"-v", "hal-vault-plugins:/vault/plugins",
-			"-v", "hal-vault-data:/vault/file",
+			"-p", fmt.Sprintf("%d:%d", vaultHTTPPort, vaultHTTPPort),
+			"-v", vaultLogsVolume + ":/vault/logs",
+			"-v", vaultPluginsVolume + ":/vault/plugins",
+			"-v", vaultDataVolume + ":/vault/file",
 		}
 
 		// Vault 2.x tries to set SETFCAP capability which fails on Docker Desktop.
@@ -145,7 +145,7 @@ var deployCmd = &cobra.Command{
 		// Append the image and the Vault Dev mode commands
 		vaultArgs = append(vaultArgs,
 			fmt.Sprintf("%s:%s", imageRepo, actualVersion),
-			"server", "-dev", "-dev-listen-address=0.0.0.0:8200", "-dev-root-token-id=root", "-dev-plugin-dir=/vault/plugins",
+			"server", "-dev", fmt.Sprintf("-dev-listen-address=0.0.0.0:%d", vaultHTTPPort), "-dev-root-token-id="+vaultRootToken, "-dev-plugin-dir=/vault/plugins",
 		)
 
 		if global.DryRun {
@@ -166,24 +166,24 @@ var deployCmd = &cobra.Command{
 		// 3. THE HEALTH CHECK PHASE
 		fmt.Println("⏳ Waiting for Vault to initialize...")
 
-		if err := waitForService("Vault", "http://vault.localhost:8200/v1/sys/health", 30); err != nil {
-			handleDockerFailure("hal-vault", engine)
+		if err := waitForService("Vault", vaultHealthURL, 30); err != nil {
+			handleDockerFailure(vaultContainer, engine)
 			return
 		}
 
 		fmt.Println("✅ Vault is up and running in Dev mode!")
 		global.RefreshHalHealth(engine)
 		fmt.Printf("   🏗️  Edition: %s\n", strings.ToUpper(vaultEdition))
-		fmt.Println("   🔗 UI Address: http://vault.localhost:8200")
-		fmt.Println("   🔑 Root Token: root")
+		fmt.Printf("   🔗 UI Address: %s\n", vaultPublicURL)
+		fmt.Printf("   🔑 Root Token: %s\n", vaultRootToken)
 
 		if vaultJoinConsul {
 			fmt.Println("   🟢 Vault is successfully tethered to the global Consul Control Plane!")
 		}
 
 		fmt.Println("\n💡 Tip: Export your environment variables to use your local CLI:")
-		fmt.Println("   export VAULT_ADDR='http://vault.localhost:8200'")
-		fmt.Println("   export VAULT_TOKEN='root'")
+		fmt.Printf("   export VAULT_ADDR='%s'\n", vaultPublicURL)
+		fmt.Printf("   export VAULT_TOKEN='%s'\n", vaultRootToken)
 	},
 }
 
@@ -233,11 +233,11 @@ var updateCmd = &cobra.Command{
 }
 
 func bindLifecycleFlags(cmd *cobra.Command, includeUpdate bool) {
-	cmd.Flags().StringVarP(&vaultVersion, "vault-tag", "v", "2.0.1", "Vault container image tag")
+	cmd.Flags().StringVarP(&vaultVersion, "vault-tag", "v", defaultVaultTag, "Vault container image tag")
 	cmd.Flags().StringVar(&vaultImage, "vault-image", "", "Vault container image name (overrides per-edition default: hashicorp/vault or hashicorp/vault-enterprise)")
-	cmd.Flags().StringVarP(&vaultEdition, "edition", "e", "ce", "Vault edition to deploy: 'ce' (Community) or 'ent' (Enterprise)")
-	cmd.Flags().StringVar(&vaultHelperImage, "vault-helper-image", "alpine", "Helper container image name for one-shot setup tasks during Vault deploy")
-	cmd.Flags().StringVar(&vaultHelperTag, "vault-helper-tag", "3.22", "Helper container image tag for one-shot setup tasks during Vault deploy")
+	cmd.Flags().StringVarP(&vaultEdition, "edition", "e", defaultVaultEdition, "Vault edition to deploy: 'ce' (Community) or 'ent' (Enterprise)")
+	cmd.Flags().StringVar(&vaultHelperImage, "vault-helper-image", defaultVaultHelperImage, "Helper container image name for one-shot setup tasks during Vault deploy")
+	cmd.Flags().StringVar(&vaultHelperTag, "vault-helper-tag", defaultVaultHelperTag, "Helper container image tag for one-shot setup tasks during Vault deploy")
 	if includeUpdate {
 		cmd.Flags().BoolVarP(&vaultUpdate, "update", "u", false, "Reconcile an existing Vault deployment in place")
 	}

--- a/cmd/vault/database.go
+++ b/cmd/vault/database.go
@@ -51,11 +51,11 @@ var vaultDatabaseCmd = &cobra.Command{
 		}
 		backendLabel := "MariaDB"
 
-		containerName := "hal-vault-mariadb"
-		hostAlias := "mariadb.localhost"
+		containerName := vaultMariaDBContainer
+		hostAlias := vaultMariaDBHostAlias
 		containerPort := "3306"
 		pluginName := "mysql-database-plugin"
-		setupCmd := []string{"mariadb", "-u", "root", "-pvaultroot", "-e", `
+		setupCmd := []string{"mariadb", "-u", "root", "-p" + vaultMariaDBRootPassword, "-e", `
 				CREATE USER 'vaultadmin'@'%' IDENTIFIED BY 'temp-vault-pass';
 				GRANT ALL PRIVILEGES ON *.* TO 'vaultadmin'@'%' WITH GRANT OPTION;
 				FLUSH PRIVILEGES;
@@ -63,11 +63,11 @@ var vaultDatabaseCmd = &cobra.Command{
 		connectionURL := "{{username}}:{{password}}@tcp(hal-vault-mariadb:3306)/"
 		createStmt := "CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}'; GRANT ALL PRIVILEGES ON *.* TO '{{name}}'@'%';"
 		startArgs := []string{
-			"run", "-d", "--name", "hal-vault-mariadb",
-			"--network", "hal-net",
-			"--network-alias", "mariadb.localhost",
-			"-p", "3306:3306",
-			"-e", "MARIADB_ROOT_PASSWORD=vaultroot",
+			"run", "-d", "--name", vaultMariaDBContainer,
+			"--network", global.HalNetName,
+			"--network-alias", vaultMariaDBHostAlias,
+			"-p", fmt.Sprintf("%d:%d", vaultMariaDBPort, vaultMariaDBPort),
+			"-e", "MARIADB_ROOT_PASSWORD=" + vaultMariaDBRootPassword,
 			fmt.Sprintf("%s:%s", mariadbImage, mariadbVersion),
 		}
 
@@ -279,7 +279,7 @@ var vaultDatabaseCmd = &cobra.Command{
 
 func waitForMariaDB(engine, containerName string, maxRetries int) error {
 	for i := 0; i < maxRetries; i++ {
-		cmd := exec.Command(engine, "exec", containerName, "mariadb-admin", "ping", "-h", "127.0.0.1", "-u", "root", "-pvaultroot", "--silent")
+		cmd := exec.Command(engine, "exec", containerName, "mariadb-admin", "ping", "-h", "127.0.0.1", "-u", "root", "-p"+vaultMariaDBRootPassword, "--silent")
 		if err := cmd.Run(); err == nil {
 			return nil
 		}
@@ -300,8 +300,8 @@ func init() {
 
 	// Backend selection and version pinning
 	vaultDatabaseCmd.Flags().StringVarP(&databaseBackend, "backend", "b", "mariadb", "Database backend to use (mariadb; pgsql planned, postgres alias accepted)")
-	vaultDatabaseCmd.Flags().StringVar(&mariadbVersion, "vault-mariadb-tag", "11.4", "MariaDB container image tag")
-	vaultDatabaseCmd.Flags().StringVar(&mariadbImage, "vault-mariadb-image", "mariadb", "MariaDB container image name")
+	vaultDatabaseCmd.Flags().StringVar(&mariadbVersion, "vault-mariadb-tag", defaultVaultMariaDBTag, "MariaDB container image tag")
+	vaultDatabaseCmd.Flags().StringVar(&mariadbImage, "vault-mariadb-image", defaultVaultMariaDBImage, "MariaDB container image name")
 	vaultDatabaseCmd.Flags().StringVar(&dbUsernamePrefix, "username-prefix", "v", "Prefix for dynamically generated database usernames (e.g. 'myapp' → 'myapp-AbCdEfGhIj')")
 
 	Cmd.AddCommand(vaultDatabaseCmd)

--- a/cmd/vault/defaults.go
+++ b/cmd/vault/defaults.go
@@ -1,0 +1,59 @@
+package vault
+
+// defaults.go is the single source of truth for values shared across the Vault
+// command package. Container/volume names, the dev endpoint+token, ports and every
+// image/tag flag default are declared once here so create, status, delete, audit,
+// database, os, ldap, oidc and k8s can never drift apart. Cross-product values
+// (the Docker network name) live in internal/global and are referenced, never
+// redeclared.
+
+const (
+	// --- Containers / instances ---
+	vaultContainer        = "hal-vault"
+	vaultMariaDBContainer = "hal-vault-mariadb"
+	vaultOSInstance       = "hal-vault-os" // Multipass VM
+	openLDAPContainer     = "hal-openldap"
+	phpLDAPAdminContainer = "hal-phpldapadmin"
+	// Feature/demo containers spun up by individual auth-method commands
+	// (referenced by status, delete, jwt, oidc and pki — kept here so they cannot drift).
+	keycloakContainer     = "hal-keycloak"
+	gitlabContainer       = "hal-gitlab"
+	gitlabRunnerContainer = "hal-gitlab-runner"
+	acmeDNSContainer      = "hal-acme-dns"
+
+	// --- Volumes ---
+	vaultLogsVolume    = "hal-vault-logs"
+	vaultPluginsVolume = "hal-vault-plugins"
+	vaultDataVolume    = "hal-vault-data"
+
+	// --- Endpoints / token / port ---
+	vaultHTTPPort    = 8200
+	vaultRootToken   = "root"
+	vaultLocalAPIURL = "http://127.0.0.1:8200"
+	vaultPublicURL   = "http://vault.localhost:8200"
+	vaultHealthURL   = "http://vault.localhost:8200/v1/sys/health"
+
+	// --- Backend DB (MariaDB) ---
+	vaultMariaDBHostAlias    = "mariadb.localhost"
+	vaultMariaDBPort         = 3306
+	vaultMariaDBRootPassword = "vaultroot"
+
+	// --- Image / tag flag defaults ---
+	defaultVaultImageCE     = "hashicorp/vault"
+	defaultVaultImageEnt    = "hashicorp/vault-enterprise"
+	defaultVaultTag         = "2.0.1"
+	defaultVaultEntTag      = "2.0.1-ent"
+	defaultVaultEdition     = "ce"
+	defaultVaultHelperImage = "alpine"
+	defaultVaultHelperTag   = "3.22"
+
+	defaultVaultMariaDBImage = "mariadb"
+	defaultVaultMariaDBTag   = "11.4"
+
+	defaultOpenLDAPTag     = "1.5.0"
+	defaultPHPLDAPAdminTag = "0.9.0"
+
+	defaultVaultOSUbuntuImage = "22.04"
+	defaultVaultOSVMCPUs      = "1"
+	defaultVaultOSVMMem       = "1G"
+)

--- a/cmd/vault/delete.go
+++ b/cmd/vault/delete.go
@@ -12,19 +12,19 @@ import (
 // The "Known Universe" of Vault infrastructure.
 // As you build new Vault features that require Docker containers, just add them here!
 var vaultEcosystem = []string{
-	"hal-vault",
-	"hal-keycloak",
-	"hal-gitlab",
-	"hal-gitlab-runner",
-	"hal-openldap",
-	"hal-phpldapadmin",
-	"hal-mariadb",
+	vaultContainer,
+	keycloakContainer,
+	gitlabContainer,
+	gitlabRunnerContainer,
+	openLDAPContainer,
+	phpLDAPAdminContainer,
+	vaultMariaDBContainer,
 }
 
 var vaultVolumes = []string{
-	"hal-vault-logs",    // Spun up by Audit/Loki
-	"hal-vault-plugins", // Spun up for external plugins (OS secret engine)
-	"hal-vault-data",    // Vault file storage (/vault/file VOLUME directive)
+	vaultLogsVolume,    // Spun up by Audit/Loki
+	vaultPluginsVolume, // Spun up for external plugins (OS secret engine)
+	vaultDataVolume,    // Vault file storage (/vault/file VOLUME directive)
 }
 
 var vaultDestroyCmd = &cobra.Command{

--- a/cmd/vault/helper.go
+++ b/cmd/vault/helper.go
@@ -12,7 +12,7 @@ import (
 func GetHealthyClient() (*vault.Client, error) {
 	config := vault.DefaultConfig()
 	if os.Getenv("VAULT_ADDR") == "" {
-		config.Address = "http://127.0.0.1:8200"
+		config.Address = vaultLocalAPIURL
 	}
 
 	client, err := vault.NewClient(config)
@@ -21,7 +21,7 @@ func GetHealthyClient() (*vault.Client, error) {
 	}
 
 	if os.Getenv("VAULT_TOKEN") == "" {
-		client.SetToken("root")
+		client.SetToken(vaultRootToken)
 	}
 
 	// The LB-Style Pre-Flight Health Check

--- a/cmd/vault/jwt.go
+++ b/cmd/vault/jwt.go
@@ -52,7 +52,7 @@ var vaultJwtCmd = &cobra.Command{
 			fmt.Println("🔍 Checking Vault JWT / GitLab Status...")
 
 			// Check Docker
-			gitlabExists := (exec.Command(engine, "inspect", "hal-gitlab").Run() == nil)
+			gitlabExists := (exec.Command(engine, "inspect", gitlabContainer).Run() == nil)
 			projectExists := false
 			runnerActive := false
 			if gitlabExists {
@@ -133,7 +133,7 @@ var vaultJwtCmd = &cobra.Command{
 					// We don't delete the root identity as it might be used by other things.
 				}
 
-				_ = exec.Command(engine, "rm", "-f", "hal-gitlab", "hal-gitlab-runner").Run()
+				_ = exec.Command(engine, "rm", "-f", gitlabContainer, gitlabRunnerContainer).Run()
 				_ = global.ClearSharedService("gitlab")
 				fmt.Println("✅ GitLab containers removed and Vault API cleaned up.")
 				global.RefreshHalHealth(engine)
@@ -455,9 +455,9 @@ func ensureJWTGitLabRunner(engine, token, projectID string) error {
 		return nil
 	}
 
-	if global.IsContainerRunning(engine, "hal-gitlab-runner") {
+	if global.IsContainerRunning(engine, gitlabRunnerContainer) {
 		fmt.Println("   ♻️  Reconfiguring HAL runner to use internal GitLab network URL...")
-		_ = exec.Command(engine, "rm", "-f", "hal-gitlab-runner").Run()
+		_ = exec.Command(engine, "rm", "-f", gitlabRunnerContainer).Run()
 		_ = os.RemoveAll(runnerConfigDir)
 	}
 
@@ -470,7 +470,7 @@ func ensureJWTGitLabRunner(engine, token, projectID string) error {
 		return fmt.Errorf("failed to prepare runner config directory: %w", err)
 	}
 
-	if !global.IsContainerRunning(engine, "hal-gitlab-runner") {
+	if !global.IsContainerRunning(engine, gitlabRunnerContainer) {
 		gitlabIP, ipErr := gitlabContainerIP(engine)
 		if ipErr != nil {
 			return ipErr
@@ -478,8 +478,8 @@ func ensureJWTGitLabRunner(engine, token, projectID string) error {
 
 		runnerArgs := []string{
 			"run", "-d",
-			"--name", "hal-gitlab-runner",
-			"--network", "hal-net",
+			"--name", gitlabRunnerContainer,
+			"--network", global.HalNetName,
 			"--add-host", fmt.Sprintf("gitlab.localhost:%s", gitlabIP),
 			"-v", fmt.Sprintf("%s:/etc/gitlab-runner", runnerConfigDir),
 			gitlabRunnerImage + ":" + gitlabRunnerTag,
@@ -495,7 +495,7 @@ func ensureJWTGitLabRunner(engine, token, projectID string) error {
 	}
 
 	registerArgs := []string{
-		"exec", "hal-gitlab-runner",
+		"exec", gitlabRunnerContainer,
 		"gitlab-runner", "register", "--non-interactive",
 		"--url", "http://hal-gitlab:8080",
 		"--clone-url", "http://hal-gitlab:8080",
@@ -529,7 +529,7 @@ func ensureJWTToolingInRunner(engine string) error {
 		"exec",
 		"-u",
 		"0",
-		"hal-gitlab-runner",
+		gitlabRunnerContainer,
 		"sh",
 		"-lc",
 		"apk add --no-cache jq curl bash >/dev/null",
@@ -546,10 +546,10 @@ func ensureJWTToolingInRunner(engine string) error {
 }
 
 func runnerHasJWTTooling(engine string) bool {
-	if !global.IsContainerRunning(engine, "hal-gitlab-runner") {
+	if !global.IsContainerRunning(engine, gitlabRunnerContainer) {
 		return false
 	}
-	out, err := exec.Command(engine, "exec", "hal-gitlab-runner", "sh", "-lc", "command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1 && command -v bash >/dev/null 2>&1").CombinedOutput()
+	out, err := exec.Command(engine, "exec", gitlabRunnerContainer, "sh", "-lc", "command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1 && command -v bash >/dev/null 2>&1").CombinedOutput()
 	if err != nil {
 		_ = out
 		return false
@@ -558,7 +558,7 @@ func runnerHasJWTTooling(engine string) bool {
 }
 
 func gitlabContainerIP(engine string) (string, error) {
-	out, err := exec.Command(engine, "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "hal-gitlab").Output()
+	out, err := exec.Command(engine, "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", gitlabContainer).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect hal-gitlab container IP: %w", err)
 	}
@@ -594,10 +594,10 @@ func createJWTRunnerAuthToken(token string) (string, error) {
 }
 
 func runnerConfigUsesInternalGitLab(engine string) bool {
-	if !global.IsContainerRunning(engine, "hal-gitlab-runner") {
+	if !global.IsContainerRunning(engine, gitlabRunnerContainer) {
 		return false
 	}
-	out, err := exec.Command(engine, "exec", "hal-gitlab-runner", "sh", "-lc", "cat /etc/gitlab-runner/config.toml").CombinedOutput()
+	out, err := exec.Command(engine, "exec", gitlabRunnerContainer, "sh", "-lc", "cat /etc/gitlab-runner/config.toml").CombinedOutput()
 	if err != nil {
 		return false
 	}

--- a/cmd/vault/k8s.go
+++ b/cmd/vault/k8s.go
@@ -285,7 +285,7 @@ var vaultK8sCmd = &cobra.Command{
 				if isPodman {
 					env = append(env, "KIND_EXPERIMENTAL_PROVIDER=podman")
 				}
-				env = append(env, "KIND_EXPERIMENTAL_DOCKER_NETWORK=hal-net")
+				env = append(env, "KIND_EXPERIMENTAL_DOCKER_NETWORK="+global.HalNetName)
 				startCmd.Env = env
 				startCmd.Stdout = os.Stdout
 				startCmd.Stderr = os.Stderr
@@ -404,10 +404,10 @@ path "sys/license/status" { capabilities = ["read"] }
 			fmt.Println("⚙️  Applying Kubernetes Manifests...")
 			_ = exec.Command("kubectl", "create", "sa", "app1-sa", "-n", "app1").Run()
 
-			ipOut, _ := exec.Command(engine, "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "hal-vault").Output()
+			ipOut, _ := exec.Command(engine, "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", vaultContainer).Output()
 			vaultIP := strings.TrimSpace(string(ipOut))
 			if vaultIP == "" {
-				vaultIP = "hal-vault"
+				vaultIP = vaultContainer
 			}
 
 			modeTitle := "VSO ROLLING UPDATE DEMO"

--- a/cmd/vault/ldap.go
+++ b/cmd/vault/ldap.go
@@ -45,8 +45,8 @@ var vaultLdapCmd = &cobra.Command{
 			fmt.Println("🔍 Checking Vault LDAP / Directory Status...")
 
 			// Check Docker
-			ldapExists := (exec.Command(engine, "inspect", "hal-openldap").Run() == nil)
-			uiExists := (exec.Command(engine, "inspect", "hal-phpldapadmin").Run() == nil)
+			ldapExists := (exec.Command(engine, "inspect", openLDAPContainer).Run() == nil)
+			uiExists := (exec.Command(engine, "inspect", phpLDAPAdminContainer).Run() == nil)
 
 			// Check Vault API (if Vault is alive)
 			authMounted := false
@@ -129,7 +129,7 @@ var vaultLdapCmd = &cobra.Command{
 				}
 
 				fmt.Println("⚙️  Removing OpenLDAP and phpLDAPadmin containers...")
-				_ = exec.Command(engine, "rm", "-f", "hal-openldap", "hal-phpldapadmin").Run()
+				_ = exec.Command(engine, "rm", "-f", openLDAPContainer, phpLDAPAdminContainer).Run()
 
 				homeDir, _ := os.UserHomeDir()
 				if homeDir != "" {
@@ -166,10 +166,10 @@ var vaultLdapCmd = &cobra.Command{
 			global.EnsureNetwork(engine)
 
 			fmt.Println("🚀 Booting OpenLDAP Directory Server...")
-			_ = exec.Command(engine, "rm", "-f", "hal-openldap").Run()
+			_ = exec.Command(engine, "rm", "-f", openLDAPContainer).Run()
 			err = exec.Command(engine, "run", "-d",
-				"--name", "hal-openldap",
-				"--network", "hal-net",
+				"--name", openLDAPContainer,
+				"--network", global.HalNetName,
 				"-p", "1389:389",
 				"--platform", "linux/amd64",
 				"-e", "LDAP_ORGANISATION=HAL",
@@ -188,13 +188,13 @@ var vaultLdapCmd = &cobra.Command{
 			}
 
 			fmt.Println("🚀 Booting phpLDAPadmin UI...")
-			_ = exec.Command(engine, "rm", "-f", "hal-phpldapadmin").Run()
+			_ = exec.Command(engine, "rm", "-f", phpLDAPAdminContainer).Run()
 			_ = exec.Command(engine, "run", "-d",
-				"--name", "hal-phpldapadmin",
-				"--network", "hal-net",
+				"--name", phpLDAPAdminContainer,
+				"--network", global.HalNetName,
 				"-p", "8082:443",
 				"--platform", "linux/amd64",
-				"-e", "PHPLDAPADMIN_LDAP_HOSTS=hal-openldap",
+				"-e", "PHPLDAPADMIN_LDAP_HOSTS="+openLDAPContainer,
 				"-e", "PHPLDAPADMIN_HTTPS=true",
 				fmt.Sprintf("osixia/phpldapadmin:%s", phpLDAPAdminImageTag),
 			).Run()
@@ -384,12 +384,12 @@ member: cn=bob,ou=users,dc=hal,dc=local
 	_ = os.WriteFile(tmpFile, []byte(ldifClean), 0644)
 	defer os.Remove(tmpFile)
 
-	_ = exec.Command(engine, "cp", tmpFile, "hal-openldap:/tmp/seed.ldif").Run()
+	_ = exec.Command(engine, "cp", tmpFile, openLDAPContainer+":/tmp/seed.ldif").Run()
 
 	fmt.Print("⚙️  Waiting for OpenLDAP to accept connections")
 
 	for i := 0; i < 10; i++ {
-		out, err := exec.Command(engine, "exec", "hal-openldap", "ldapadd", "-c", "-x", "-D", "cn=admin,dc=hal,dc=local", "-w", "admin", "-H", "ldap://localhost", "-f", "/tmp/seed.ldif").CombinedOutput()
+		out, err := exec.Command(engine, "exec", openLDAPContainer, "ldapadd", "-c", "-x", "-D", "cn=admin,dc=hal,dc=local", "-w", "admin", "-H", "ldap://localhost", "-f", "/tmp/seed.ldif").CombinedOutput()
 		if err == nil {
 			fmt.Println("\n✅ LDAP Directory seeded successfully.")
 			return
@@ -412,8 +412,8 @@ func init() {
 	_ = vaultLdapCmd.Flags().MarkHidden("enable")
 	_ = vaultLdapCmd.Flags().MarkHidden("disable")
 	_ = vaultLdapCmd.Flags().MarkHidden("update")
-	vaultLdapCmd.Flags().StringVar(&ldapServerImageTag, "openldap-version", "1.5.0", "OpenLDAP image tag for the LDAP demo")
-	vaultLdapCmd.Flags().StringVar(&phpLDAPAdminImageTag, "phpldapadmin-version", "0.9.0", "phpLDAPadmin image tag for the LDAP demo UI")
+	vaultLdapCmd.Flags().StringVar(&ldapServerImageTag, "openldap-version", defaultOpenLDAPTag, "OpenLDAP image tag for the LDAP demo")
+	vaultLdapCmd.Flags().StringVar(&phpLDAPAdminImageTag, "phpldapadmin-version", defaultPHPLDAPAdminTag, "phpLDAPadmin image tag for the LDAP demo UI")
 
 	Cmd.AddCommand(vaultLdapCmd)
 }

--- a/cmd/vault/oidc.go
+++ b/cmd/vault/oidc.go
@@ -372,7 +372,7 @@ func provisionAuthentikForVault(c *integrations.AuthentikClient) (string, string
 	// OAuth2 provider
 	redirectURIs := []integrations.AuthentikRedirectURI{
 		{MatchingMode: "strict", URL: "http://localhost:8250/oidc/callback"},
-		{MatchingMode: "strict", URL: "http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback"},
+		{MatchingMode: "strict", URL: vaultPublicURL + "/ui/vault/auth/oidc/oidc/callback"},
 		{MatchingMode: "strict", URL: "http://127.0.0.1:8250/oidc/callback"},
 	}
 	providerPK, clientID, clientSecret, err := c.CreateOAuth2Provider(
@@ -384,7 +384,7 @@ func provisionAuthentikForVault(c *integrations.AuthentikClient) (string, string
 
 	// Application — set meta_launch_url so the Authentik portal tile points to the
 	// browser-accessible Vault UI OIDC page, not an auto-computed internal URL.
-	vaultUIURL := "http://vault.localhost:8200/ui/vault/auth/oidc"
+	vaultUIURL := vaultPublicURL + "/ui/vault/auth/oidc"
 	if err := c.CreateApplication("HashiCorp Vault", authentikVaultSlug, providerPK, vaultUIURL); err != nil {
 		return "", "", fmt.Errorf("create application: %w", err)
 	}
@@ -446,7 +446,7 @@ path "kv-oidc/metadata/team1" { capabilities = ["read", "list"] }
 		"allowed_redirect_uris": []string{
 			"http://localhost:8250/oidc/callback",
 			"http://127.0.0.1:8250/oidc/callback",
-			"http://vault.localhost:8200/ui/vault/auth/oidc/oidc/callback",
+			vaultPublicURL + "/ui/vault/auth/oidc/oidc/callback",
 		},
 		"oidc_scopes": []string{"openid", "profile", "email", "groups"},
 	})
@@ -517,7 +517,7 @@ func printOIDCSuccess(secrets *integrations.AuthentikSecrets) {
 	fmt.Println()
 	fmt.Println("✅ Vault OIDC + Authentik IdP ready!")
 	fmt.Println()
-	fmt.Println("  UI login   : http://vault.localhost:8200  (select 'OIDC', leave role blank)")
+	fmt.Printf("  UI login   : %s  (select 'OIDC', leave role blank)\n", vaultPublicURL)
 	fmt.Println("  CLI login  : vault login -method=oidc")
 	fmt.Println()
 	fmt.Println("  Demo users:")

--- a/cmd/vault/os.go
+++ b/cmd/vault/os.go
@@ -51,10 +51,10 @@ var vaultOSCmd = &cobra.Command{
 		if !osEnable && !osDisable && !osUpdate {
 			fmt.Println("🔍 Checking Vault OS Secret Engine Status...")
 
-			vmExists := exec.Command("multipass", "info", "hal-vault-os").Run() == nil
+			vmExists := exec.Command("multipass", "info", vaultOSInstance).Run() == nil
 			vmIP := ""
 			if vmExists {
-				ipOut, _ := exec.Command("multipass", "info", "hal-vault-os", "--format", "csv").Output()
+				ipOut, _ := exec.Command("multipass", "info", vaultOSInstance, "--format", "csv").Output()
 				vmIP = extractMultipassIP(string(ipOut))
 			}
 
@@ -117,7 +117,7 @@ var vaultOSCmd = &cobra.Command{
 				}
 
 				fmt.Println("⚙️  Removing Multipass VM...")
-				_ = exec.Command("multipass", "delete", "hal-vault-os").Run()
+				_ = exec.Command("multipass", "delete", vaultOSInstance).Run()
 				_ = exec.Command("multipass", "purge").Run()
 
 				if osDisable {
@@ -166,7 +166,7 @@ var vaultOSCmd = &cobra.Command{
 
 			// 1. Launch the VM
 			fmt.Println("📦 Provisioning Ubuntu VM (this takes a moment)...")
-			launchArgs := []string{"launch", osUbuntuImage, "--name", "hal-vault-os", "--cpus", osVMCPUs, "--memory", osVMMem}
+			launchArgs := []string{"launch", osUbuntuImage, "--name", vaultOSInstance, "--cpus", osVMCPUs, "--memory", osVMMem}
 			out, err := exec.Command("multipass", launchArgs...).CombinedOutput()
 			if err != nil {
 				if strings.Contains(string(out), "already exists") {
@@ -182,7 +182,7 @@ var vaultOSCmd = &cobra.Command{
 			var vmIP string
 			for i := 0; i < 30; i++ {
 				time.Sleep(2 * time.Second)
-				ipOut, err := exec.Command("multipass", "info", "hal-vault-os", "--format", "csv").Output()
+				ipOut, err := exec.Command("multipass", "info", vaultOSInstance, "--format", "csv").Output()
 				if err != nil {
 					continue
 				}
@@ -224,7 +224,7 @@ var vaultOSCmd = &cobra.Command{
 				echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/60-cloudimg-settings.conf > /dev/null
 				sudo systemctl restart ssh
 			`
-			execArgs := []string{"exec", "hal-vault-os", "--", "bash", "-c", setupScript}
+			execArgs := []string{"exec", vaultOSInstance, "--", "bash", "-c", setupScript}
 			if out, err := exec.Command("multipass", execArgs...).CombinedOutput(); err != nil {
 				fmt.Printf("❌ Failed to configure VM: %v\nOutput: %s\n", err, string(out))
 				return
@@ -250,10 +250,10 @@ var vaultOSCmd = &cobra.Command{
 			fmt.Println("⚙️  Registering OS secret engine plugin...")
 			osPluginVersion := "0.1.0+ent"
 			registerCmd := fmt.Sprintf(
-				"VAULT_ADDR='http://127.0.0.1:8200' VAULT_TOKEN='root' vault plugin register -download -version='%s' secret vault-plugin-secrets-os",
-				osPluginVersion,
+				"VAULT_ADDR='%s' VAULT_TOKEN='%s' vault plugin register -download -version='%s' secret vault-plugin-secrets-os",
+				vaultLocalAPIURL, vaultRootToken, osPluginVersion,
 			)
-			if out, err := exec.Command(engine, "exec", "hal-vault", "sh", "-c", registerCmd).CombinedOutput(); err != nil {
+			if out, err := exec.Command(engine, "exec", vaultContainer, "sh", "-c", registerCmd).CombinedOutput(); err != nil {
 				fmt.Printf("❌ Failed to register OS plugin: %v\nOutput: %s\n", err, string(out))
 				fmt.Println("   💡 Check https://releases.hashicorp.com/vault-plugin-secrets-os for the latest version.")
 				return
@@ -386,9 +386,9 @@ func init() {
 	_ = vaultOSCmd.Flags().MarkHidden("disable")
 	_ = vaultOSCmd.Flags().MarkHidden("update")
 
-	vaultOSCmd.Flags().StringVar(&osUbuntuImage, "ubuntu-image", "22.04", "Ubuntu image for Multipass VM")
-	vaultOSCmd.Flags().StringVar(&osVMCPUs, "vm-cpus", "1", "Number of CPUs for the VM")
-	vaultOSCmd.Flags().StringVar(&osVMMem, "vm-mem", "1G", "Amount of RAM for the VM")
+	vaultOSCmd.Flags().StringVar(&osUbuntuImage, "ubuntu-image", defaultVaultOSUbuntuImage, "Ubuntu image for Multipass VM")
+	vaultOSCmd.Flags().StringVar(&osVMCPUs, "vm-cpus", defaultVaultOSVMCPUs, "Number of CPUs for the VM")
+	vaultOSCmd.Flags().StringVar(&osVMMem, "vm-mem", defaultVaultOSVMMem, "Amount of RAM for the VM")
 
 	Cmd.AddCommand(vaultOSCmd)
 }

--- a/cmd/vault/pki.go
+++ b/cmd/vault/pki.go
@@ -257,7 +257,7 @@ var vaultPKICmd = &cobra.Command{
 					fmt.Println("  ✅ pki-acme-demo namespace removed.")
 				}
 				// Remove the CoreDNS sidecar used for ACME challenge DNS resolution.
-				_ = exec.Command(engine, "rm", "-f", "hal-acme-dns").Run()
+				_ = exec.Command(engine, "rm", "-f", acmeDNSContainer).Run()
 
 				// Conditionally delete KinD cluster
 				vsoOut, _ := exec.Command("helm", "list", "-n", "vso", "-q").Output()
@@ -1155,16 +1155,16 @@ func tunePKIACMEHeaders(client *vault.Client, mount string) error {
 // Returns the DNS container IP (to be set as Vault ACME dns_resolver).
 func ensureACMEDNS(engine, kindIP string) (string, error) {
 	// Return early if already running with the correct mapping.
-	runningOut, _ := exec.Command(engine, "inspect", "-f", "{{.State.Running}}", "hal-acme-dns").Output()
+	runningOut, _ := exec.Command(engine, "inspect", "-f", "{{.State.Running}}", acmeDNSContainer).Output()
 	if strings.TrimSpace(string(runningOut)) == "true" {
 		ipOut, _ := exec.Command(engine, "inspect",
-			"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "hal-acme-dns").Output()
+			"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", acmeDNSContainer).Output()
 		if ip := strings.TrimSpace(string(ipOut)); ip != "" {
 			return ip, nil
 		}
 	}
 	// Remove any stopped/stale container.
-	_ = exec.Command(engine, "rm", "-f", "hal-acme-dns").Run()
+	_ = exec.Command(engine, "rm", "-f", acmeDNSContainer).Run()
 
 	// Write a minimal Corefile to a temp directory.
 	tmpDir, err := os.MkdirTemp("", "hal-acme-dns-*")
@@ -1186,8 +1186,8 @@ func ensureACMEDNS(engine, kindIP string) (string, error) {
 	}
 
 	startOut, startErr := exec.Command(engine, "run", "-d",
-		"--name", "hal-acme-dns",
-		"--network", "hal-net",
+		"--name", acmeDNSContainer,
+		"--network", global.HalNetName,
 		"-v", tmpDir+"/Corefile:/Corefile:ro",
 		"coredns/coredns:latest", "-conf", "/Corefile",
 	).CombinedOutput()
@@ -1199,7 +1199,7 @@ func ensureACMEDNS(engine, kindIP string) (string, error) {
 	time.Sleep(2 * time.Second)
 
 	ipOut, _ := exec.Command(engine, "inspect",
-		"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "hal-acme-dns").Output()
+		"-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", acmeDNSContainer).Output()
 	dnsIP := strings.TrimSpace(string(ipOut))
 	if dnsIP == "" {
 		return "", fmt.Errorf("hal-acme-dns started but could not determine its IP")

--- a/cmd/vault/status.go
+++ b/cmd/vault/status.go
@@ -31,7 +31,7 @@ var vaultStatusCmd = &cobra.Command{
 		fmt.Println("  [ Container Infrastructure ]")
 
 		// 🎯 FIX: Use Output() instead of CombinedOutput() so we don't capture stderr garbage
-		vaultCheck, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-vault").Output()
+		vaultCheck, err := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", vaultContainer).Output()
 		vaultStatus := strings.TrimSpace(string(vaultCheck))
 
 		// 🎯 FIX: If err != nil, the container just doesn't exist
@@ -46,7 +46,7 @@ var vaultStatusCmd = &cobra.Command{
 			fmt.Println("\n  📜 Fetching recent crash logs...")
 
 			// We DO want stderr here so we can see why it crashed!
-			logsOut, _ := exec.Command(engine, "logs", "--tail", "10", "hal-vault").CombinedOutput()
+			logsOut, _ := exec.Command(engine, "logs", "--tail", "10", vaultContainer).CombinedOutput()
 			logStr := strings.TrimSpace(string(logsOut))
 
 			if logStr != "" {
@@ -68,16 +68,16 @@ var vaultStatusCmd = &cobra.Command{
 			Container string
 			Command   string
 		}{
-			{"OIDC (Keycloak)", "hal-keycloak", "oidc"},
-			{"JWT (GitLab)", "hal-gitlab", "jwt"},
-			{"LDAP (OpenLDAP)", "hal-openldap", "ldap"},
-			{"DBs (MariaDB/PgSQL)", "hal-vault-mariadb", "database"},
+			{"OIDC (Keycloak)", keycloakContainer, "oidc"},
+			{"JWT (GitLab)", gitlabContainer, "jwt"},
+			{"LDAP (OpenLDAP)", openLDAPContainer, "ldap"},
+			{"DBs (MariaDB/PgSQL)", vaultMariaDBContainer, "database"},
 			{"K8s (KinD)", "kind-control-plane", "k8s"},
 		}
 
 		for _, f := range features {
 			if f.Command == "database" {
-				mariaOut, mariaErr := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-vault-mariadb").Output()
+				mariaOut, mariaErr := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", vaultMariaDBContainer).Output()
 				postgresOut, postgresErr := exec.Command(engine, "inspect", "-f", "{{.State.Status}}", "hal-vault-postgres").Output()
 				mariaStatus := strings.TrimSpace(string(mariaOut))
 				postgresStatus := strings.TrimSpace(string(postgresOut))
@@ -125,7 +125,7 @@ var vaultStatusCmd = &cobra.Command{
 		// ==========================================
 		fmt.Println("\n  [ Vault API Health ]")
 		client := http.Client{Timeout: 2 * time.Second}
-		resp, err := client.Get("http://127.0.0.1:8200/v1/sys/health")
+		resp, err := client.Get(vaultLocalAPIURL + "/v1/sys/health")
 
 		if err != nil {
 			fmt.Println("  🟡 API is unreachable (Vault might still be booting up).")

--- a/docs/cli-lifecycle-model.md
+++ b/docs/cli-lifecycle-model.md
@@ -147,8 +147,11 @@ Rule for every product package under `cmd/<product>/`:
 	deliberately different (twin org, twin container name) stay as local literals.
 
 `cmd/terraform/defaults.go` is the reference implementation. The same pattern is
-to be applied to the other product packages (`vault`, `consul`, `nomad`,
-`boundary`, ...) as they are revisited.
+now applied across every product package — `terraform`, `vault`, `consul`,
+`nomad`, `observability`, `plus` and `boundary` each own a `defaults.go`. The
+Docker network name is never written as a `"hal-net"` literal in a product
+package; it always comes from `global.HalNetName`. When adding a new product
+package, create its `defaults.go` first and wire every shared value through it.
 
 ## Migration Policy
 

--- a/docs/cli-lifecycle-model.md
+++ b/docs/cli-lifecycle-model.md
@@ -116,6 +116,40 @@ Rules:
 - `<component-id>` maps to stable internal IDs (container/service/resource names used by HAL).
 - Invalid target fails fast and prints allowed target values.
 
+## Single Source of Truth for Shared Values
+
+HAL provisions multi-container product stacks, and the same identity, endpoint,
+credential, image, and path values are consumed by many sibling commands within
+a product package (create, delete, status, twin, agent, api/vcs workflow, saml,
+obs, foundation). Hardcoding those literals per file causes silent configuration
+drift: one command bootstraps `org=hal` while another looks for `org=hal-org`,
+and the stack appears healthy while downstream flows fail. This class of bug is
+expensive to diagnose because nothing errors at the duplication site.
+
+Rule for every product package under `cmd/<product>/`:
+
+1. Each product owns one `defaults.go` file that declares every value shared
+	across more than one file in that package, plus every identity / credential /
+	endpoint / URL flag default — even when currently referenced once — because
+	those are the values users and downstream automation depend on staying stable.
+2. Cobra flag defaults AND their `if !cmd.Flags().Changed(...)` fallback
+	overrides MUST reference the same constant. Never repeat the literal in both
+	the `StringVar(..., "<literal>", ...)` default and the fallback assignment.
+3. Cross-product values (e.g. the Docker network name) live in `internal/global`
+	(`global.HalNetName`, `global.HalNetStaticIP`) and are referenced, never
+	re-declared inside a product package.
+4. Genuinely feature-local values that are used in exactly one file and have no
+	identity/credential/endpoint meaning (e.g. a single workflow's demo project
+	name) may remain inline in that file.
+5. Twin / secondary-instance defaults that intentionally mirror the primary
+	(image, version, encryption password, admin identity) reference the primary
+	constants so an upgrade in one place propagates; only the values that are
+	deliberately different (twin org, twin container name) stay as local literals.
+
+`cmd/terraform/defaults.go` is the reference implementation. The same pattern is
+to be applied to the other product packages (`vault`, `consul`, `nomad`,
+`boundary`, ...) as they are revisited.
+
 ## Migration Policy
 
 - New UX/docs should prefer explicit `update` over `--force`.


### PR DESCRIPTION
## Centralize shared values into per-product `defaults.go` (+ creds fixes)

Eliminates silent configuration drift across the `cmd/` product packages by
giving each product a single `defaults.go` source of truth, and fixes two
teardown/credential bugs surfaced during the sweep.

### What changed
- **`defaults.go` per product** — `terraform`, `vault`, `consul`, `nomad`,
  `observability`, `plus` and `boundary` each own one `defaults.go` declaring
  every container/instance/volume/port/endpoint/credential/image-tag value used
  across the package. Cobra flag defaults and their `Changed()` fallbacks now
  reference the same constant instead of repeating literals.
- **Network name** — no product package writes a `"hal-net"` literal anymore;
  it always comes from `global.HalNetName`.
- **Docs** — `docs/cli-lifecycle-model.md` updated to mark the pattern as
  applied to all products and document the rule for new packages.

### Bug fixes
- **Vault teardown drift** — `vault delete` listed `"hal-mariadb"`, but the real
  container is `"hal-vault-mariadb"`, leaving the DB container orphaned. Fixed.
- **Creds detection drift** — `creds` looked up the Boundary SSH lab and MariaDB
  target by the wrong names (`hal-ssh-target` / `hal-mariadb-target`), so those
  blocks never displayed. Now keyed off the Multipass VM `hal-boundary-ssh` and
  container `hal-boundary-target-mariadb`, in both the terminal output and
  `CollectActiveCredentials()`.
- **Creds** — `creds status` now surfaces the TFE `haladmin` password.

### Validation
- `go build ./...` and `go vet ./...` clean.
- Zero `"hal-net"` literals remain in `cmd/`.

No behavioral change to provisioning beyond the two bug fixes above.