### PR TITLE
docs(readme): add brew trust step for Homebrew 6.0+ tap trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ HAL is a local lab orchestrator for HashiCorp products. It replaces the hand-wri
 ## TL;DR
 
 ```bash
-brew tap hashimiche/tap && brew install hal
+brew tap hashimiche/tap && brew trust hashimiche/tap && brew install hal
 
 hal status          # see what's running
 hal vault create    # spin up Vault
@@ -49,8 +49,11 @@ Install the tooling required by the labs you want to run before installing HAL.
 
 ```bash
 brew tap hashimiche/tap
+brew trust hashimiche/tap   # Homebrew 6.0+ requires trusting non-official taps
 brew install hal
 ```
+
+> **Homebrew 6.0+ (June 2026):** non-official taps must be explicitly trusted before install. `brew trust hashimiche/tap` grants whole-tap trust. To trust only the formula instead, run `brew trust --formula hashimiche/tap/hal`, or skip trust entirely by installing the fully-qualified name: `brew install hashimiche/tap/hal`.
 
 ### Manual binary
 


### PR DESCRIPTION
<!--
Thanks for contributing to HAL! Please fill out the sections below.
See CONTRIBUTING.md for branch naming, the doc-sync rule, and conventions.
-->

## Summary

<!-- What does this PR do, and why? Link any related issue. -->

## Type of change

- [ ] New capability (branch `feature/...`)
- [ ] Bug fix (branch `bugfix/...`)
- [x] Docs / internal only

## Checklist

- [x] Branch follows `feature/<desc>` or `bugfix/<desc>` naming
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` is clean
- [ ] Change is scoped to one logical concern (repo squash-merges PRs)

## Doc-sync (required when command behavior/flags/lifecycle change)

<!-- Tick every surface your change touches. Delete rows that don't apply,
     but do not skip a surface that your change affects. -->

- [ ] `docs/cli-lifecycle-model.md` — lifecycle verbs / naming semantics
- [ ] `.github/copilot-instructions.md` — policy or convention deltas
- [ ] `LLM_CONTEXT.md` — command behavior, flags, or workflows
- [ ] `README.md` — contributor-facing command behavior
- [ ] `.github/copilot/skills/**/*.md` — AI skill guidance
- [ ] MCP contracts: `HAL_MCP_CONTRACT.json`, `cmd/mcp/ops_api.go`, `cmd/mcp/testdata/*_help_snapshot.json`
- [x] N/A — this change does not alter command behavior

## Notes for reviewers

Brew changes its trust method for unverified tap repo, need to be trusted now
