### PR TITLE
Feature/standardized outputs

### DIFF
--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -32,6 +32,12 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
 ### 4. Output Hygiene
 - Use `exec.Command(...).Output()` for read-only container checks when stderr noise from the engine would pollute UI output.
 - Keep user-facing output short, state-oriented, and action-oriented.
+- **Standardized installer-style output (`internal/ui`)**: long-running create/enable flows should use the shared `ui` package instead of ad-hoc `fmt.Println` + emoji.
+  - `ui.Title(...)` prints a persistent header. `ui.Start()` begins a progress flow; each `ui.Step(...)` overwrites the previous line with an animated Braille spinner (single updating line, like a software installer). `ui.Stop()`/`ui.Fail(...)` end the flow.
+  - Non-TTY (piped/MCP) degrades automatically to one plain `→ step` line each; the global `--verbose`/`-v` flag forces the same per-step lines on a TTY.
+  - The "command is done" block uses `ui.Success`/`ui.Section`/`ui.Field`/`ui.Item`/`ui.Hint` for a consistent summary across products.
+  - **Credential placement rule**: command output shows credentials with immediate demo value (e.g. Vault OIDC `alice`/`bob`); operator/admin credentials (e.g. Authentik `akadmin`) live in `hal creds status` and the product's `status`/`-h`, not in the enable summary.
+  - **Pilot**: `hal vault oidc enable/status` is the reference implementation; the Authentik integration (`internal/integrations/authentik.go`) routes its start/wait substeps through `ui.Step`. Roll the same pattern out to other products after review.
 
 ### 5. Local Infrastructure Gotchas
 - Docker volumes cannot be removed while attached containers are running; feature disable flows often need in-container cleanup instead of volume deletion.

--- a/README.md
+++ b/README.md
@@ -488,8 +488,3 @@ Before changing command behavior or UX patterns, read these files in order:
 
 Keep all three in sync when adding or renaming commands.
 
----
-
-## License
-
-This tool was developed on HashiCorp/IBM equipment and is subject to HashiCorp/IBM's intellectual property policies. No independent open-source license has been applied. All rights reserved unless explicitly stated otherwise by HashiCorp/IBM.

--- a/cmd/boundary/create.go
+++ b/cmd/boundary/create.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -38,16 +39,24 @@ var deployCmd = &cobra.Command{
 			return
 		}
 
+		ui.LogoStart("boundary")
+		defer ui.LogoStop()
+		step := func(cols int, format string, args ...any) {
+			ui.LogoStep(format, args...)
+			ui.LogoAdvance(cols)
+		}
+
 		if boundaryUpdate {
-			fmt.Println("♻️  Update requested. Reconciling existing Boundary Control Plane...")
+			step(1, "Reconciling existing Boundary Control Plane (update)")
 			_ = exec.Command(engine, "rm", "-f", boundaryContainer, boundaryBackendContainer).Run()
 		}
 
-		fmt.Printf("🚀 Deploying Boundary %s (with Postgres %s) via %s...\n", boundaryVersion, pgVersion, engine)
+		step(1, "Deploying Boundary %s (Postgres %s)", boundaryVersion, pgVersion)
 
 		global.EnsureNetwork(engine)
 
