### PR TITLE
Update hint for using Consul with Nomad

### DIFF
--- a/cmd/consul/create.go
+++ b/cmd/consul/create.go
@@ -78,7 +78,7 @@ var deployCmd = &cobra.Command{
 		ui.Success("Standalone Consul server is up!")
 		ui.Section("Access")
 		ui.Field("UI", consulBaseURL)
-		ui.Hint("Test the KV store / API. For real workloads: hal nomad create --with-consul")
+		ui.Hint("Test the KV store / API. For real workloads: hal nomad create --join-consul")
 	},
 }
 


### PR DESCRIPTION


## Summary

fix hint after creating consul cluster

use --join-consul
fix wrong command --with-consul

## Type of change

- [ ] New capability (branch `feature/...`)
- [x] Bug fix (branch `bugfix/...`)
- [ ] Docs / internal only

## Checklist

- [x] Branch follows `feature/<desc>` or `bugfix/<desc>` naming
- [x] `go build ./...` passes
- [ ] `go test ./...` passes
- [x] `go vet ./...` is clean
- [x] Change is scoped to one logical concern (repo squash-merges PRs)

## Doc-sync (required when command behavior/flags/lifecycle change)

NA

- [ ] `docs/cli-lifecycle-model.md` — lifecycle verbs / naming semantics
- [ ] `.github/copilot-instructions.md` — policy or convention deltas
- [ ] `LLM_CONTEXT.md` — command behavior, flags, or workflows
- [ ] `README.md` — contributor-facing command behavior
- [ ] `.github/copilot/skills/**/*.md` — AI skill guidance
- [ ] MCP contracts: `HAL_MCP_CONTRACT.json`, `cmd/mcp/ops_api.go`, `cmd/mcp/testdata/*_help_snapshot.json`
- [ ] N/A — this change does not alter command behavior

## Notes for reviewers

A simple fix 
