### PR TITLE
feat(agent): T16 create-cr + agent-approve workflows

### DIFF
--- a/.github/issueresolution.template.yaml
+++ b/.github/issueresolution.template.yaml
@@ -1,0 +1,17 @@
+# Template for IssueResolution — filled by create-cr workflow (gh/yq).
+# Placeholders are overwritten; do not kubectl apply this file as-is.
+apiVersion: agent.hal.dev/v1alpha1
+kind: IssueResolution
+metadata:
+  name: issue-0
+  namespace: hal-agent
+spec:
+  repository: owner/repo
+  issueNumber: 0
+  issueURL: ""
+  author: ""
+  title: ""
+  body: ""
+  labels: []
+  approved: false
+  maxFixAttempts: 2

--- a/.github/workflows/agent-approve.yml
+++ b/.github/workflows/agent-approve.yml
@@ -1,0 +1,191 @@
+name: agent-approve
+
+# Human gate #1: a CODEOWNER approves agent execution via comment "agent go"
+# or label "agent: go". Patches spec.approved on the IssueResolution CR only
+# (never status.*). Runs from the default-branch workflow file (not PR/fork
+# workflow edits) — see docs/agent-approval-runbook.md.
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read # checkout CODEOWNERS
+  id-token: write # OIDC → WIF
+  issues: write # feedback / rejection comments
+
+concurrency:
+  group: agent-approve-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    environment: hal-cluster
+    if: >-
+      ( github.event_name == 'issue_comment'
+        && github.event.issue.pull_request == null )
+      || ( github.event_name == 'issues'
+        && github.event.action == 'labeled' )
+    steps:
+      - name: Checkout (CODEOWNERS)
+        uses: actions/checkout@v4
+
+      - name: Determine trigger, actor and number
+        id: ctx
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          APPROVE_LABEL: "agent: go"
+        run: |
+          set -euo pipefail
+          NUM="${{ github.event.issue.number }}"
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            norm="$(printf '%s' "$COMMENT_BODY" | tr -d '\r' \
+              | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+            if [ "$norm" != "agent go" ]; then
+              echo "Non-trigger comment; skipping"
+              echo "match=false" >>"$GITHUB_OUTPUT"
+              exit 0
+            fi
+            ACTOR="${{ github.event.comment.user.login }}"
+          else
+            if [ "$LABEL_NAME" != "$APPROVE_LABEL" ]; then
+              echo "Non-trigger label; skipping"
+              echo "match=false" >>"$GITHUB_OUTPUT"
+              exit 0
+            fi
+            ACTOR="${{ github.event.sender.login }}"
+          fi
+          echo "match=true" >>"$GITHUB_OUTPUT"
+          echo "num=$NUM" >>"$GITHUB_OUTPUT"
+          echo "actor=$ACTOR" >>"$GITHUB_OUTPUT"
+
+      - name: Authorize actor (CODEOWNERS + repo permission)
+        if: steps.ctx.outputs.match == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ steps.ctx.outputs.actor }}
+          NUM: ${{ steps.ctx.outputs.num }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          reject() {
+            gh issue comment "$NUM" --repo "$REPO" --body "$1"
+            exit 1
+          }
+
+          CO_FILE=""
+          for p in .github/CODEOWNERS CODEOWNERS docs/CODEOWNERS; do
+            if [ -f "$p" ]; then
+              CO_FILE="$p"
+              break
+            fi
+          done
+          if [ -z "$CO_FILE" ]; then
+            echo "::error::CODEOWNERS file not found"
+            reject "@${ACTOR} approval failed: CODEOWNERS file is missing. No action taken."
+          fi
+
+          OWNERS_LINE="$(grep -E '^\*[[:space:]]' "$CO_FILE" | head -1 | sed -E 's/#.*$//')"
+          if [ -z "$OWNERS_LINE" ]; then
+            echo "::error::No repo-wide (*) owner in CODEOWNERS"
+            reject "@${ACTOR} approval failed: CODEOWNERS has no \`*\` owner line. No action taken."
+          fi
+
+          codeowner_ok=false
+          for token in $OWNERS_LINE; do
+            [ "$token" = "*" ] && continue
+            owner="${token#@}"
+            if [[ "$owner" == */* ]]; then
+              org="${owner%%/*}"
+              team="${owner#*/}"
+              state="$(gh api "orgs/${org}/teams/${team}/memberships/${ACTOR}" \
+                --jq '.state' 2>/dev/null || true)"
+              if [ "$state" = "active" ]; then
+                codeowner_ok=true
+                break
+              fi
+            elif [ "$ACTOR" = "$owner" ]; then
+              codeowner_ok=true
+              break
+            fi
+          done
+
+          if [ "$codeowner_ok" != true ]; then
+            echo "::error::Actor is not a CODEOWNER"
+            reject "@${ACTOR} is not authorized to approve (CODEOWNERS required). No action taken."
+          fi
+
+          PERM="$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission')"
+          case "$PERM" in
+            admin|maintain|write) ;;
+            *)
+              echo "::error::Actor lacks write permission (permission=${PERM})"
+              reject "@${ACTOR} is not authorized to approve (repository write permission required). No action taken."
+              ;;
+          esac
+
+          echo "Actor @${ACTOR} authorized (CODEOWNERS + ${PERM} permission)"
+
+      - name: GCP auth via OIDC/WIF
+        if: steps.ctx.outputs.match == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOYER_SA }}
+
+      - name: Get GKE credentials
+        if: steps.ctx.outputs.match == 'true'
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
+          location: ${{ vars.GKE_CLUSTER_LOCATION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Patch spec.approved=true (guards + idempotence)
+        if: steps.ctx.outputs.match == 'true'
+        env:
+          NS: ${{ vars.HAL_AGENT_NAMESPACE }}
+          NUM: ${{ steps.ctx.outputs.num }}
+          APPROVER: ${{ steps.ctx.outputs.actor }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          post_comment() {
+            gh issue comment "$NUM" --repo "$REPO" --body "$1"
+          }
+
+          CR_NAME="issue-${NUM}"
+
+          if ! kubectl -n "$NS" get issueresolution "$CR_NAME" >/dev/null 2>&1; then
+            echo "::error::CR ${CR_NAME} not found"
+            post_comment "IssueResolution \`${CR_NAME}\` not found yet. Please retry after triage completes."
+            exit 1
+          fi
+
+          PHASE="$(kubectl -n "$NS" get issueresolution "$CR_NAME" \
+            -o jsonpath='{.status.phase}')"
+          if [ "$PHASE" != "PendingValidation" ]; then
+            echo "::warning::Phase=${PHASE} (expected PendingValidation)"
+            post_comment "Cannot approve: IssueResolution \`${CR_NAME}\` is in phase \`${PHASE}\` (expected \`PendingValidation\`). No action taken."
+            exit 1
+          fi
+
+          ALREADY="$(kubectl -n "$NS" get issueresolution "$CR_NAME" \
+            -o jsonpath='{.spec.approved}')"
+          if [ "$ALREADY" = "true" ]; then
+            echo "Already approved; no-op"
+            exit 0
+          fi
+
+          NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          kubectl -n "$NS" patch issueresolution "$CR_NAME" --type merge \
+            -p "{\"spec\":{\"approved\":true,\"approvedBy\":\"${APPROVER}\",\"approvedAt\":\"${NOW}\"}}"
+
+          post_comment "Approval recorded by @${APPROVER}. The agent will launch the fix."

--- a/.github/workflows/create-cr.yml
+++ b/.github/workflows/create-cr.yml
@@ -1,0 +1,97 @@
+name: create-cr
+
+# On issues.opened: fill IssueResolution template and kubectl apply CR
+# issue-<n> in hal-agent. Writes spec.* only (never status.*). Runs from
+# the default-branch workflow file — see docs/create-cr-runbook.md.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read # checkout template
+  id-token: write # OIDC → WIF
+
+concurrency:
+  group: create-cr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    environment: hal-cluster
+    if: github.event.issue.pull_request == null
+    steps:
+      - name: Checkout (template)
+        uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: GCP auth via OIDC/WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOYER_SA }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
+          location: ${{ vars.GKE_CLUSTER_LOCATION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Build and apply IssueResolution CR
+        env:
+          NS: ${{ vars.HAL_AGENT_NAMESPACE }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          TITLE: ${{ github.event.issue.title }}
+          BODY: ${{ github.event.issue.body }}
+          LABELS_JSON: ${{ toJson(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+
+          CR_NAME="issue-${NUM}"
+          TEMPLATE=".github/issueresolution.template.yaml"
+          OUT="/tmp/cr.yaml"
+
+          if ! kubectl -n "$NS" get issueresolution "$CR_NAME" >/dev/null 2>&1; then
+            :
+          else
+            echo "CR ${CR_NAME} already exists; no-op"
+            exit 0
+          fi
+
+          cp "$TEMPLATE" "$OUT"
+
+          # Truncate snapshots to CRD limits (~16KiB body, 500 title).
+          export CR_NAME NS REPO ISSUE_URL AUTHOR
+          export TITLE="$(printf '%s' "$TITLE" | head -c 500)"
+          export BODY_TRUNC="$(printf '%s' "${BODY:-}" | head -c 16384)"
+
+          yq -i '
+            .metadata.name = strenv(CR_NAME) |
+            .metadata.namespace = strenv(NS) |
+            .spec.repository = strenv(REPO) |
+            .spec.issueNumber = (env(NUM) | tonumber) |
+            .spec.issueURL = strenv(ISSUE_URL) |
+            .spec.author = strenv(AUTHOR) |
+            .spec.title = strenv(TITLE) |
+            .spec.body = strenv(BODY_TRUNC) |
+            .spec.approved = false |
+            .spec.maxFixAttempts = 2
+          ' "$OUT"
+
+          LABELS="$(printf '%s' "$LABELS_JSON" | jq '[.[].name // empty]')"
+          printf '%s' "$LABELS" | yq -i '.spec.labels = load("/dev/stdin")' "$OUT"
+
+          kubectl apply -f "$OUT"
+          echo "Applied IssueResolution ${CR_NAME} in namespace ${NS}"

--- a/docs/agent-approval-runbook.md
+++ b/docs/agent-approval-runbook.md
@@ -1,0 +1,97 @@
+# Agent approval workflow (GitHub ↔ GKE)
+
+Human gate #1 for the HAL issue-resolver agent. A CODEOWNER approves agent
+execution by posting an exact comment or applying a label; a GitHub Action
+patches `spec.approved` on the `IssueResolution` CR. The operator owns all
+`status.*` transitions.
+
+Workflow file: [`.github/workflows/agent-approve.yml`](../.github/workflows/agent-approve.yml).
+
+## Triggers
+
+| Gesture | Event | Filter |
+|---|---|---|
+| Comment body exactly `agent go` | `issue_comment` (`created`) | Issue only (not PR); leading/trailing whitespace trimmed; case-sensitive |
+| Label `agent: go` | `issues` (`labeled`) | Label name must match exactly |
+
+Removing the label does **not** revoke approval.
+
+## Security model
+
+- **`issue_comment` and `issues` workflows always run from the workflow file on
+  the repository default branch**, not from a PR or fork. Contributors cannot
+  change approval logic via a PR — only what is merged to `main` executes.
+- Restrict `GITHUB_TOKEN` with minimal `permissions:` in the workflow (`contents:
+  read`, `id-token: write`, `issues: write`).
+- **Authority comes from CODEOWNERS + repository permission**, not from
+  `author_association` on the event payload (defense in depth).
+- The workflow writes **only** `spec.*` via merge patch (no
+  `--subresource=status`). Cluster RBAC (`gha-approver` Role) also omits
+  `issueresolutions/status`.
+- **No long-lived secrets**: GCP access uses OIDC → Workload Identity Federation
+  → short-lived SA token. Non-sensitive Terraform outputs are repository /
+  environment **variables** (not secrets).
+
+## Required configuration
+
+### Repository / environment variables
+
+Set on the `hal-cluster` GitHub environment (or repository variables):
+
+| Variable | Source (T13 Terraform) | Example |
+|---|---|---|
+| `GCP_WIF_PROVIDER` | `wif_provider` | `projects/…/locations/global/workloadIdentityPools/…/providers/…` |
+| `GCP_DEPLOYER_SA` | `deployer_sa_email` | `gha-deployer@….iam.gserviceaccount.com` |
+| `GKE_CLUSTER_NAME` | `cluster_name` | `hal-agent` |
+| `GKE_CLUSTER_LOCATION` | `cluster_location` | `europe-west1` |
+| `GCP_PROJECT_ID` | `project_id` | `my-project` |
+| `HAL_AGENT_NAMESPACE` | `hal_agent_namespace` | `hal-agent` |
+
+WIF trust conditions should pin `attribute.repository` to this repo and,
+ideally, the `hal-cluster` environment name.
+
+### GitHub environment
+
+- Name: **`hal-cluster`** (protected environment; optional required reviewers).
+- Must match the WIF attribute condition configured in T13.
+
+### Labels
+
+Pre-create the label **`agent: go`** in the repository (Settings → Labels).
+
+### CODEOWNERS
+
+A repo-wide owner line is required, e.g.:
+
+```
+* @hashimiche
+```
+
+Team owners (`@org/team`) are resolved via the GitHub API at runtime.
+
+## Patch behavior
+
+Merge patch on `IssueResolution` `issue-<number>` in namespace `hal-agent`:
+
+```json
+{"spec":{"approved":true,"approvedBy":"<login>","approvedAt":"<RFC3339>"}}
+```
+
+Guards (in order):
+
+1. CR must exist — otherwise comment and fail.
+2. `status.phase` must be `PendingValidation` — otherwise comment and fail.
+3. If `spec.approved` is already `true` — no-op success (idempotent).
+
+## Prerequisites
+
+- T13 applied: GKE cluster, WIF, `gha-approver` RBAC, smoke WIF workflow green.
+- T16 [`create-cr` workflow](create-cr-runbook.md) operational (CR created on
+  `issues.opened`; same `hal-cluster` env vars as below).
+- Operator running and reconciling `IssueResolution` CRs.
+
+## Operator handoff
+
+After `spec.approved=true`, the operator transitions
+`PendingValidation → Ready`, creates Job 2, and eventually sets `PROpen`.
+PR merge remains a separate human gate (#2).

--- a/docs/create-cr-runbook.md
+++ b/docs/create-cr-runbook.md
@@ -1,0 +1,80 @@
+# Create IssueResolution CR (GitHub ↔ GKE)
+
+When a GitHub issue is opened, a workflow fills an `IssueResolution` template and
+`kubectl apply`s CR `issue-<number>` in namespace `hal-agent`. The operator
+owns all `status.*` transitions; this workflow writes **spec only**.
+
+Workflow file: [`.github/workflows/create-cr.yml`](../.github/workflows/create-cr.yml).
+
+Template: [`.github/issueresolution.template.yaml`](../.github/issueresolution.template.yaml).
+
+## Trigger
+
+| Event | Filter |
+|---|---|
+| `issues` (`opened`) | Issue only (not PR); all new issues |
+
+## Spec fields written
+
+| Field | Source |
+|---|---|
+| `repository` | `github.repository` |
+| `issueNumber` | Issue number |
+| `issueURL` | Issue HTML URL |
+| `author` | Issue author login |
+| `title` | Issue title (truncated to 500 chars) |
+| `body` | Issue body (truncated to ~16KiB) |
+| `labels` | Issue label names |
+| `approved` | `false` |
+| `maxFixAttempts` | `2` |
+
+Never writes `status.*`.
+
+## Security model
+
+- **`issues` workflows run from the workflow file on the repository default
+  branch**, not from a PR or fork.
+- Minimal `permissions:` (`contents: read`, `id-token: write`).
+- **No long-lived secrets**: GCP access uses OIDC → Workload Identity Federation
+  → short-lived SA token. Cluster access vars are repository / environment
+  **variables** (not secrets).
+
+## Required configuration
+
+Set on the `hal-cluster` GitHub environment (or repository variables):
+
+| Variable | Source (T13 Terraform) | Example |
+|---|---|---|
+| `GCP_WIF_PROVIDER` | `wif_provider` | `projects/…/locations/global/workloadIdentityPools/…/providers/…` |
+| `GCP_DEPLOYER_SA` | `deployer_sa_email` | `gha-deployer@….iam.gserviceaccount.com` |
+| `GKE_CLUSTER_NAME` | `cluster_name` | `hal-agent` |
+| `GKE_CLUSTER_LOCATION` | `cluster_location` | `europe-west1` |
+| `GCP_PROJECT_ID` | `project_id` | `my-project` |
+| `HAL_AGENT_NAMESPACE` | `hal_agent_namespace` | `hal-agent` |
+
+WIF trust conditions should pin `attribute.repository` to this repo and,
+ideally, the `hal-cluster` environment name.
+
+### GitHub environment
+
+- Name: **`hal-cluster`** (protected environment; optional required reviewers).
+- Must match the WIF attribute condition configured in T13.
+
+## Idempotence
+
+- CR name = `issue-<number>`. If the CR already exists, the workflow exits
+  successfully without changes.
+
+## Prerequisites
+
+- T13 applied: GKE cluster, WIF, `gha-approver` RBAC (`create` on
+  `issueresolutions`), smoke WIF workflow green.
+- Operator running and reconciling `IssueResolution` CRs.
+- Workflow merged to the repository **default branch** (not active from PR
+  workflow edits alone).
+
+## Handoff
+
+After the CR exists, the operator runs triage (Job 1) and sets
+`status.phase = PendingValidation`. Human gate #1 is
+[`agent-approve`](agent-approval-runbook.md) (`agent go` / label `agent: go`).


### PR DESCRIPTION
## Summary
- Add `create-cr.yml` (`issues.opened` → IssueResolution CR via OIDC/WIF)
- Add `agent-approve.yml` (CODEOWNER `agent go` / label `agent: go` → `spec.approved`)
- Template + runbooks

## Test plan
- [ ] Env `hal-cluster` vars set (GCP_*/GKE_*/HAL_AGENT_NAMESPACE)
- [ ] WIF allowlist includes `hashimiche/hal`
- [ ] Open issue → CR `issue-<n>` in `hal-agent`
- [ ] CODEOWNER `agent go` → approved → Job 2

Made with [Cursor](https://cursor.com)