### PR TITLE
docs: add issue templates and Filing issues guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Report a defect in HAL command behavior, output, or lifecycle handling.
+title: "bug: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections
+        below so we can reproduce and fix it quickly. For contribution
+        conventions, see [CONTRIBUTING.md](https://github.com/hashimiche/hal/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands you ran, in order.
+      placeholder: |
+        1. Run `hal vault create ...`
+        2. Run `hal vault oidc enable`
+        3. See error
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected HAL to do.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include the full command output or error.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: HAL version
+      description: Output of `hal version` (or the commit SHA if built from source).
+      placeholder: "e.g. v0.5.2 or commit d82d83d"
+    validations:
+      required: true
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Container engine
+      description: Which runtime were you using, if relevant?
+      options:
+        - Docker
+        - Podman
+        - Not applicable
+        - Other (note in description)
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: OS / platform
+      placeholder: "e.g. macOS 15.3 (arm64), Ubuntu 24.04 (amd64)"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, or anything else that helps.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Propose a new capability or an enhancement to existing HAL behavior.
+title: "feat: <short description>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Before filing, please skim the
+        [CLI lifecycle model](https://github.com/hashimiche/hal/blob/main/docs/cli-lifecycle-model.md) and
+        [CONTRIBUTING.md](https://github.com/hashimiche/hal/blob/main/CONTRIBUTING.md) so the proposal fits
+        HAL's two-tier command conventions.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what's getting in the way today?
+      placeholder: "I'm always frustrated when ..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: >
+        Describe the behavior you'd like. If it adds or changes a command,
+        sketch the command surface (e.g. `hal <product> <action>`).
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you set them aside.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — related issues, prior art, mockups.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,22 @@ change. The deeper design context lives elsewhere (see
 [Sources of truth](#sources-of-truth)) — this file is the short version you need
 before opening a pull request.
 
+## Filing issues
+
+Before writing code, open an issue so the change can be discussed. Use the
+templates in the issue chooser — blank issues are disabled to keep reports
+actionable:
+
+- **Bug report** — for defects in command behavior, output, or lifecycle
+  handling. Include the exact commands you ran, expected vs. actual behavior,
+  your `hal version`, and your OS / container engine.
+- **Feature request** — for new capabilities or enhancements. Describe the
+  problem first, then a proposed command surface that fits the two-tier CLI
+  conventions below.
+
+Search existing issues before opening a new one, and keep each issue scoped to a
+single bug or request.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary

Adds GitHub Issue Forms so contributors get structure when opening issues, and documents the process in `CONTRIBUTING.md` alongside the existing PR flow. Previously the repo had a PR template and CODEOWNERS but no issue templates.

- `.github/ISSUE_TEMPLATE/bug_report.yml` — bug report form (repro, expected/actual, `hal version`, OS/container engine)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — feature request form (problem, proposed command surface, alternatives)
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues
- `CONTRIBUTING.md` — new "Filing issues" section

## Type of change

- [ ] New capability (branch `feature/...`)
- [ ] Bug fix (branch `bugfix/...`)
- [x] Docs / internal only

## Checklist

- [x] Branch follows `feature/<desc>` or `bugfix/<desc>` naming
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` is clean
- [x] Change is scoped to one logical concern (repo squash-merges PRs)

## Doc-sync (required when command behavior/flags/lifecycle change)

- [x] N/A — this change does not alter command behavior

## Notes for reviewers

Forms only render in GitHub's "New issue" UI, so the definitive check is after merge. The `bug`/`enhancement` labels are GitHub defaults — if the repo renamed them, the `labels:` keys need adjusting.

