### PR TITLE
docs: add contributor guidance (CONTRIBUTING, PR template, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Code owners for HAL.
+# Order matters: the last matching pattern takes precedence.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo.
+*                               @hashimiche
+
+# AI-facing contract surfaces: changes here affect Copilot, HAL Plus, and the
+# MCP server, so they must be reviewed before merge.
+/cmd/mcp/                       @hashimiche
+/LLM_CONTEXT.md                 @hashimiche
+/HAL_MCP_CONTRACT.json          @hashimiche
+/.github/copilot-instructions.md @hashimiche
+/.github/copilot/               @hashimiche
+/docs/cli-lifecycle-model.md    @hashimiche

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Thanks for contributing to HAL! Please fill out the sections below.
+See CONTRIBUTING.md for branch naming, the doc-sync rule, and conventions.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? Link any related issue. -->
+
+## Type of change
+
+- [ ] New capability (branch `feature/...`)
+- [ ] Bug fix (branch `bugfix/...`)
+- [ ] Docs / internal only
+
+## Checklist
+
+- [ ] Branch follows `feature/<desc>` or `bugfix/<desc>` naming
+- [ ] `go build ./...` passes
+- [ ] `go test ./...` passes
+- [ ] `go vet ./...` is clean
+- [ ] Change is scoped to one logical concern (repo squash-merges PRs)
+
+## Doc-sync (required when command behavior/flags/lifecycle change)
+
+<!-- Tick every surface your change touches. Delete rows that don't apply,
+     but do not skip a surface that your change affects. -->
+
+- [ ] `docs/cli-lifecycle-model.md` — lifecycle verbs / naming semantics
+- [ ] `.github/copilot-instructions.md` — policy or convention deltas
+- [ ] `LLM_CONTEXT.md` — command behavior, flags, or workflows
+- [ ] `README.md` — contributor-facing command behavior
+- [ ] `.github/copilot/skills/**/*.md` — AI skill guidance
+- [ ] MCP contracts: `HAL_MCP_CONTRACT.json`, `cmd/mcp/ops_api.go`, `cmd/mcp/testdata/*_help_snapshot.json`
+- [ ] N/A — this change does not alter command behavior
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, manual test steps, screenshots, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to HAL
+
+Thanks for contributing to HAL. This guide covers the essentials for landing a
+change. The deeper design context lives elsewhere (see
+[Sources of truth](#sources-of-truth)) — this file is the short version you need
+before opening a pull request.
+
+## Quick start
+
+```bash
+# From the repo root
+go build -o hal main.go   # build the binary the way CI does
+go build ./...            # verify all packages compile
+go test ./...             # run the full test suite
+go vet ./...              # static checks
+```
+
+All four must pass before you open a PR.
+
+## Branch naming
+
+Every change lands on a named branch before merging to `main` — never commit to
+`main` directly.
+
+- New capabilities: `feature/<short-description>`
+- Bug fixes or corrections: `bugfix/<short-description>`
+
+The repository squash-merges PRs, so keep your branch focused on one logical
+change.
+
+## The doc-sync rule (most-missed step)
+
+HAL's command surface is consumed by AI tooling (Copilot, the HAL Plus UI, and
+the MCP server), so **documentation is part of the code, not an afterthought.**
+When you change command behavior, naming, flags, or lifecycle semantics, update
+the affected surfaces **in the same PR**:
+
+| If you change… | Also update… |
+| --- | --- |
+| Lifecycle verbs / naming semantics | `docs/cli-lifecycle-model.md` (source of truth) |
+| Policy or architecture conventions | `.github/copilot-instructions.md` |
+| Command behavior, flags, or workflows | `LLM_CONTEXT.md` |
+| Contributor-facing command behavior | `README.md` |
+| MCP command syntax or contracts | `HAL_MCP_CONTRACT.json`, `cmd/mcp/ops_api.go`, `cmd/mcp/testdata/*_help_snapshot.json` |
+| AI skill guidance | `.github/copilot/skills/**/*.md` |
+
+A PR that changes command behavior without updating the matching docs will be
+sent back. The PR template has a checklist to help you catch this.
+
+## Key conventions
+
+- **Two-tier CLI.** Core products use verb subcommands (`hal vault create`);
+  feature/integration flows use noun + lifecycle-action subcommands
+  (`hal vault oidc enable`). See `LLM_CONTEXT.md` for the full pattern.
+- **Smart status default.** Running a command with no lifecycle action returns a
+  read-only status view (up / down / degraded) ending in a copy-pasteable
+  `Next Step`, not Cobra help.
+- **Naming:** the observability namespace is `obs`, not `observability`.
+- **No hardcoded images/versions.** Any path that launches a container, KinD
+  cluster, Helm release, or VM must expose a version/image override flag with a
+  sensible default.
+- **Reuse shared runtime helpers** in `internal/global` (engine detection,
+  `hal-net` management, `HalNetStaticIP`) instead of open-coding them.
+
+## Commit and PR discipline
+
+- Keep commits scoped and messages descriptive (imperative mood, e.g.
+  `feat(mcp): add ...`, `fix(vault): ...`).
+- Do not disable safety checks (no `--no-verify`) or force-push shared branches.
+- Confirm `go build ./...`, `go test ./...`, and `go vet ./...` are green
+  locally before requesting review.
+
+## Sources of truth
+
+Read these in order before changing command behavior or UX patterns:
+
+1. [`docs/cli-lifecycle-model.md`](docs/cli-lifecycle-model.md) — authoritative lifecycle verb model
+2. [`.github/copilot-instructions.md`](.github/copilot-instructions.md) — concise policy and architecture notes
+3. [`LLM_CONTEXT.md`](LLM_CONTEXT.md) — repo-specific architecture patterns and implementation lessons
+
+Keep all three in sync when adding or renaming commands.

--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -217,6 +217,8 @@ For product-level delete flows, prefer deleting the known local ecosystem direct
 
 If guidance here starts duplicating `.github/copilot-instructions.md`, move the canonical rule there and keep only the repo-specific reminder here.
 
+**Scope discipline:** this file is for durable architecture patterns and implementation lessons, not a changelog. One-off bug-fix history and version-specific API quirks belong next to the code (package doc comments or `docs/`), not here — keep entries at the "pattern worth remembering" level so the file stays loadable as AI context. Human contribution process (branch naming, doc-sync, build/test) lives in `CONTRIBUTING.md`; do not duplicate it here.
+
 When lifecycle verbs/flags change (for example replacing force with update), keep all LLM-facing guidance synchronized in the same change set: this file, `.github/copilot/skills/**/*.md`, and MCP-facing docs/contracts (`docs/commands/mcp*.md`, `cmd/mcp/ops_api.go`, MCP test snapshots).
 
 Before making code changes in either `hal` or `hal-plus`, ask the user to create or confirm a working branch first. Every `hal` CLI change must land on a named branch — use `feature/<short-description>` for new capabilities and `bugfix/<short-description>` for fixes. Once the branch exists, keep code and LLM markdown updates aligned on that branch.

--- a/README.md
+++ b/README.md
@@ -472,6 +472,9 @@ HAL uses environment variables and Docker/Podman networking — there is no conf
 
 ## Contributing & Development
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, the doc-sync rule, and
+conventions before opening a pull request.
+
 ```bash
 # From the repo root
 go build -o hal main.go   # build the binary


### PR DESCRIPTION
Add human-facing contribution guardrails for a growing contributor base:
- CONTRIBUTING.md surfaces build/test commands, branch naming, the doc-sync rule, and key conventions, pointing to existing sources of truth
- .github/PULL_REQUEST_TEMPLATE.md enforces the doc-sync rule at PR time
- .github/CODEOWNERS auto-requests review on AI-contract surfaces
- LLM_CONTEXT.md gains a scope-discipline note (architecture-only)
- README links to CONTRIBUTING.md