-		fmt.Printf("⚙️  Provisioning Boundary Control Plane Database (%s:%s)...\n", pgImage, pgVersion)
+		ui.LogoStep("Provisioning Control Plane database")
+		ui.LogoCreep(2 * time.Second)
 		backendArgs := []string{
 			"run", "-d",
 			"--name", boundaryBackendContainer,
@@ -59,6 +68,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		if global.DryRun {
+			ui.LogoStop()
 			fmt.Printf("[DRY RUN] Would execute: %s %s\n", engine, strings.Join(backendArgs, " "))
 			return
 		}
@@ -66,7 +76,7 @@ var deployCmd = &cobra.Command{
 		_ = exec.Command(engine, backendArgs...).Run()
 		time.Sleep(3 * time.Second)
 
-		fmt.Println("⚙️  Booting Boundary Controller & Worker...")
+		step(2, "Booting Boundary Controller & Worker")
 		boundaryArgs := []string{
 			"run", "-d",
 			"--name", boundaryContainer,
@@ -77,7 +87,6 @@ var deployCmd = &cobra.Command{
 		}
 
 		if boundaryJoinConsul {
-			fmt.Println("   🤝 --join-consul detected! Tethering Boundary to the global HAL Consul...")
 			boundaryArgs = append(boundaryArgs, "-e", "CONSUL_HTTP_ADDR=http://hal-consul:8500")
 		}
 
@@ -91,6 +100,7 @@ var deployCmd = &cobra.Command{
 
 		out, err := exec.Command(engine, boundaryArgs...).CombinedOutput()
 		if err != nil {
+			ui.LogoStop()
 			if strings.Contains(string(out), "AlreadyExists") || strings.Contains(string(out), "already in use") {
 				fmt.Println("⚠️  Boundary already exists. Use '--update' to reconcile it.")
 				return
@@ -99,27 +109,28 @@ var deployCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println("⏳ Waiting for Boundary to initialize (this can take 10-15 seconds)...")
+		ui.LogoStep("Waiting for Boundary to initialize")
+		ui.LogoCreep(2 * time.Second)
 
 		if err := waitForService("Boundary", boundaryLocalAPIURL, 30); err != nil {
+			ui.LogoStop()
 			handleDockerFailure(boundaryContainer, engine)
 			return
 		}
 
-		fmt.Println()
-		fmt.Println("✅ Boundary Controller & Worker are up!")
+		ui.LogoStop()
 		global.RefreshHalHealth(engine)
-		fmt.Println("---------------------------------------------------------")
-		fmt.Printf("   🔗 UI Address: %s\n", boundaryUIURL)
-		fmt.Printf("   👤 Login:      %s / %s\n", boundaryAdminUsername, boundaryAdminPassword)
+		ui.Success("Boundary Controller & Worker are up!")
+		ui.Section("Access")
+		ui.Field("UI", boundaryUIURL)
+		ui.Field("Login", fmt.Sprintf("%s / %s", boundaryAdminUsername, boundaryAdminPassword))
 		if boundaryJoinConsul {
-			fmt.Println("   🟢 Tethered:   Global Consul Control Plane")
+			ui.Item("🟢 Tethered to the global Consul Control Plane")
 		}
-		fmt.Println("---------------------------------------------------------")
-		fmt.Println("💡 Next Step: Deploy some targets to connect to!")
-		fmt.Println("   hal boundary mariadb enable")
-		fmt.Println("   hal boundary mariadb enable --with-vault (for dynamic credentials, Vault must be running)")
-		fmt.Println("   hal boundary ssh enable")
+		ui.Section("Next: add targets")
+		ui.Item("hal boundary mariadb enable")
+		ui.Item("hal boundary mariadb enable --with-vault  (dynamic creds; Vault must be running)")
+		ui.Item("hal boundary ssh enable")
 	},
 }
 

--- a/cmd/boundary/ssh.go
+++ b/cmd/boundary/ssh.go
@@ -103,7 +103,7 @@ var sshCmd = &cobra.Command{
 			_ = exec.Command("multipass", "delete", boundarySSHInstance).Run()
 			_ = exec.Command("multipass", "purge").Run()
 
-			vmArgs := []string{"launch", sshUbuntuImage, "--name", boundarySSHInstance, "--cpus", sshVMCPUs, "--mem", sshVMMem}
+			vmArgs := []string{"launch", sshUbuntuImage, "--name", boundarySSHInstance, "--cpus", sshVMCPUs, "--memory", sshVMMem}
 			_, vmErr := exec.Command("multipass", vmArgs...).CombinedOutput()
 
 			if vmErr == nil {

--- a/cmd/consul/create.go
+++ b/cmd/consul/create.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -31,14 +32,18 @@ var deployCmd = &cobra.Command{
 		// 2. Ensure the global grid exists
 		global.EnsureNetwork(engine)
 
+		ui.LogoStart("consul")
+		defer ui.LogoStop()
+
 		if consulUpdate {
 			if global.Debug {
 				fmt.Println("[DEBUG] --update detected. Reconciling existing standalone Consul...")
 			}
+			ui.LogoStep("Reconciling existing Consul (update)")
 			_ = exec.Command(engine, "rm", "-f", consulContainer).Run()
 		}
 
-		fmt.Printf(" Deploying standalone Consul %s via %s...\n", consulVersion, engine)
+		ui.LogoStep("Deploying standalone Consul %s", consulVersion)
 
 		// Command: <engine> run -d --name hal-consul --network hal-net -p 8500:8500 hashicorp/consul:1.15.0 agent -server -ui -node=server-1 -bootstrap-expect=1 -client=0.0.0.0
 		consulArgs := []string{
@@ -51,12 +56,15 @@ var deployCmd = &cobra.Command{
 		}
 
 		if global.DryRun {
+			ui.LogoStop()
 			fmt.Printf("[DRY RUN] Would execute: %s %s\n", engine, strings.Join(consulArgs, " "))
 			return
 		}
 
+		ui.LogoStep("Starting Consul server")
 		out, err := exec.Command(engine, consulArgs...).CombinedOutput()
 		if err != nil {
+			ui.LogoStop()
 			if strings.Contains(string(out), "AlreadyExists") || strings.Contains(string(out), "already in use") {
 				fmt.Println("⚠️  Consul already exists. Use '--update' to reconcile it.")
 				return
@@ -65,11 +73,12 @@ var deployCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println("✅ Standalone Consul Server is up!")
+		ui.LogoStop()
 		global.RefreshHalHealth(engine)
-		fmt.Printf("   🔗 UI Address: %s\n", consulBaseURL)
-		fmt.Println("\n💡 Tip: Use this to test the KV store or learn the API.")
-		fmt.Println("   (For real workloads, use 'hal nomad create --with-consul' instead!)")
+		ui.Success("Standalone Consul server is up!")
+		ui.Section("Access")
+		ui.Field("UI", consulBaseURL)
+		ui.Hint("Test the KV store / API. For real workloads: hal nomad create --with-consul")
 	},
 }
 

--- a/cmd/creds/creds.go
+++ b/cmd/creds/creds.go
@@ -65,7 +65,7 @@ var statusCmd = &cobra.Command{
 			fmt.Println("🌐 Authentik IdP")
 			fmt.Printf("   URL      : http://authentik.localhost:%s/if/admin/\n", integrations.AuthentikHTTPPort)
 			fmt.Println("   Username : akadmin")
-			adminPass := loadAuthentikAdminPassword()
+			adminPass := integrations.LoadAuthentikAdminPassword()
 			if adminPass != "" {
 				fmt.Printf("   Password : %s\n", adminPass)
 			} else {
@@ -230,7 +230,7 @@ func CollectActiveCredentials() (ActiveCredentials, error) {
 			URL:     fmt.Sprintf("http://authentik.localhost:%s/if/admin/", integrations.AuthentikHTTPPort),
 		}
 		entry := CredentialEntry{Name: "akadmin", Username: "akadmin"}
-		if adminPass := loadAuthentikAdminPassword(); adminPass != "" {
+		if adminPass := integrations.LoadAuthentikAdminPassword(); adminPass != "" {
 			entry.Secret = adminPass
 		} else {
 			entry.Note = "see " + integrations.AuthentikEnvPath()
@@ -325,19 +325,4 @@ func vaultAuthMountExists(method string) bool {
 	}
 	_, ok := auths[strings.TrimSuffix(method, "/")+"/"]
 	return ok
-}
-
-// loadAuthentikAdminPassword reads AUTHENTIK_BOOTSTRAP_PASSWORD from ~/.hal/authentik/env.
-func loadAuthentikAdminPassword() string {
-	data, err := os.ReadFile(integrations.AuthentikEnvPath())
-	if err != nil {
-		return ""
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		parts := strings.SplitN(strings.TrimSpace(line), "=", 2)
-		if len(parts) == 2 && parts[0] == "AUTHENTIK_BOOTSTRAP_PASSWORD" {
-			return parts[1]
-		}
-	}
-	return ""
 }

--- a/cmd/nomad/create.go
+++ b/cmd/nomad/create.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -63,13 +64,22 @@ var deployCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf(" Deploying Nomad %s via Multipass (Ubuntu VM)...\n", nomadVersion)
+		ui.LogoStart("nomad")
+		defer ui.LogoStop()
+		step := func(cols int, format string, args ...any) {
+			ui.LogoStep(format, args...)
+			ui.LogoAdvance(cols)
+		}
+
+		step(1, "Deploying Nomad %s via Multipass (Ubuntu VM)", nomadVersion)
 
 		// 1. Launch the VM
-		fmt.Println("📦 Provisioning Ubuntu VM (This takes a few seconds)...")
-		launchArgs := []string{"launch", nomadUbuntuImage, "--name", nomadInstance, "--cpus", nomadCPUs, "--mem", nomadMem}
+		ui.LogoStep("Provisioning Ubuntu VM")
+		ui.LogoCreep(3 * time.Second)
+		launchArgs := []string{"launch", nomadUbuntuImage, "--name", nomadInstance, "--cpus", nomadCPUs, "--memory", nomadMem}
 		out, err := exec.Command("multipass", launchArgs...).CombinedOutput()
 		if err != nil {
+			ui.LogoStop()
 			if strings.Contains(string(out), "already exists") {
 				fmt.Println("⚠️  VM 'hal-nomad' already exists. Use '--update' to reconcile it.")
 				return
@@ -79,11 +89,8 @@ var deployCmd = &cobra.Command{
 		}
 
 		// 2. Build the dynamic installation script
-		fmt.Println("🔧 Installing binaries and configuring systemd services...")
-
 		joinConsulStr := "false"
 		if nomadJoinConsul {
-			fmt.Println("   🤝 --join-consul detected! Tethering Nomad to the global HAL Consul...")
 			joinConsulStr = "true"
 		}
 
@@ -120,7 +127,10 @@ var deployCmd = &cobra.Command{
 		`, nomadVersion, nomadVersion, joinConsulStr)
 
 		execArgs := []string{"exec", nomadInstance, "--", "bash", "-c", installScript}
+		ui.LogoStep("Installing Nomad + configuring systemd services")
+		ui.LogoCreep(3 * time.Second)
 		if out, err := exec.Command("multipass", execArgs...).CombinedOutput(); err != nil {
+			ui.LogoStop()
 			fmt.Printf("❌ Failed to configure VM: %v\nOutput: %s\n", err, string(out))
 			return
 		}
@@ -130,17 +140,20 @@ var deployCmd = &cobra.Command{
 		ip := extractMultipassIP(string(ipOut))
 
 		// 4. THE HEALTH CHECK PHASE
-		fmt.Println("⏳ Waiting for Nomad to become healthy...")
+		ui.LogoStep("Waiting for Nomad to become healthy")
+		ui.LogoCreep(3 * time.Second)
 		if err := waitForService("Nomad", fmt.Sprintf("http://%s:%d/v1/status/leader", ip, nomadHTTPPort), 45); err != nil {
+			ui.LogoStop()
 			handleServiceFailure("nomad")
 			return
 		}
 
-		fmt.Println("\n✅ Environment is fully verified and ready!")
-		fmt.Printf("   🔗 Nomad UI:  http://%s:%d\n", ip, nomadHTTPPort)
-
+		ui.LogoStop()
+		ui.Success("Nomad is up and ready!")
+		ui.Section("Endpoints")
+		ui.Field("Nomad UI", fmt.Sprintf("http://%s:%d", ip, nomadHTTPPort))
 		if nomadJoinConsul {
-			fmt.Println("   🟢 Nomad is successfully tethered to the global Consul Control Plane!")
+			ui.Item("🟢 Tethered to the global Consul Control Plane")
 		}
 	},
 }

--- a/cmd/observability/create.go
+++ b/cmd/observability/create.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"fmt"
 	"hal/internal/global"
+	"hal/internal/ui"
 	"net/http"
 	"os"
 	"os/exec"
@@ -67,9 +68,19 @@ var deployCmd = &cobra.Command{
 			return
 		}
 
+		ui.LogoStart("observability")
+		defer ui.LogoStop()
+		step := func(cols int, format string, args ...any) {
+			ui.LogoStep(format, args...)
+			ui.LogoAdvance(cols)
+		}
+
+		// Anchor the fill low, then creep it forward across the (possibly long) pull.
+		step(1, "Pulling observability images (Prometheus, Loki, Promtail, Grafana)")
+		ui.LogoCreep(1500 * time.Millisecond)
+
 		global.EnsureNetwork(engine)
 
-		fmt.Println("📥 Pulling Observability images (this might take a minute)...")
 		images := []string{
 			promImage + ":" + promVer,
 			lokiImage + ":" + lokiVer,
@@ -82,7 +93,7 @@ var deployCmd = &cobra.Command{
 			_ = pullCmd.Run() // Silent pull
 		}
 
-		fmt.Println("⚙️  Generating PLG stack configurations...")
+		step(6, "Generating PLG stack configuration")
 		homeDir, _ := os.UserHomeDir()
 		configDir := filepath.Join(homeDir, ".hal", "obs")
 		targetsDir := filepath.Join(configDir, "targets")
@@ -94,10 +105,12 @@ var deployCmd = &cobra.Command{
 		if promConfigPath != "" {
 			src, err := os.ReadFile(promConfigPath)
 			if err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ Cannot read --prom-config-path %q: %v\n", promConfigPath, err)
 				return
 			}
 			if err := os.WriteFile(filepath.Join(configDir, "prometheus.yml"), src, 0644); err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ Failed to write prometheus.yml: %v\n", err)
 				return
 			}
@@ -216,9 +229,10 @@ providers:
 
 		// Helper function to boot containers and catch errors
 		bootContainer := func(name string, args ...string) {
-			fmt.Printf("⚙️  Booting %s...\n", name)
+			step(6, "Booting %s", name)
 			out, err := exec.Command(engine, args...).CombinedOutput()
 			if err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ Failed to boot %s!\n", name)
 				fmt.Printf("   Error: %v\n", err)
 				fmt.Printf("   Docker Output: %s\n", string(out))
@@ -231,21 +245,22 @@ providers:
 		bootContainer("Promtail", "run", "-d", "--name", obsPromtailContainer, "--network", global.HalNetName, "-v", "hal-vault-logs:/vault/logs:ro", "-v", filepath.Join(configDir, "promtail-config.yaml")+":/etc/promtail/config.yml", promtailImage+":"+promtailVer, "-config.file=/etc/promtail/config.yml")
 		bootContainer("Grafana", "run", "-d", "--name", obsGrafanaContainer, "--network", global.HalNetName, "-p", "3000:3000", "-v", filepath.Join(configDir, "datasources.yml")+":/etc/grafana/provisioning/datasources/datasources.yml", "-v", filepath.Join(configDir, "dashboards.yml")+":/etc/grafana/provisioning/dashboards/dashboards.yml", "-v", dashboardsDir+":/var/lib/grafana/dashboards", "-e", "GF_AUTH_ANONYMOUS_ENABLED=true", "-e", "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin", grafanaImage+":"+grafanaVer)
 
-		fmt.Println("⏳ Waiting for Prometheus, Loki, and Grafana health checks...")
+		ui.LogoStep("Waiting for Prometheus, Loki, Grafana to become healthy")
+		ui.LogoCreep(1500 * time.Millisecond)
 		if err := waitForObsHealth(engine); err != nil {
+			ui.LogoStop()
 			fmt.Printf("⚠️  Stack started but health checks are not fully ready yet: %v\n", err)
 			fmt.Println("   You can still check logs with: hal obs status")
 			return
 		}
 
-		fmt.Println()
-		fmt.Println("✅ Observability Stack Deployed Successfully!")
+		ui.LogoStop()
 		global.RefreshHalHealth(engine)
-		fmt.Println("---------------------------------------------------------")
-		fmt.Printf("🔗 Grafana:    %s (Auto-logged in as Admin)\n", obsGrafanaURL)
-		fmt.Printf("🔗 Prometheus: %s\n", obsPrometheusURL)
-		fmt.Printf("🔗 Loki API:   %s\n", obsLokiReadyURL)
-		fmt.Println("---------------------------------------------------------")
+		ui.Success("Observability stack deployed!")
+		ui.Section("Endpoints")
+		ui.Field("Grafana", fmt.Sprintf("%s  (auto-login as Admin)", obsGrafanaURL))
+		ui.Field("Prometheus", obsPrometheusURL)
+		ui.Field("Loki API", obsLokiReadyURL)
 
 		if obsJobName != "" {
 			configPath := filepath.Join(filepath.Join(homeDir, ".hal", "obs"), "prometheus.yml")
@@ -290,21 +305,18 @@ func waitForObsHealth(engine string) error {
 		grafanaReady := probeHTTP("http://127.0.0.1:3000/api/health")
 		allReady := promReady && lokiReady && grafanaReady
 
-		fmt.Printf("\r   readiness: Prometheus %s | Loki %s | Grafana %s   ", readinessLabel(promReady), readinessLabel(lokiReady), readinessLabel(grafanaReady))
+		ui.LogoStep("Health: Prometheus %s · Loki %s · Grafana %s", readinessLabel(promReady), readinessLabel(lokiReady), readinessLabel(grafanaReady))
 		if allReady {
-			fmt.Print("\n")
 			return nil
 		}
 
 		exitedContainer, stateErr := firstNonRunningObsContainer(engine)
 		if stateErr == nil && exitedContainer != "" {
-			fmt.Print("\n")
 			return fmt.Errorf("%s is not running", exitedContainer)
 		}
 
 		select {
 		case <-timeout:
-			fmt.Print("\n")
 			return fmt.Errorf("timeout while waiting for endpoints to report ready")
 		case <-ticker.C:
 		}

--- a/cmd/plus/create.go
+++ b/cmd/plus/create.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -69,33 +70,45 @@ var createCmd = &cobra.Command{
 			return
 		}
 
+		ui.LogoStart("plus")
+		defer ui.LogoStop()
+
+		ui.LogoStep("Preparing Ollama model %s", runtimeConfig.RuntimeModel)
 		if err := reconcileOllamaModel(runtimeConfig); err != nil {
+			ui.LogoStop()
 			fmt.Printf("❌ Failed to prepare Ollama model '%s': %v\n", runtimeConfig.RuntimeModel, err)
 			fmt.Printf("   💡 Ensure Ollama is installed, running, and reachable at %s.\n", ollamaHostURL)
 			return
 		}
 
+		ui.LogoStep("Verifying Ollama model")
 		ok, err := ollamaModelAvailable(ollamaHostURL, runtimeConfig.RuntimeModel)
 		if err != nil {
+			ui.LogoStop()
 			fmt.Printf("❌ Ollama preflight failed at %s: %v\n", ollamaHostURL, err)
 			fmt.Printf("   💡 Ensure Ollama is running on host and reachable before 'hal plus create'.\n")
 			return
 		}
 		if !ok {
+			ui.LogoStop()
 			fmt.Printf("❌ Ollama model '%s' was not found at %s after reconciliation\n", runtimeConfig.RuntimeModel, ollamaHostURL)
 			fmt.Printf("   💡 Check the configured model source or Modelfile and retry 'hal plus create'.\n")
 			return
 		}
 
 		if qdrantEnabled {
+			ui.LogoStep("Preparing embedding model %s", embedModel)
 			if err := ensureEmbedModel(embedModel); err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ Failed to prepare embedding model '%s': %v\n", embedModel, err)
 				fmt.Printf("   💡 Ensure Ollama is reachable at %s, or rerun with --rag local.\n", ollamaHostURL)
 				return
 			}
 		}
 
+		ui.LogoStep("Checking HAL MCP image")
 		if !imageExists(engine, mcpImage) {
+			ui.LogoStop()
 			fmt.Printf("❌ Required HAL MCP image not found locally: %s\n", mcpImage)
 			fmt.Println("   💡 Run 'hal mcp create --http' first, then retry 'hal plus create'.")
 			return
@@ -104,40 +117,51 @@ var createCmd = &cobra.Command{
 		global.EnsureNetwork(engine)
 
 		if plusPull {
+			ui.LogoStep("Pulling HAL MCP + Plus images")
 			if err := pullImage(engine, mcpImage); err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ %v\n", err)
 				return
 			}
 			if err := pullImage(engine, plusImage); err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ %v\n", err)
 				return
 			}
 		} else if !imageExists(engine, plusImage) {
+			ui.LogoStep("Pulling HAL Plus image")
 			if out, err := exec.Command(engine, "pull", plusImage).CombinedOutput(); err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ Failed to pull HAL Plus image %s: %v\n%s\n", plusImage, err, string(out))
 				return
 			}
 		}
 
+		ui.LogoStep("Starting HAL MCP")
 		if err := ensureRunningContainer(engine, halMCPContainerName, []string{"--network", global.HalNetName, mcpImage}); err != nil {
+			ui.LogoStop()
 			fmt.Printf("❌ %v\n", err)
 			return
 		}
 
 		if qdrantEnabled {
+			ui.LogoStep("Starting Qdrant")
 			if plusPull {
 				if err := pullImage(engine, qdrantImage); err != nil {
+					ui.LogoStop()
 					fmt.Printf("❌ %v\n", err)
 					return
 				}
 			} else if !imageExists(engine, qdrantImage) {
 				if out, err := exec.Command(engine, "pull", qdrantImage).CombinedOutput(); err != nil {
+					ui.LogoStop()
 					fmt.Printf("❌ Failed to pull pre-seeded HAL Plus Qdrant image %s: %v\n%s\n", qdrantImage, err, string(out))
 					fmt.Println("   💡 Rerun with '--rag local' to use the in-process retrieval backend instead.")
 					return
 				}
 			}
 			if err := ensureRunningContainer(engine, halQdrantContainerName, []string{"--network", global.HalNetName, qdrantImage}); err != nil {
+				ui.LogoStop()
 				fmt.Printf("❌ %v\n", err)
 				return
 			}
@@ -167,28 +191,32 @@ var createCmd = &cobra.Command{
 			}
 			plusArgs = append(plusArgs[:len(plusArgs)-1], append(qdrantEnv, plusArgs[len(plusArgs)-1])...)
 		}
+		ui.LogoStep("Starting HAL Plus")
 		if err := ensureRunningContainer(engine, halPlusContainerName, plusArgs); err != nil {
+			ui.LogoStop()
 			fmt.Printf("❌ %v\n", err)
 			return
 		}
 
-		fmt.Println("✅ HAL Plus runtime created successfully.")
+		ui.LogoStop()
 		global.RefreshHalHealth(engine)
-		fmt.Printf("🐳 Engine:       %s\n", engine)
-		fmt.Printf("🐳 HAL Plus:     %s\n", plusImage)
-		fmt.Printf("🐳 HAL MCP:      %s\n", mcpImage)
+		ui.Success("HAL Plus runtime created!")
+		ui.Section("Runtime")
+		ui.Field("Engine", engine)
+		ui.Field("HAL Plus", plusImage)
+		ui.Field("HAL MCP", mcpImage)
 		if qdrantEnabled {
-			fmt.Printf("🐳 HAL Qdrant:   %s\n", qdrantImage)
-			fmt.Printf("🔎 RAG backend:  qdrant (embed model: %s)\n", embedModel)
+			ui.Field("Qdrant", qdrantImage)
+			ui.Field("RAG", fmt.Sprintf("qdrant (embed model: %s)", embedModel))
 		} else {
-			fmt.Println("🔎 RAG backend:  local (in-process)")
+			ui.Field("RAG", "local (in-process)")
 		}
-		fmt.Printf("🧠 Ollama model: %s\n", runtimeConfig.RuntimeModel)
+		ui.Field("Model", runtimeConfig.RuntimeModel)
 		if runtimeConfig.RequestedModel != runtimeConfig.RuntimeModel {
-			fmt.Printf("🧩 Model preset: %s\n", runtimeConfig.RequestedModel)
+			ui.Field("Preset", runtimeConfig.RequestedModel)
 		}
-		fmt.Printf("🧠 Ollama host:  %s\n", ollamaHostURL)
-		fmt.Printf("🌐 UI URL:       http://%s:%d\n", plusUIHostname, plusPort)
-		fmt.Println("💡 Run 'hal plus status' to verify container and endpoint health.")
+		ui.Field("Ollama", ollamaHostURL)
+		ui.Field("UI", fmt.Sprintf("http://%s:%d", plusUIHostname, plusPort))
+		ui.Hint("hal plus status  to verify container and endpoint health")
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"hal/cmd/vault"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -45,6 +46,7 @@ func init() {
 	// Point the flags directly to the memory addresses of your global variables
 	rootCmd.PersistentFlags().BoolVarP(&global.Debug, "debug", "", false, "Enable debug output")
 	rootCmd.PersistentFlags().BoolVarP(&global.DryRun, "dry-run", "", false, "Simulate the execution without changing state")
+	rootCmd.PersistentFlags().BoolVarP(&ui.Verbose, "verbose", "", false, "Show every sub-step instead of a single collapsing progress line")
 	rootCmd.PersistentFlags().StringVar(&global.HalNetSubnet, "network-subnet", "", "Subnet for the hal-net Docker network on first creation (e.g. 10.89.3.0/24)")
 
 	rootCmd.AddCommand(vault.Cmd)

--- a/cmd/terraform/create.go
+++ b/cmd/terraform/create.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -108,31 +109,44 @@ var deployCmd = &cobra.Command{
 		uiURL := tfePrimaryBaseURL
 
 		// 2. FORGE THE TLS CERTIFICATES
-		fmt.Println("🔐 Forging local TLS certificates for TFE...")
+		ui.LogoStart("terraform")
+		defer ui.LogoStop()
+		// Non-fatal warnings raised mid-deploy are collected and printed after the
+		// animation stops, so they are not eaten by the logo redraw.
+		var warnings []string
+		// step updates the activity caption and nudges the logo fill by a fixed
+		// number of columns, so each quick step maps to 1–2 columns. The long boot
+		// wait below uses ui.LogoCreep so it keeps inching instead of stalling.
+		step := func(cols int, format string, args ...any) {
+			ui.LogoStep(format, args...)
+			ui.LogoAdvance(cols)
+		}
+
+		step(1, "Forging local TLS certificates")
 		homeDir, _ := os.UserHomeDir()
 		certDir := filepath.Join(homeDir, halStateDirName, tfeCertsDirName)
 
 		if tfeUpdate {
-			fmt.Println("♻️  Update requested. Reconciling existing TFE resources...")
+			step(1, "Reconciling existing TFE resources (update)")
 			// 🎯 Included the proxy in the teardown list
 			_ = exec.Command(engine, "rm", "-f", tfeCoreContainer, tfeProxyContainer, tfeDBContainer, tfeRedisContainer, tfeMinioContainer).Run()
 			_ = os.Remove(filepath.Join(certDir, "cert.pem"))
 			_ = os.Remove(filepath.Join(certDir, "key.pem"))
 		}
 		if err := ensureCerts(certDir); err != nil {
-			fmt.Printf("❌ Failed to generate TLS certificates: %v\n", err)
+			ui.Fail("Failed to generate TLS certificates: %v", err)
 			return
 		}
 
-		fmt.Printf("🚀 Deploying Terraform Enterprise %s (PG: %s, Redis: %s) via %s...\n", tfeVersion, pgVersion, redisVersion, engine)
+		step(1, "Deploying Terraform Enterprise %s (PG %s, Redis %s)", tfeVersion, pgVersion, redisVersion)
 
 		// 3. SECURE REGISTRY AUTHENTICATION (only for the default HashiCorp registry)
 		if strings.Contains(tfeImage, "images.releases.hashicorp.com") {
-			fmt.Println("🔑 Authenticating with HashiCorp private image registry...")
+			step(1, "Authenticating with HashiCorp image registry")
 			loginCmd := exec.Command(engine, "login", "images.releases.hashicorp.com", "-u", "terraform", "--password-stdin")
 			loginCmd.Stdin = strings.NewReader(license)
 			if err := loginCmd.Run(); err != nil {
-				fmt.Println("❌ Error: Failed to authenticate with images.releases.hashicorp.com.")
+				ui.Fail("Failed to authenticate with images.releases.hashicorp.com")
 				return
 			}
 		}
@@ -143,20 +157,20 @@ var deployCmd = &cobra.Command{
 		proxyInternalIP := global.HalNetStaticIP(engine, tfePrimaryProxyHostNum)
 
 		// 5. Deploy PostgreSQL
-		fmt.Printf("⚙️  Provisioning TFE PostgreSQL Database...\n")
+		step(1, "Provisioning PostgreSQL database")
 		_ = exec.Command(engine, "run", "-d", "--name", tfeDBContainer, "--network", global.HalNetName,
 			"-v", tfeDBVolume+":/var/lib/postgresql/data",
 			"-e", "POSTGRES_USER="+tfeDBUser, "-e", "POSTGRES_PASSWORD="+tfeDBPassword, "-e", "POSTGRES_DB="+tfeDBName,
 			fmt.Sprintf("%s:%s", pgImage, pgVersion)).Run()
 
 		// 6. Deploy Redis
-		fmt.Printf("⚙️  Provisioning TFE Redis Cache...\n")
+		step(1, "Provisioning Redis cache")
 		_ = exec.Command(engine, "run", "-d", "--name", tfeRedisContainer, "--network", global.HalNetName,
 			"-v", tfeRedisVolume+":/data",
 			fmt.Sprintf("%s:%s", redisImage, redisVersion)).Run()
 
 		// 7. Deploy MinIO (S3 Mock)
-		fmt.Println("⚙️  Provisioning TFE Object Storage (MinIO)...")
+		step(1, "Provisioning object storage (MinIO)")
 		_ = exec.Command(engine, "run", "-d", "--name", tfeMinioContainer, "--network", global.HalNetName,
 			"-p", fmt.Sprintf("%d:9000", minioAPIPort), "-p", fmt.Sprintf("%d:9001", minioConsolePort),
 			"-v", tfeMinioVolume+":/data",
@@ -167,7 +181,7 @@ var deployCmd = &cobra.Command{
 		_ = exec.Command(engine, "exec", tfeMinioContainer, "sh", "-c", "mkdir -p /data/"+tfeS3Bucket).Run()
 
 		// 8. Deploy TFE Core (NO EXPOSED HOST PORTS!)
-		fmt.Println("⚙️  Booting TFE Core Application (This requires heavy compute)...")
+		step(2, "Booting TFE core application (heavy compute)")
 		tfeArgs := []string{
 			"run", "-d",
 			"--name", tfeCoreContainer,
@@ -228,7 +242,7 @@ var deployCmd = &cobra.Command{
 
 		out, err := exec.Command(engine, tfeArgs...).CombinedOutput()
 		if err != nil {
-			fmt.Printf("❌ Failed to start TFE: %s\n", string(out))
+			ui.Fail("Failed to start TFE: %s", string(out))
 			return
 		}
 
@@ -245,7 +259,7 @@ var deployCmd = &cobra.Command{
 			"-lc",
 			"cp /etc/ssl/tfe/cert.pem /usr/local/share/ca-certificates/tfe-localhost.crt && update-ca-certificates 2>&1",
 		).CombinedOutput(); trustErr != nil {
-			fmt.Printf("⚠️  Could not refresh TFE trust store automatically: %s\n", strings.TrimSpace(string(trustOut)))
+			warnings = append(warnings, fmt.Sprintf("⚠️  Could not refresh TFE trust store automatically: %s", strings.TrimSpace(string(trustOut))))
 		}
 
 		// TFE 1.2.0 on this local Podman flow generates an agent-run task-worker config that
@@ -261,11 +275,11 @@ var deployCmd = &cobra.Command{
 			"-lc",
 			"test -f /run/terraform-enterprise/task-worker/config.hcl && sed -i 's/readonly = \"true\"/readonly = \"false\"/' /run/terraform-enterprise/task-worker/config.hcl 2>&1 || true",
 		).CombinedOutput(); taskWorkerErr != nil {
-			fmt.Printf("⚠️  Could not patch TFE task-worker cache mount automatically: %s\n", strings.TrimSpace(string(taskWorkerOut)))
+			warnings = append(warnings, fmt.Sprintf("⚠️  Could not patch TFE task-worker cache mount automatically: %s", strings.TrimSpace(string(taskWorkerOut))))
 		}
 
 		// 8.5 Deploy the Magic Redirect Fixer (AFTER TFE BOOTS!)
-		fmt.Println("⚙️  Deploying TFE Ingress Proxy (The Redirect Fixer)...")
+		step(1, "Deploying ingress proxy (redirect fixer)")
 		nginxConfig := `events {}
 http {
 	server {
@@ -337,22 +351,20 @@ http {
 			fmt.Sprintf("%s:%s", tfeProxyImage, tfeProxyNginxTag)).Run()
 
 		// 9. THE HEALTH CHECK PHASE
-		fmt.Println("⏳ Waiting for TFE to initialize (WARNING: This can take 3-5 minutes!)...")
+		ui.LogoStep("Waiting for TFE to initialize (this can take a few minutes)")
+		// Long step: creep one column every few seconds so the logo keeps moving
+		// instead of stalling. Tuned so a typical ~1 min boot shows clear motion;
+		// slower boots fill toward the cap and then hold until readiness.
+		ui.LogoCreep(6 * time.Second)
 
 		// This will naturally hit the Proxy, which routes to TFE
 		if err := waitForService("TFE", healthURL, 60); err != nil {
+			ui.LogoStop()
 			handleDockerFailure(tfeCoreContainer, engine)
 			return
 		}
 
-		fmt.Printf("\n✅ Terraform Enterprise %s is UP!\n", tfeVersion)
-		global.RefreshHalHealth(engine)
-		fmt.Println("---------------------------------------------------------")
-		fmt.Printf("🔗 UI Address:   %s\n", uiURL)
-		fmt.Printf("🗂️  MinIO API:    http://127.0.0.1:%d\n", minioAPIPort)
-		fmt.Printf("🧭 MinIO Console: http://127.0.0.1:%d\n", minioConsolePort)
-		fmt.Printf("👤 Admin User:   %s\n", deployTFEAdminUser)
-		fmt.Printf("🔑 Admin Pass:   %s\n", deployTFEAdminPass)
+		step(1, "Bootstrapping TFE foundation (org, project, admin token)")
 		token, _, err := ensureTFEFoundation(engine, tfeFoundationConfig{
 			BaseURL:       uiURL,
 			OrgName:       deployTFEOrg,
@@ -361,19 +373,36 @@ http {
 			AdminEmail:    deployTFEAdminEmail,
 			AdminPassword: deployTFEAdminPass,
 		})
+
+		ui.LogoStop()
+		global.RefreshHalHealth(engine)
+		for _, w := range warnings {
+			fmt.Println(w)
+		}
+
+		ui.Success("Terraform Enterprise %s is UP!", tfeVersion)
+		ui.Section("Endpoints")
+		ui.Field("UI", uiURL)
+		ui.Field("MinIO API", fmt.Sprintf("http://127.0.0.1:%d", minioAPIPort))
+		ui.Field("MinIO UI", fmt.Sprintf("http://127.0.0.1:%d", minioConsolePort))
+		ui.Section("Admin")
+		ui.Field("User", deployTFEAdminUser)
+		ui.Field("Password", deployTFEAdminPass)
+
 		if err != nil {
-			fmt.Printf("⚠️  TFE foundation bootstrap incomplete: %v\n", err)
-			fmt.Println("   💡 HAL could not mint a usable API token automatically from this TFE instance.")
+			ui.Section("Foundation")
+			ui.Item("⚠️  Bootstrap incomplete: %v", err)
+			ui.Item("HAL could not mint a usable API token automatically from this TFE instance.")
 		} else {
-			fmt.Println("✅ TFE foundation ready: admin token + org/project are configured.")
+			ui.Section("Foundation")
+			ui.Item("✅ Admin token + org/project configured")
 			if token != "" {
-				fmt.Printf("   📄 Token cache: ~/%s/%s\n", halStateDirName, tfeAPITokenFileName)
+				ui.Item("Token cache: ~/%s/%s", halStateDirName, tfeAPITokenFileName)
 			}
 		}
-		fmt.Println("⚠️  Note:        Accept the browser warning for the self-signed certificate.")
-		fmt.Println("\n💡 Next Step:")
-		fmt.Println("   Run 'hal terraform vcs-workflow enable' to bootstrap org/project/workspace wiring.")
-		fmt.Println("---------------------------------------------------------")
+
+		ui.Item("⚠️  Accept the browser warning for the self-signed certificate.")
+		ui.Hint("Next: hal terraform vcs-workflow enable  (org/project/workspace wiring)")
 
 		if target == tfeTargetBoth {
 			fmt.Println("\n🔁 Target includes twin. Continuing with twin Terraform Enterprise deployment...")

--- a/cmd/vault/create.go
+++ b/cmd/vault/create.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -97,13 +98,15 @@ var deployCmd = &cobra.Command{
 			imageRepo = vaultImage
 		}
 
-		fmt.Printf("🚀 Deploying Vault %s (%s) via %s...\n", actualVersion, strings.ToUpper(vaultEdition), engine)
+		ui.LogoStart("vault", 4)
+		defer ui.LogoStop()
+		ui.LogoStep("Deploying Vault %s (%s) via %s", actualVersion, strings.ToUpper(vaultEdition), engine)
 
 		// 1. Ensure the global HAL network exists
 		global.EnsureNetwork(engine)
 
 		// Correction des permissions du volume d'audit pour l'utilisateur Vault (UID 100)
-		fmt.Println("⚙️  Preparing shared volume permissions...")
+		ui.LogoStep("Preparing shared volume permissions")
 		helperRef := vaultHelperImage + ":" + vaultHelperTag
 		_ = exec.Command(engine, "run", "--rm", "-v", vaultLogsVolume+":/vault/logs", helperRef, "chown", "-R", "100:1000", "/vault/logs").Run()
 		_ = exec.Command(engine, "run", "--rm", "-v", vaultPluginsVolume+":/vault/plugins", helperRef, "sh", "-c", "mkdir -p /vault/plugins && chown -R 100:1000 /vault/plugins").Run()
@@ -132,13 +135,13 @@ var deployCmd = &cobra.Command{
 
 		// Inject the Enterprise License (we already know it exists thanks to the pre-flight check)
 		if vaultEdition == "ent" || vaultEdition == "enterprise" {
-			fmt.Println("   🔐 Injecting VAULT_LICENSE into container...")
+			ui.LogoStep("Injecting VAULT_LICENSE into container")
 			vaultArgs = append(vaultArgs, "-e", fmt.Sprintf("VAULT_LICENSE=%s", os.Getenv("VAULT_LICENSE")))
 		}
 
 		// Inject the Consul Tether
 		if vaultJoinConsul {
-			fmt.Println("   🤝 --join-consul detected! Tethering Vault to the global HAL Consul...")
+			ui.LogoStep("Tethering Vault to the global HAL Consul")
 			vaultArgs = append(vaultArgs, "-e", "CONSUL_HTTP_ADDR=http://hal-consul:8500")
 		}
 
@@ -149,12 +152,15 @@ var deployCmd = &cobra.Command{
 		)
 
 		if global.DryRun {
+			ui.LogoStop()
 			fmt.Printf("[DRY RUN] Would execute: %s %s\n", engine, strings.Join(vaultArgs, " "))
 			return
 		}
 
+		ui.LogoStep("Starting Vault container")
 		out, err := exec.Command(engine, vaultArgs...).CombinedOutput()
 		if err != nil {
+			ui.LogoStop()
 			if strings.Contains(string(out), "AlreadyExists") || strings.Contains(string(out), "already in use") {
 				fmt.Println("⚠️  Vault already exists. Use '--update' to reconcile it.")
 				return
@@ -164,26 +170,29 @@ var deployCmd = &cobra.Command{
 		}
 
 		// 3. THE HEALTH CHECK PHASE
-		fmt.Println("⏳ Waiting for Vault to initialize...")
+		ui.LogoStep("Waiting for Vault to initialize")
 
 		if err := waitForService("Vault", vaultHealthURL, 30); err != nil {
+			ui.LogoStop()
 			handleDockerFailure(vaultContainer, engine)
 			return
 		}
 
-		fmt.Println("✅ Vault is up and running in Dev mode!")
+		ui.LogoStop()
 		global.RefreshHalHealth(engine)
-		fmt.Printf("   🏗️  Edition: %s\n", strings.ToUpper(vaultEdition))
-		fmt.Printf("   🔗 UI Address: %s\n", vaultPublicURL)
-		fmt.Printf("   🔑 Root Token: %s\n", vaultRootToken)
+		ui.Success("Vault is up and running in Dev mode!")
+		ui.Section("Connection")
+		ui.Field("Edition", strings.ToUpper(vaultEdition))
+		ui.Field("UI", vaultPublicURL)
+		ui.Field("Token", vaultRootToken)
 
 		if vaultJoinConsul {
-			fmt.Println("   🟢 Vault is successfully tethered to the global Consul Control Plane!")
+			ui.Item("🟢 Tethered to the global Consul Control Plane")
 		}
 
-		fmt.Println("\n💡 Tip: Export your environment variables to use your local CLI:")
-		fmt.Printf("   export VAULT_ADDR='%s'\n", vaultPublicURL)
-		fmt.Printf("   export VAULT_TOKEN='%s'\n", vaultRootToken)
+		ui.Section("Use your local CLI")
+		ui.Item("export VAULT_ADDR='%s'", vaultPublicURL)
+		ui.Item("export VAULT_TOKEN='%s'", vaultRootToken)
 	},
 }
 

--- a/cmd/vault/oidc.go
+++ b/cmd/vault/oidc.go
@@ -6,6 +6,7 @@ import (
 
 	"hal/internal/global"
 	"hal/internal/integrations"
+	"hal/internal/ui"
 
 	vault "github.com/hashicorp/vault/api"
 	"github.com/spf13/cobra"
@@ -44,6 +45,12 @@ Actions:
 Demo users created in Authentik:
   alice / password  → group: admin  → Vault policy: admin (all paths)
   bob   / password  → group: user-ro → Vault policy: user-ro (kv-oidc/team1 read)
+
+Authentik admin (for managing the IdP itself):
+  Admin UI : http://authentik.localhost:9100/if/admin/
+  Username : akadmin
+  Password : run 'hal vault oidc status' or 'hal creds status' to reveal it
+  Reset    : docker exec hal-authentik-server ak changepassword akadmin
 
 Flags:
   --scim   [Vault Enterprise] Also wire SCIM provisioning from Authentik to Vault
@@ -170,6 +177,20 @@ func runOIDCStatus(engine string, client *vault.Client, vaultErr error) {
 	fmt.Printf("  %s Vault KV sandbox  : %s/\n", icon(kvMounted), oidcKVMount)
 	fmt.Println()
 
+	// Authentik admin reference — useful for managing the IdP itself.
+	// The demo logins (alice/bob) belong to the enable summary; this block is
+	// the operator-facing admin reference and also lives in 'hal creds status'.
+	fmt.Println("🔑 Authentik admin (manage the IdP):")
+	fmt.Printf("   Admin UI : %s/if/admin/\n", integrations.AuthentikAdminURL())
+	fmt.Println("   Username : akadmin")
+	if pw := integrations.LoadAuthentikAdminPassword(); pw != "" {
+		fmt.Printf("   Password : %s\n", pw)
+	} else {
+		fmt.Printf("   Password : (see %s)\n", integrations.AuthentikEnvPath())
+	}
+	fmt.Println("   Reset    : docker exec hal-authentik-server ak changepassword akadmin")
+	fmt.Println()
+
 	fmt.Println("💡 Next Step:")
 	akt := integrations.IsAuthentikRunning(engine)
 	switch {
@@ -177,7 +198,6 @@ func runOIDCStatus(engine string, client *vault.Client, vaultErr error) {
 		fmt.Println("   hal vault oidc enable")
 	case akt && authMounted:
 		fmt.Println("   vault login -method=oidc")
-		fmt.Printf("   Authentik UI: %s/if/admin/\n", integrations.AuthentikAdminURL())
 	default:
 		fmt.Println("   Environment partially degraded — run: hal vault oidc update")
 	}
@@ -196,8 +216,7 @@ func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
 		return
 	}
 
-	fmt.Println("🔐 hal vault oidc — deploying Authentik IdP + Vault OIDC")
-	fmt.Println()
+	ui.Title("hal vault oidc — deploying Authentik IdP + Vault OIDC")
 
 	// 1. Load or generate Authentik secrets
 	secrets, err := integrations.LoadOrCreateAuthentikSecrets()
@@ -206,19 +225,23 @@ func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
 		return
 	}
 
+	ui.Start()
+	fail := func(format string, args ...any) {
+		ui.Fail(format, args...)
+	}
+
 	// 2. Start Authentik if not already up
 	firstBoot := false
 	if integrations.IsAuthentikRunning(engine) {
-		fmt.Println("  ✅ Authentik stack already running — skipping start")
+		ui.Step("Authentik stack already running — skipping start")
 	} else {
 		firstBoot = true
-		fmt.Println("  Starting Authentik stack...")
 		if err := integrations.StartAuthentikStack(engine, oidcAuthentikImage, oidcAuthentikTag, secrets); err != nil {
-			fmt.Printf("❌ %v\n", err)
+			fail("%v", err)
 			return
 		}
 		if err := integrations.WaitAuthentikHealthy(); err != nil {
-			fmt.Printf("❌ %v\n", err)
+			fail("%v", err)
 			return
 		}
 	}
@@ -228,7 +251,7 @@ func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
 	// if the server health check passed — and on a re-provision (update) the
 	// container is already running but we still need a valid token.
 	if err := integrations.WaitAuthentikTokenReady(secrets.BootstrapToken); err != nil {
-		fmt.Printf("❌ %v\n", err)
+		fail("%v", err)
 		return
 	}
 
@@ -236,60 +259,60 @@ func runOIDCEnable(engine string, client *vault.Client, vaultErr error) {
 		// On first boot Authentik seeds default scope mappings asynchronously
 		// after the token becomes usable — wait for them before provisioning.
 		if err := integrations.WaitAuthentikScopesReady(secrets.BootstrapToken); err != nil {
-			fmt.Printf("❌ %v\n", err)
+			fail("%v", err)
 			return
 		}
 		if err := integrations.WaitAuthentikFlowsReady(secrets.BootstrapToken); err != nil {
-			fmt.Printf("❌ %v\n", err)
+			fail("%v", err)
 			return
 		}
-	}
-
-	if firstBoot {
-		printAuthentikCredentials(secrets)
 	}
 
 	// 3. Register this product as a consumer
 	if err := global.AddSharedServiceConsumer(integrations.AuthentikSharedServiceKey, oidcSharedServiceKey); err != nil {
-		fmt.Printf("⚠️  Could not register shared service consumer: %v\n", err)
+		ui.Step("⚠️  Could not register shared service consumer: %v", err)
 	}
 
 	// 4. Provision Authentik: groups, users, OAuth2 provider, application
-	fmt.Println("  ⚙️  Provisioning Authentik (users, groups, OAuth2 provider, application)...")
+	ui.Step("Provisioning Authentik (users, groups, OAuth2 provider, application)")
 	aktClient := integrations.NewAuthentikClient(secrets.BootstrapToken)
 	clientID, clientSecret, err := provisionAuthentikForVault(aktClient)
 	if err != nil {
-		fmt.Printf("❌ Authentik provisioning failed: %v\n", err)
+		fail("Authentik provisioning failed: %v", err)
 		return
 	}
 
 	// 5. Verify Vault container can reach the discovery URL
 	issuer := integrations.AuthentikOIDCIssuer(authentikVaultSlug)
-	fmt.Println("  ⏳ Verifying Vault can reach Authentik OIDC discovery URL...")
+	ui.Step("Verifying Vault can reach Authentik OIDC discovery URL")
 	if err := integrations.WaitVaultVisibleAuthentik(engine, issuer); err != nil {
-		fmt.Printf("❌ %v\n", err)
+		fail("%v", err)
 		return
 	}
 
 	// 6. Configure Vault OIDC
-	fmt.Println("  ⚙️  Configuring Vault OIDC auth, policies, and identity groups...")
+	ui.Step("Configuring Vault OIDC auth, policies, and identity groups")
 	if err := configureVaultOIDC(client, issuer, clientID, clientSecret); err != nil {
-		fmt.Printf("❌ %v\n", err)
+		fail("%v", err)
 		return
 	}
 
 	// 7. SCIM provisioning (Vault Enterprise + Authentik outbound sync)
 	if oidcWithSCIM {
-		fmt.Println()
-		fmt.Println("🔗 Configuring SCIM provisioning (Authentik → Vault)...")
+		ui.Step("Configuring SCIM provisioning (Authentik → Vault)")
 		if err := configureSCIM(client, aktClient, authentikVaultSlug); err != nil {
+			ui.Stop()
 			fmt.Printf("❌ SCIM setup failed: %v\n", err)
 			fmt.Println("   OIDC is still active. Fix the error and re-run with --scim to retry.")
+			global.RefreshHalHealth(engine)
+			printOIDCSuccess()
+			return
 		}
 	}
 
 	global.RefreshHalHealth(engine)
-	printOIDCSuccess(secrets)
+	ui.Stop()
+	printOIDCSuccess()
 }
 
 // ─── disable ──────────────────────────────────────────────────────────────────
@@ -501,31 +524,18 @@ func setupExternalGroup(client *vault.Client, groupName, accessor string, polici
 	})
 }
 
-func printAuthentikCredentials(secrets *integrations.AuthentikSecrets) {
-	fmt.Println()
-	fmt.Println("  🔑 Authentik — first boot credentials")
-	fmt.Printf("     Admin UI  : %s/if/admin/\n", integrations.AuthentikAdminURL())
-	fmt.Println("     Username  : akadmin")
-	fmt.Printf("     Password  : %s\n", secrets.AdminPassword)
-	fmt.Printf("     Saved at  : %s\n", integrations.AuthentikEnvPath())
-	fmt.Println()
-	fmt.Println("     To reset: docker exec hal-authentik-server ak changepassword akadmin")
-	fmt.Println()
-}
+func printOIDCSuccess() {
+	ui.Success("Vault OIDC + Authentik IdP ready!")
 
-func printOIDCSuccess(secrets *integrations.AuthentikSecrets) {
-	fmt.Println()
-	fmt.Println("✅ Vault OIDC + Authentik IdP ready!")
-	fmt.Println()
-	fmt.Printf("  UI login   : %s  (select 'OIDC', leave role blank)\n", vaultPublicURL)
-	fmt.Println("  CLI login  : vault login -method=oidc")
-	fmt.Println()
-	fmt.Println("  Demo users:")
-	fmt.Println("    alice / password  →  admin policy (full access)")
-	fmt.Println("    bob   / password  →  user-ro policy (kv-oidc/team1 read)")
-	fmt.Println()
-	fmt.Printf("  Authentik admin  : %s/if/admin/\n", integrations.AuthentikAdminURL())
-	fmt.Printf("  Authentik login  : akadmin / %s\n", secrets.AdminPassword)
+	ui.Section("Sign in to Vault")
+	ui.Field("UI login", fmt.Sprintf("%s  (select 'OIDC', leave role blank)", vaultPublicURL))
+	ui.Field("CLI login", "vault login -method=oidc")
+
+	ui.Section("Demo users")
+	ui.Item("alice / password  →  admin policy (full access)")
+	ui.Item("bob   / password  →  user-ro policy (kv-oidc/team1 read)")
+
+	ui.Hint("Authentik admin credentials: hal creds status  (or: hal vault oidc status)")
 }
 
 func init() {

--- a/internal/integrations/authentik.go
+++ b/internal/integrations/authentik.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"hal/internal/global"
+	"hal/internal/ui"
 )
 
 const (
@@ -101,6 +102,23 @@ func randomHex(n int) string {
 	return hex.EncodeToString(b)
 }
 
+// LoadAuthentikAdminPassword returns the saved akadmin bootstrap password
+// without generating any secrets. It returns "" if the env file is missing or
+// the password is not present, so callers can fall back to a hint.
+func LoadAuthentikAdminPassword() string {
+	data, err := os.ReadFile(AuthentikEnvPath())
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), "=", 2)
+		if len(parts) == 2 && parts[0] == "AUTHENTIK_BOOTSTRAP_PASSWORD" {
+			return parts[1]
+		}
+	}
+	return ""
+}
+
 // LoadOrCreateAuthentikSecrets reads ~/.hal/authentik/env or generates fresh values.
 // The file is created with mode 0600.
 func LoadOrCreateAuthentikSecrets() (*AuthentikSecrets, error) {
@@ -183,7 +201,7 @@ func StartAuthentikStack(engine, image, tag string, secrets *AuthentikSecrets) e
 	global.EnsureNetwork(engine)
 
 	// ── 1. PostgreSQL ────────────────────────────────────────────────────────────
-	fmt.Println("  ⏳ Starting Authentik PostgreSQL...")
+	ui.Step("Starting Authentik PostgreSQL")
 	pgArgs := []string{
 		"run", "-d",
 		"--name", AuthentikPGContainer,
@@ -200,7 +218,7 @@ func StartAuthentikStack(engine, image, tag string, secrets *AuthentikSecrets) e
 	}
 
 	// ── 2. Wait for pg ───────────────────────────────────────────────────────────
-	fmt.Print("  ⏳ Waiting for PostgreSQL")
+	ui.Step("Waiting for PostgreSQL")
 	deadline := time.Now().Add(30 * time.Second)
 	pgReady := false
 	for time.Now().Before(deadline) {
@@ -209,17 +227,14 @@ func StartAuthentikStack(engine, image, tag string, secrets *AuthentikSecrets) e
 			pgReady = true
 			break
 		}
-		fmt.Print(".")
 		time.Sleep(2 * time.Second)
 	}
-	fmt.Println()
 	if !pgReady {
 		return fmt.Errorf("postgresql did not become ready within 30s")
 	}
-	fmt.Println("  ✅ PostgreSQL ready")
 
 	// ── 3. Server ────────────────────────────────────────────────────────────────
-	fmt.Println("  ⏳ Starting Authentik server...")
+	ui.Step("Starting Authentik server")
 	serverArgs := []string{
 		"run", "-d",
 		"--name", AuthentikServerContainer,
@@ -261,7 +276,7 @@ func StartAuthentikStack(engine, image, tag string, secrets *AuthentikSecrets) e
 	}
 
 	// ── 4. Worker (no docker socket) ─────────────────────────────────────────────
-	fmt.Println("  ⏳ Starting Authentik worker...")
+	ui.Step("Starting Authentik worker")
 	workerArgs := []string{
 		"run", "-d",
 		"--name", AuthentikWorkerContainer,
@@ -305,20 +320,17 @@ func WaitAuthentikHealthy() error {
 	client := &http.Client{Timeout: 5 * time.Second}
 	deadline := time.Now().Add(90 * time.Second)
 
-	fmt.Print("  ⏳ Waiting for Authentik API")
+	ui.Step("Waiting for Authentik API")
 	for time.Now().Before(deadline) {
 		resp, err := client.Get(url)
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				fmt.Println(" ✅")
 				return nil
 			}
 		}
-		fmt.Print(".")
 		time.Sleep(3 * time.Second)
 	}
-	fmt.Println()
 	return fmt.Errorf("authentik did not become ready within 90s — check: docker logs %s", AuthentikServerContainer)
 }
 
@@ -333,7 +345,7 @@ func WaitAuthentikTokenReady(token string) error {
 	client := &http.Client{Timeout: 5 * time.Second}
 	deadline := time.Now().Add(60 * time.Second)
 
-	fmt.Print("  ⏳ Waiting for Authentik bootstrap token")
+	ui.Step("Waiting for Authentik bootstrap token")
 	for time.Now().Before(deadline) {
 		req, _ := http.NewRequest("GET", url, nil)
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -341,14 +353,11 @@ func WaitAuthentikTokenReady(token string) error {
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				fmt.Println(" ✅")
 				return nil
 			}
 		}
-		fmt.Print(".")
 		time.Sleep(3 * time.Second)
 	}
-	fmt.Println()
 	return fmt.Errorf("authentik bootstrap token not ready within 60s — check: docker logs %s", AuthentikWorkerContainer)
 }
 
@@ -361,7 +370,7 @@ func WaitAuthentikFlowsReady(token string) error {
 	deadline := time.Now().Add(120 * time.Second)
 	base := fmt.Sprintf("http://localhost:%s/api/v3/flows/instances/", AuthentikHTTPPort)
 
-	fmt.Print("  ⏳ Waiting for Authentik default flows")
+	ui.Step("Waiting for Authentik default flows")
 	for time.Now().Before(deadline) {
 		authzOK, invOK := false, false
 		for _, desig := range []string{"authorization", "invalidation"} {
@@ -385,13 +394,10 @@ func WaitAuthentikFlowsReady(token string) error {
 			}
 		}
 		if authzOK && invOK {
-			fmt.Println(" ✅")
 			return nil
 		}
-		fmt.Print(".")
 		time.Sleep(3 * time.Second)
 	}
-	fmt.Println()
 	return fmt.Errorf("authentik default flows not ready within 120s — check: docker logs %s", AuthentikWorkerContainer)
 }
 
@@ -406,7 +412,7 @@ func WaitAuthentikScopesReady(token string) error {
 	deadline := time.Now().Add(180 * time.Second)
 	required := map[string]bool{"openid": true, "profile": true, "email": true}
 
-	fmt.Printf("  ⏳ Waiting for Authentik scope mappings (0/%d)", len(required))
+	ui.Step("Waiting for Authentik scope mappings (0/%d)", len(required))
 	lastFound := -1
 	for time.Now().Before(deadline) {
 		req, _ := http.NewRequest("GET", url, nil)
@@ -426,22 +432,19 @@ func WaitAuthentikScopesReady(token string) error {
 					}
 				}
 				if found == len(required) {
-					fmt.Println(" ✅")
 					return nil
 				}
-				// Print updated counter only when progress is made.
+				// Update the counter only when progress is made.
 				if found != lastFound {
-					fmt.Printf(" (%d/%d)", found, len(required))
+					ui.Step("Waiting for Authentik scope mappings (%d/%d)", found, len(required))
 					lastFound = found
 				}
 			}
 		} else if resp != nil {
 			resp.Body.Close()
 		}
-		fmt.Print(".")
 		time.Sleep(3 * time.Second)
 	}
-	fmt.Println()
 	return fmt.Errorf("authentik default scope mappings not ready within 180s — check: docker logs %s", AuthentikWorkerContainer)
 }
 

--- a/internal/ui/logo.go
+++ b/internal/ui/logo.go
@@ -1,0 +1,527 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// logoArt is a product banner: a brand ANSI color (applied only on a TTY) plus
+// the ASCII/Unicode art lines. Lines may use Unicode block characters — the
+// reveal renderer is rune-aware, so multi-byte glyphs animate correctly.
+type logoArt struct {
+	color string // ANSI SGR color sequence, "" for none
+	lines []string
+}
+
+// Brand colors (256-color SGR) approximating each product's identity.
+const (
+	colorVault     = "\033[38;5;221m" // gold/yellow
+	colorTerraform = "\033[38;5;99m"  // purple
+	colorNomad     = "\033[38;5;42m"  // green (Nomad ~#00CA8E)
+	colorBoundary  = "\033[38;5;203m" // coral red (Boundary ~#F24C53)
+	colorConsul    = "\033[38;5;205m" // pink (Consul ~#DC477D)
+	colorObs       = "\033[38;5;208m" // orange (observability / Grafana ~#F46800)
+	colorPlus      = "\033[38;5;45m"  // cyan (HAL+)
+	colorReset     = "\033[0m"
+)
+
+// productLogos maps a product key (the `hal <product>` name) to its banner.
+var productLogos = map[string]logoArt{
+	"vault": {
+		color: colorVault,
+		lines: []string{
+			"::::::::::::::::::::::::::::::::::",
+			" :::::::::::::::::::::::::::::::: ",
+			"  ::::::::::::::::::::::::::::::  ",
+			"   ::::::::::::::::::::::::::::   ",
+			"    ::::::::  ::  ::  ::::::::    ",
+			"     ::::::::::::::::::::::::     ",
+			"      ::::::  ::  ::  ::::::      ",
+			"       ::::::::::::::::::::       ",
+			"        ::::::::  ::::::::        ",
+			"         ::::::::::::::::         ",
+			"          ::::::::::::::          ",
+			"           ::::::::::::           ",
+			"            ::::::::::            ",
+			"             ::::::::             ",
+			"              ::::::              ",
+			"               ::::               ",
+			"                ::                ",
+		},
+	},
+	// Reused from the original tf api build animation so there is a single home
+	// for the Terraform mark.
+	"terraform": {
+		color: colorTerraform,
+		lines: []string{
+			"   ***                          ",
+			"   ******.                      ",
+			"   ********..                .  ",
+			"   ********..***          .###  ",
+			"   ********..******.   .######  ",
+			"      *****..******** ########  ",
+			"         **..******** ########  ",
+			"            .******** ########  ",
+			"            .* .***** #####.    ",
+			"            .****. ** ##        ",
+			"            .*******            ",
+			"            .********           ",
+			"            .********           ",
+			"             .*******           ",
+			"                 ****           ",
+			"                    *           ",
+		},
+	},
+	"nomad": {
+		color: colorNomad,
+		lines: []string{
+			"              ++++              ",
+			"           ++++++++++           ",
+			"       ++++++++++++++++++       ",
+			"    ++++++++++++++++++++++++    ",
+			" +++++++++++++++++++++ ++++++++ ",
+			"+++++++++++++++++++    +++++++++",
+			"++++++++++++++++++     +++++++++",
+			"++++++++++++ +++++     +++++++++",
+			"+++++++++        +     +++++++++",
+			"+++++++++              +++++++++",
+			"+++++++++     +        +++++++++",
+			"+++++++++     ++++ +++++++++++++",
+			"+++++++++     ++++++++++++++++++",
+			"+++++++++    +++++++++++++++++++",
+			" ++++++++ +++++++++++++++++++++ ",
+			"    ++++++++++++++++++++++++    ",
+			"       ++++++++++++++++++       ",
+			"           ++++++++++           ",
+			"              ++++              ",
+		},
+	},
+	"boundary": {
+		color: colorBoundary,
+		lines: []string{
+			"++++++++++++++++++++++++    ",
+			"+++++++++++++++++++++++++   ",
+			"++++++++++++++++++++++++++  ",
+			"+++++++++++++++++++++++++++ ",
+			"+++++++            ++++++++ ",
+			"+++++++           ++++++++  ",
+			"+++++++          ++++++++   ",
+			"+++++++         ++++++++    ",
+			"+++++++        ++++++++     ",
+			"+++++++       ++++++++      ",
+			"+++++++        ++++++++     ",
+			"+++++++         ++++++++    ",
+			"                 ++++++++   ",
+			"                  ++++++++  ",
+			"                   ++++++++.",
+			"   ++- ++++++++++++++++++++=",
+			"          ++++++++++++++++: ",
+			"+++ +++++++++++++++++++++.  ",
+			"+++ ++++++++++++++++++++    ",
+		},
+	},
+	"consul": {
+		color: colorConsul,
+		lines: []string{
+			"          **********          ",
+			"      +*****************       ",
+			"    *********************      ",
+			"   *******          ***        ",
+			"  ******                  **   ",
+			" *****.                        ",
+			"******       +***       **  ** ",
+			"*****       ******            ",
+			"*****       ******            ",
+			"******       +***       **  ** ",
+			" *****.                        ",
+			"  ******                  **   ",
+			"   *******          ***        ",
+			"    *********************      ",
+			"      +*****************       ",
+			"          **********          ",
+		},
+	},
+	"observability": {
+		color: colorObs,
+		lines: []string{
+			"   .@@@@@@@@@@@@@@@@@@@@@@@@@@@@@       ",
+			"   @@                          @@.      ",
+			"   @@         @                @@.      ",
+			"   @@    .@  .@@  @@     @@@@@. @.      ",
+			"   @@    @@. @@@ .@@: @@@@@@@@@@@.      ",
+			"   @@ ..@..@ @ @-@. .@@@       @@@@     ",
+			"   @@      @.@ .@@  @@@         .@@     ",
+			"   @@      .@@  @@  @@.          @@@    ",
+			"   @@       @.      @@.          @@.    ",
+			"   @@               %@@.       .@@@     ",
+			"   @@@@@@@@@@@@@@@@@@.@@@@...@@@@@      ",
+			"   :@@@@@@@@@@@@@@@@@@:.@@@@@@@@@@      ",
+			"               @@@@@@         @@@@@     ",
+			"           .@@@@@@@@@@@@.      @@@@@    ",
+			"           @@@@@@@@@@@@@@.      @@@@@   ",
+			"                                 @@@@   ",
+		},
+	},
+	"plus": {
+		color: colorPlus,
+		lines: []string{
+			"  _    _              _              ",
+			" | |  | |     /\\     | |         _   ",
+			" | |__| |    /  \\    | |       _| |_ ",
+			" |  __  |   / /\\ \\   | |      |_   _|",
+			" | |  | |  / ____ \\  | |____    |_|  ",
+			" |_|  |_| /_/    \\_\\ |______|        ",
+		},
+	},
+}
+
+// HasLogo reports whether a banner exists for the given product key.
+func HasLogo(product string) bool {
+	_, ok := productLogos[strings.ToLower(strings.TrimSpace(product))]
+	return ok
+}
+
+// Logo prints the product's ASCII banner. On an interactive terminal (and
+// without --verbose) it reveals the art left-to-right like an installer splash;
+// otherwise it prints the art statically so logs and MCP transports stay clean.
+func Logo(product string) {
+	art, ok := productLogos[strings.ToLower(strings.TrimSpace(product))]
+	if !ok {
+		return
+	}
+
+	printLogoTopMargin()
+
+	if !isTTY() || Verbose {
+		for _, line := range art.lines {
+			fmt.Println(strings.TrimRight(line, " "))
+		}
+		fmt.Println()
+		return
+	}
+
+	maxCols := maxRuneLen(art.lines)
+	// Aim for a quick ~0.6s reveal regardless of width.
+	stepCols := maxCols/30 + 1
+	delay := 18 * time.Millisecond
+
+	printed := 0
+	for reveal := 0; reveal < maxCols; reveal += stepCols {
+		frame, n := renderLogoFrame(art, reveal, maxCols)
+		redraw(frame, &printed, n)
+		time.Sleep(delay)
+	}
+	// Final full frame.
+	frame, n := renderLogoFrame(art, maxCols, maxCols)
+	redraw(frame, &printed, n)
+}
+
+// logoTopMargin is the number of blank lines printed above a banner so it does
+// not hug the shell prompt.
+const logoTopMargin = 1
+
+// printLogoTopMargin prints the leading blank lines above a banner. These lines
+// sit above the redrawn frame block, so the cursor-up redraw logic never
+// overwrites them.
+func printLogoTopMargin() {
+	for i := 0; i < logoTopMargin; i++ {
+		fmt.Println()
+	}
+}
+
+// redraw moves the cursor up over the previously printed block (if any) and
+// prints the new frame, tracking how many lines it occupied.
+func redraw(frame string, printed *int, lines int) {
+	if *printed > 0 {
+		fmt.Printf("\033[%dA", *printed)
+	}
+	fmt.Print(frame)
+	*printed = lines
+}
+
+// renderLogoFrame returns the banner revealed up to revealCols columns and the
+// number of terminal lines it occupies. Slicing is rune-aware.
+func renderLogoFrame(art logoArt, revealCols, maxCols int) (string, int) {
+	if maxCols <= 0 {
+		maxCols = 1
+	}
+	if revealCols < 0 {
+		revealCols = 0
+	}
+	if revealCols > maxCols {
+		revealCols = maxCols
+	}
+
+	var b strings.Builder
+	for _, line := range art.lines {
+		runes := []rune(line)
+		limit := revealCols
+		if limit > len(runes) {
+			limit = len(runes)
+		}
+		if art.color != "" {
+			b.WriteString(art.color)
+		}
+		b.WriteString(string(runes[:limit]))
+		if art.color != "" {
+			b.WriteString(colorReset)
+		}
+		// Pad the rest of the row so cursor-up redraws overwrite cleanly.
+		if limit < maxCols {
+			b.WriteString(strings.Repeat(" ", maxCols-limit))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	return b.String(), len(art.lines) + 1
+}
+
+// maxRuneLen returns the widest line measured in runes.
+func maxRuneLen(lines []string) int {
+	maxLen := 0
+	for _, line := range lines {
+		if n := len([]rune(line)); n > maxLen {
+			maxLen = n
+		}
+	}
+	return maxLen
+}
+
+// ─── Logo loader ────────────────────────────────────────────────────────────────
+// The logo loader shares the same loading system as the feature spinner: a top
+// line shows the spinning icon and the current activity (updated in place as the
+// flow advances), exactly like ui.Start/Step/Stop. Beneath it, the product
+// banner reveals left-to-right (tf-api style) at a steady pace — the "fancy"
+// part unique to create flows. This replaces ad-hoc per-step status lines
+// (🚀 Deploying…, ⚙️ Preparing…, ⏳ Waiting…) on a create command.
+
+// logoTick drives both the spinner icon and the one-column-per-tick reveal. It
+// matches the feature spinner cadence so the loading icon feels identical.
+const logoTick = 90 * time.Millisecond
+
+type logoLoader struct {
+	mu      sync.Mutex
+	art     logoArt
+	maxCols int
+	reveal  int // revealed columns, advanced one per tick
+	caption string
+	frame   int // spinner frame index
+	ceiling int // column ceiling the reveal advances toward; <0 means free-run
+	// creep slowly raises the ceiling during a long step so the reveal never
+	// fully stalls. creepEvery == 0 disables it.
+	creepEvery time.Duration
+	creepCap   int
+	lastCreep  time.Time
+	printed    int
+	animated   bool
+	stopCh     chan struct{}
+	wg         sync.WaitGroup
+}
+
+// currentLoader holds the in-flight logo loader, mirroring the spinner handle so
+// nested helpers can drive steps via package-level functions.
+var currentLoader *logoLoader
+
+// LogoStart begins a logo-as-progress flow for the product. On an interactive
+// terminal (and without --verbose) the banner reveals at a steady pace while a
+// header shows the current activity and percentage; otherwise it prints the
+// static banner once and LogoStep emits plain one-line-per-step output. The
+// variadic int argument is accepted for backward compatibility and ignored.
+func LogoStart(product string, _ ...int) {
+	key := strings.ToLower(strings.TrimSpace(product))
+
+	art, ok := productLogos[key]
+	l := &logoLoader{
+		art:      art,
+		animated: ok && isTTY() && !Verbose,
+		ceiling:  -1, // free-run until a caller steers progress in columns
+		stopCh:   make(chan struct{}),
+	}
+	currentLoader = l
+
+	if !l.animated {
+		// Static brand banner once (no-op if the product has no logo), then
+		// LogoStep falls back to plain lines.
+		if ok {
+			Logo(product)
+		}
+		return
+	}
+
+	l.maxCols = maxRuneLen(art.lines)
+	printLogoTopMargin()
+	l.wg.Add(1)
+	go l.run()
+}
+
+// LogoStep updates the header caption to the current activity. In animated mode
+// the steady reveal continues underneath; otherwise it prints a plain step line.
+func LogoStep(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	l := currentLoader
+	if l == nil || !l.animated {
+		fmt.Printf("  → %s\n", msg)
+		return
+	}
+	l.mu.Lock()
+	l.caption = msg
+	l.mu.Unlock()
+}
+
+// LogoAdvance raises the reveal ceiling by cols columns — use it to map a short
+// step to a fixed amount of logo fill (typically 1–2 columns). It cancels any
+// active creep, since a new discrete step has started. The reveal animates
+// smoothly up to the new ceiling.
+func LogoAdvance(cols int) {
+	l := currentLoader
+	if l == nil || !l.animated {
+		return
+	}
+	l.mu.Lock()
+	if l.ceiling < 0 {
+		l.ceiling = l.reveal // leave free-run, anchor at current fill
+	}
+	l.ceiling += cols
+	if l.ceiling > l.maxCols {
+		l.ceiling = l.maxCols
+	}
+	l.creepEvery = 0
+	l.mu.Unlock()
+}
+
+// LogoCreep makes the reveal advance by one column every interval, stopping a
+// couple of columns short of full, so a long-running step keeps inching forward
+// instead of stalling. The next LogoAdvance or LogoStop cancels it.
+func LogoCreep(every time.Duration) {
+	l := currentLoader
+	if l == nil || !l.animated {
+		return
+	}
+	l.mu.Lock()
+	if l.ceiling < 0 {
+		l.ceiling = l.reveal
+	}
+	l.creepEvery = every
+	l.creepCap = l.maxCols - 2 // leave room for the remaining steps + final snap
+	if l.creepCap < l.ceiling {
+		l.creepCap = l.ceiling
+	}
+	l.lastCreep = time.Now()
+	l.mu.Unlock()
+}
+
+// LogoStop completes the reveal (snapping the banner to 100%), clears the
+// header, and ends the flow. It is safe to call multiple times.
+func LogoStop() {
+	l := currentLoader
+	currentLoader = nil
+	if l == nil || !l.animated {
+		return
+	}
+	close(l.stopCh)
+	l.wg.Wait()
+
+	// Snap to a full, header-free banner so a summary can print cleanly below.
+	// The final frame has fewer lines than the running frame (no spinner header),
+	// so clear from the cursor to end-of-screen to remove any stale lines.
+	frame, n := renderLogoFrame(l.art, l.maxCols, l.maxCols)
+	if l.printed > 0 {
+		fmt.Printf("\033[%dA", l.printed)
+	}
+	fmt.Print("\033[J") // clear from cursor to end of screen
+	fmt.Print(frame)
+	l.printed = n
+}
+
+func (l *logoLoader) run() {
+	defer l.wg.Done()
+	ticker := time.NewTicker(logoTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.stopCh:
+			return
+		case <-ticker.C:
+			l.mu.Lock()
+			l.frame++
+			// Creep: during a long step, slowly raise the ceiling so the reveal
+			// keeps inching forward instead of stalling.
+			if l.creepEvery > 0 && l.ceiling < l.creepCap && time.Since(l.lastCreep) >= l.creepEvery {
+				l.ceiling++
+				l.lastCreep = time.Now()
+			}
+			// Determine the reveal ceiling: free-run to full, or the column
+			// ceiling set by LogoAdvance/LogoCreep.
+			ceiling := l.maxCols
+			if l.ceiling >= 0 {
+				ceiling = l.ceiling
+			}
+			if ceiling > l.maxCols {
+				ceiling = l.maxCols
+			}
+			if l.reveal < ceiling {
+				l.reveal++
+			}
+			frame, n := l.render()
+			printed := l.printed
+			l.printed = n
+			l.mu.Unlock()
+
+			if printed > 0 {
+				fmt.Printf("\033[%dA", printed)
+			}
+			fmt.Print(frame)
+		}
+	}
+}
+
+// render builds the spinner header (loading icon + current activity) and the
+// partially revealed banner beneath it. Caller must hold l.mu.
+func (l *logoLoader) render() (string, int) {
+	reveal := l.reveal
+	if reveal > l.maxCols {
+		reveal = l.maxCols
+	}
+
+	var b strings.Builder
+	// Top line: same format as the feature spinner — "  <icon> <activity>".
+	sp := spinnerFrames[l.frame%len(spinnerFrames)]
+	header := fmt.Sprintf("  %s %s", sp, l.caption)
+	b.WriteString(padRunes(header, logoCaptionWidth))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+
+	for _, line := range l.art.lines {
+		runes := []rune(line)
+		limit := reveal
+		if limit > len(runes) {
+			limit = len(runes)
+		}
+		if l.art.color != "" {
+			b.WriteString(l.art.color)
+		}
+		b.WriteString(string(runes[:limit]))
+		if l.art.color != "" {
+			b.WriteString(colorReset)
+		}
+		if limit < l.maxCols {
+			b.WriteString(strings.Repeat(" ", l.maxCols-limit))
+		}
+		b.WriteByte('\n')
+	}
+
+	return b.String(), len(l.art.lines) + 2
+}
+
+const logoCaptionWidth = 60
+
+// padRunes pads s with trailing spaces to at least width runes so a redraw
+// fully overwrites a longer previous caption.
+func padRunes(s string, width int) string {
+	if n := len([]rune(s)); n < width {
+		return s + strings.Repeat(" ", width-n)
+	}
+	return s
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,167 @@
+// Package ui provides a consistent, installer-style output for hal commands.
+//
+// The goal is to standardize the "what is happening" progress output and the
+// "command is done" summary across all products. Long-running flows show a
+// single updating line (an animated spinner) where each stage overwrites the
+// previous one, like a software installer. When stdout is not a terminal, or
+// when --verbose is set, the output degrades to one plain line per step so logs
+// and MCP transports stay clean and complete.
+//
+// Typical usage:
+//
+//	ui.Title("hal vault oidc — deploying Authentik IdP + Vault OIDC")
+//	ui.Start()
+//	ui.Step("Starting Authentik stack")
+//	ui.Step("Configuring Vault OIDC")
+//	ui.Stop()
+//	ui.Success("Vault OIDC + Authentik IdP ready")
+//	ui.Section("Demo users")
+//	ui.Item("alice / password  →  admin policy")
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Verbose, when true, persists every step as its own line even on a TTY.
+// It is wired to the global --verbose flag in cmd/root.go.
+var Verbose bool
+
+// spinnerFrames are Braille dots that animate smoothly in a single cell.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// current holds the in-flight progress flow, if any. The CLI is single-threaded
+// per command, so a package-level handle lets nested helpers (e.g. the Authentik
+// integration) emit steps via ui.Step without threading a handle everywhere.
+var current *spinner
+
+type spinner struct {
+	mu       sync.Mutex
+	msg      string
+	animated bool // true only on a TTY without --verbose
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+}
+
+// isTTY reports whether stdout is an interactive terminal capable of cursor
+// control. A "dumb" terminal (TERM=dumb) is treated as non-interactive so
+// animations degrade to plain output.
+func isTTY() bool {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("TERM")), "dumb") {
+		return false
+	}
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// Title prints a persistent header line that introduces a flow. It always
+// prints (TTY or not) and is never overwritten by the spinner.
+func Title(format string, args ...any) {
+	fmt.Printf("🔧 %s\n\n", fmt.Sprintf(format, args...))
+}
+
+// Start begins an installer-style progress flow. On a TTY (and without
+// --verbose) it launches an animated single-line spinner that subsequent
+// Step calls update in place. Otherwise it is a no-op and Step prints plain
+// lines.
+func Start() {
+	s := &spinner{
+		animated: isTTY() && !Verbose,
+		stopCh:   make(chan struct{}),
+	}
+	current = s
+	if !s.animated {
+		return
+	}
+	s.wg.Add(1)
+	go s.run()
+}
+
+// Step advances the flow to a new stage. In animated mode it replaces the
+// current line; otherwise it prints a plain one-line-per-step entry.
+func Step(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	s := current
+	if s == nil || !s.animated {
+		fmt.Printf("  → %s\n", msg)
+		return
+	}
+	s.mu.Lock()
+	s.msg = msg
+	s.mu.Unlock()
+}
+
+// Stop ends the flow and clears the active spinner line. Call it before
+// printing a summary or an error so the line does not linger.
+func Stop() {
+	s := current
+	current = nil
+	if s == nil || !s.animated {
+		return
+	}
+	close(s.stopCh)
+	s.wg.Wait()
+	fmt.Print("\r\033[K") // return to col 0 and clear to end of line
+}
+
+// Fail stops the flow (clearing the spinner line) and prints an error line.
+func Fail(format string, args ...any) {
+	Stop()
+	fmt.Printf("❌ %s\n", fmt.Sprintf(format, args...))
+}
+
+func (s *spinner) run() {
+	defer s.wg.Done()
+	ticker := time.NewTicker(90 * time.Millisecond)
+	defer ticker.Stop()
+	i := 0
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			msg := s.msg
+			s.mu.Unlock()
+			if msg != "" {
+				fmt.Printf("\r\033[K  %s %s", spinnerFrames[i%len(spinnerFrames)], msg)
+			}
+			i++
+		}
+	}
+}
+
+// ─── Summary primitives ────────────────────────────────────────────────────────
+// These produce a consistent "command is done" block across products.
+
+// Success prints the headline result line of a completed flow.
+func Success(format string, args ...any) {
+	fmt.Printf("\n✅ %s\n", fmt.Sprintf(format, args...))
+}
+
+// Section prints an indented section heading inside a summary block.
+func Section(format string, args ...any) {
+	fmt.Printf("\n  %s\n", fmt.Sprintf(format, args...))
+}
+
+// Item prints an indented list item inside a section.
+func Item(format string, args ...any) {
+	fmt.Printf("    %s\n", fmt.Sprintf(format, args...))
+}
+
+// Field prints an aligned "label : value" line inside a section.
+func Field(label, value string) {
+	fmt.Printf("    %-10s %s\n", label+":", value)
+}
+
+// Hint prints a trailing next-step suggestion.
+func Hint(format string, args ...any) {
+	fmt.Printf("\n💡 %s\n", fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
## Standardized installer-style CLI output

Adds a shared `internal/ui` package for consistent progress + summary output, wired into every product `create`/`enable` flow — replacing per-product ad-hoc prints and mismatched emoji.

**What's in it**
- Animated spinner activity line + per-product ASCII logo that fills as work progresses; clean plain-text fallback on non-TTY or `--verbose` (new global flag).
- Brand-colored logos for vault, terraform, nomad, boundary, consul, observability, hal plus.
- Consistent `Success`/`Section`/`Field`/`Hint` summary blocks.
- `vault oidc enable` keeps alice/bob demo logins; Authentik admin creds moved to `oidc status`/`-h` and `hal creds status`.
- Fix: deprecated Multipass `--mem` → `--memory`.

**Testing:** `go build`/`go vet` clean; TTY + non-TTY checked; rebased on latest main (Oracle PR) — no conflicts.

_Note: `hal mcp create` left out of this pass._